### PR TITLE
Fix quotes processing auto-load functionality

### DIFF
--- a/bsky/bsky-core.js
+++ b/bsky/bsky-core.js
@@ -564,11 +564,6 @@ function loadStateFromUrl() {
         // Update pagination warning after setting values
         updatePaginationWarning();
     }
-    
-    // Auto-process if we have everything needed
-    if (typeof autoProcessIfReady === 'function') {
-        autoProcessIfReady();
-    }
 }
 
 /* Export debug object for development use */

--- a/bsky/bsky-thread.js
+++ b/bsky/bsky-thread.js
@@ -140,13 +140,14 @@ export function initializeThreadProcessing() {
 export function autoProcessThread() {
     const urlInput = document.getElementById('url-input');
     const currentUrl = urlInput.value.trim();
-    
+
     if (currentUrl) {
         const processType = location.search.includes('quotes=true') ? 'process-quotes' : 'process-replies';
         const button = document.getElementById(processType);
-        
+
         if (button && !button.disabled) {
-            document.getElementById('processor-form').dispatchEvent(new Event('submit'));
+            /* Click the button directly so the submitter is properly set */
+            button.click();
         }
     }
 }

--- a/bsky/processor.html
+++ b/bsky/processor.html
@@ -405,11 +405,11 @@
         import { initializeBskyCore } from './bsky-core.js';
         import { initializeThreadProcessing, autoProcessThread } from './bsky-thread.js';
         import { initializeSearchProcessing } from './bsky-search.js';
-    
+
         window.addEventListener('DOMContentLoaded', async () => {
           try {
             const coreInitialized = await initializeBskyCore();
-            
+
             if (coreInitialized) {
               /* Then initialize the specific processing modules */
               try {
@@ -419,7 +419,7 @@
                 document.getElementById('error').textContent = "Thread processing module failed to initialize";
                 document.getElementById('error').style.display = 'block';
               }
-              
+
               try {
                 initializeSearchProcessing();
               } catch (e) {
@@ -427,9 +427,12 @@
                 document.getElementById('error').textContent = "Search processing module failed to initialize";
                 document.getElementById('error').style.display = 'block';
               }
-              
+
               /* Show UI regardless of partial initialization */
               document.getElementById('app').style.display = 'block';
+
+              /* Auto-process thread if URL parameters are set */
+              autoProcessThread();
             }
           } catch (e) {
             console.error("Core initialization failed:", e);


### PR DESCRIPTION
The process quotes function was broken when using URL parameter quotes=true.

Root causes:
1. autoProcessThread() was never called during initialization - the code
   referenced a non-existent autoProcessIfReady() function
2. When autoProcessThread() dispatched a form submit event, it didn't set
   the submitter property, causing the handler to default to reply processing

Fixes:
- Changed autoProcessThread() to click the appropriate button directly,
  ensuring the submitter is properly set
- Added autoProcessThread() call in the main initialization script
- Removed unused reference to autoProcessIfReady() in bsky-core.js

This fixes both quotes=true and quotes=false URL parameter handling.