### PR TITLE
Build Preact no-build page for Claude Skill releases

### DIFF
--- a/ai-tools/claude-skill-releases.html
+++ b/ai-tools/claude-skill-releases.html
@@ -123,7 +123,7 @@
             <div class="bg-white rounded-lg shadow-lg p-6 mb-6">
               <h1 class="text-3xl font-bold text-gray-800 mb-2">Claude Skills - Releases</h1>
               <p class="text-gray-600">
-                Alphabetical listing of all releases from
+                Alphabetical listing of all releases from ${' '}
                 <a href="https://github.com/oaustegard/claude-skills"
                    class="text-blue-500 hover:underline"
                    target="_blank"


### PR DESCRIPTION
Create a client-side Preact page that fetches and displays all releases from the oaustegard/claude-skill repository. The page shows releases in alphabetical order with:
- Name and version
- Description
- Direct download links to .zip files

Built using zero-build Preact with HTM syntax, signals for state management, and Tailwind CSS for styling.