### PR TITLE
Improve UX: Hide input form when results are displayed

### DIFF
--- a/web-utilities/pdf-text-extractor.html
+++ b/web-utilities/pdf-text-extractor.html
@@ -214,9 +214,49 @@
       font-weight: 600;
     }
 
+    .hidden {
+      display: none !important;
+    }
+
+    #input-section {
+      transition: opacity 0.3s;
+    }
+
     #output-container {
       display: none;
       margin-top: 1.5rem;
+    }
+
+    #result-controls {
+      display: flex;
+      gap: 1rem;
+      align-items: center;
+      margin-bottom: 1rem;
+      padding: 1rem;
+      background: #f3f4f6;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      flex-wrap: wrap;
+    }
+
+    #result-controls .control-group {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    #result-controls select {
+      padding: 0.5rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: white;
+      cursor: pointer;
+    }
+
+    #result-controls button {
+      padding: 0.5rem 1rem;
+      margin: 0;
+      width: auto;
     }
 
     #text-output {
@@ -265,61 +305,75 @@
   <h1>📄 PDF Text Extractor</h1>
   <p class="subtitle">Optimized for LLM In-Context Learning and RAG Systems</p>
 
-  <div id="drop">
-    <div class="icon">📄</div>
-    <div><strong>Drop PDF here</strong> or click to browse</div>
-    <div style="font-size: 0.85rem; color: #6b7280; margin-top: 0.5rem;">
-      Text extraction happens in your browser - no data leaves your device
+  <div id="input-section">
+    <div id="drop">
+      <div class="icon">📄</div>
+      <div><strong>Drop PDF here</strong> or click to browse</div>
+      <div style="font-size: 0.85rem; color: #6b7280; margin-top: 0.5rem;">
+        Text extraction happens in your browser - no data leaves your device
+      </div>
     </div>
+    <input type="file" id="fileIn" accept="application/pdf" style="display:none">
+
+    <div id="file-info">No file loaded</div>
+
+    <fieldset>
+      <legend>Output Format</legend>
+
+      <div class="info-box">
+        <h3>Format Guide</h3>
+        <ul>
+          <li><strong>Markdown:</strong> Best for both full-context and RAG chunking. Each page has clear headers with filename and page number.</li>
+          <li><strong>JSON:</strong> Structured format with metadata. Ideal for programmatic processing and custom chunking strategies.</li>
+          <li><strong>Plain Text:</strong> Simple format with page markers. Works with any text processor.</li>
+        </ul>
+      </div>
+
+      <div class="format-options">
+        <div class="format-option">
+          <input type="radio" id="format-markdown" name="format" value="markdown" checked>
+          <label for="format-markdown">
+            <span class="format-title">Markdown</span>
+            <span class="format-desc">Optimized for LLM context windows and RAG chunking</span>
+          </label>
+        </div>
+
+        <div class="format-option">
+          <input type="radio" id="format-json" name="format" value="json">
+          <label for="format-json">
+            <span class="format-title">JSON</span>
+            <span class="format-desc">Structured data with full metadata</span>
+          </label>
+        </div>
+
+        <div class="format-option">
+          <input type="radio" id="format-text" name="format" value="text">
+          <label for="format-text">
+            <span class="format-title">Plain Text</span>
+            <span class="format-desc">Simple format with page markers</span>
+          </label>
+        </div>
+      </div>
+
+      <button id="extract-btn" disabled>Extract Text</button>
+    </fieldset>
+
+    <div id="progress">Select a PDF file to begin</div>
   </div>
-  <input type="file" id="fileIn" accept="application/pdf" style="display:none">
-
-  <div id="file-info">No file loaded</div>
-
-  <fieldset>
-    <legend>Output Format</legend>
-
-    <div class="info-box">
-      <h3>Format Guide</h3>
-      <ul>
-        <li><strong>Markdown:</strong> Best for both full-context and RAG chunking. Each page has clear headers with filename and page number.</li>
-        <li><strong>JSON:</strong> Structured format with metadata. Ideal for programmatic processing and custom chunking strategies.</li>
-        <li><strong>Plain Text:</strong> Simple format with page markers. Works with any text processor.</li>
-      </ul>
-    </div>
-
-    <div class="format-options">
-      <div class="format-option">
-        <input type="radio" id="format-markdown" name="format" value="markdown" checked>
-        <label for="format-markdown">
-          <span class="format-title">Markdown</span>
-          <span class="format-desc">Optimized for LLM context windows and RAG chunking</span>
-        </label>
-      </div>
-
-      <div class="format-option">
-        <input type="radio" id="format-json" name="format" value="json">
-        <label for="format-json">
-          <span class="format-title">JSON</span>
-          <span class="format-desc">Structured data with full metadata</span>
-        </label>
-      </div>
-
-      <div class="format-option">
-        <input type="radio" id="format-text" name="format" value="text">
-        <label for="format-text">
-          <span class="format-title">Plain Text</span>
-          <span class="format-desc">Simple format with page markers</span>
-        </label>
-      </div>
-    </div>
-
-    <button id="extract-btn" disabled>Extract Text</button>
-  </fieldset>
-
-  <div id="progress">Select a PDF file to begin</div>
 
   <div id="output-container">
+    <div id="result-controls">
+      <div class="control-group">
+        <label for="result-format"><strong>Format:</strong></label>
+        <select id="result-format">
+          <option value="markdown">Markdown</option>
+          <option value="json">JSON</option>
+          <option value="text">Plain Text</option>
+        </select>
+      </div>
+      <button id="new-pdf-btn">Process Another PDF</button>
+    </div>
+
     <fieldset>
       <legend>Extracted Text</legend>
       <div id="text-output"></div>
@@ -341,15 +395,20 @@
     const extractBtn = document.getElementById('extract-btn');
     const fileInfo = document.getElementById('file-info');
     const progress = document.getElementById('progress');
+    const inputSection = document.getElementById('input-section');
     const outputContainer = document.getElementById('output-container');
     const textOutput = document.getElementById('text-output');
     const copyBtn = document.getElementById('copy-btn');
     const downloadBtn = document.getElementById('download-btn');
+    const resultFormat = document.getElementById('result-format');
+    const newPdfBtn = document.getElementById('new-pdf-btn');
 
     let currentFile = null;
     let extractedText = '';
     let currentFormat = 'markdown';
     let currentPdfUrl = null;
+    let extractedMetadata = null;
+    let extractedPages = null;
 
     // Parse URL parameters (supports both query string and hash)
     function parseUrlParams() {
@@ -450,16 +509,29 @@
     };
     fileInput.onchange = () => handleFile(fileInput.files[0]);
 
-    // Format selection
+    // Format selection (for input section)
     document.querySelectorAll('input[name="format"]').forEach(radio => {
       radio.onchange = (e) => {
         currentFormat = e.target.value;
-        // Re-render if we already have extracted text
-        if (extractedText) {
-          renderOutput();
-        }
       };
     });
+
+    // Format selection (for result controls)
+    resultFormat.onchange = (e) => {
+      if (extractedMetadata && extractedPages) {
+        currentFormat = e.target.value;
+        extractedText = generateOutput(extractedMetadata, extractedPages, currentFormat);
+        renderOutput();
+      }
+    };
+
+    // Process another PDF button
+    newPdfBtn.onclick = () => {
+      inputSection.classList.remove('hidden');
+      outputContainer.style.display = 'none';
+      progress.textContent = 'Select a PDF file to begin';
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
 
     function handleFile(file) {
       if (!file || file.type !== 'application/pdf') {
@@ -547,11 +619,25 @@
           });
         }
 
+        // Store metadata and pages for format switching
+        extractedMetadata = metadata;
+        extractedPages = pages;
+
         // Generate output in selected format
         extractedText = generateOutput(metadata, pages, currentFormat);
 
+        // Update result format dropdown to match current format
+        resultFormat.value = currentFormat;
+
         renderOutput();
+
+        // Hide input section and show results
+        inputSection.classList.add('hidden');
         outputContainer.style.display = 'block';
+
+        // Scroll to results
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+
         progress.innerHTML = `<span class="success">✓ Successfully extracted text from ${pdf.numPages} pages</span>`;
 
       } catch (error) {


### PR DESCRIPTION
Changes:
- Hide input section when extraction results are shown
- Add result controls panel at top of output with:
  - Format selector (switch between Markdown/JSON/Text without re-extracting)
  - "Process Another PDF" button to return to input form
- Auto-scroll to top when results are displayed
- Store extracted metadata and pages to enable instant format switching
- Results now visible above the fold without scrolling

This fixes the issue where the input form occupied all above-the-fold space, hiding the extraction results from the user.

The format switcher in result controls provides instant re-rendering without re-extracting the PDF, improving performance for users who want to try different output formats.