### PR TITLE
Fix speedo.html for iPhone compatibility

### DIFF
--- a/fun-and-games/speedo.html
+++ b/fun-and-games/speedo.html
@@ -125,10 +125,10 @@
         };
       }, []);
 
-      // Auto-start tracking
-      useEffect(() => {
-        startTracking();
-      }, []);
+      // Don't auto-start on iOS - requires user gesture
+      // useEffect(() => {
+      //   startTracking();
+      // }, []);
 
       // Keep screen awake and bright
       useEffect(() => {
@@ -175,18 +175,6 @@
 
       return html`
         <div class="${hudMode.value ? 'hud-mirror' : ''} w-screen h-screen flex flex-col items-center justify-center bg-black text-white">
-          
-          ${error.value && html`
-            <div class="absolute top-4 left-4 right-4 bg-red-900/80 text-white p-4 rounded-lg">
-              <p class="text-sm">${error.value}</p>
-              <button 
-                onClick=${startTracking}
-                class="mt-2 px-4 py-2 bg-red-600 rounded hover:bg-red-700"
-              >
-                Retry
-              </button>
-            </div>
-          `}
 
           <!-- Main speed display -->
           <div class="text-center">
@@ -246,19 +234,27 @@
           `}
 
           <!-- Permission prompt -->
-          ${!hasPermission.value && !error.value && html`
-            <div class="absolute inset-0 flex items-center justify-center bg-black/90">
+          ${!hasPermission.value && html`
+            <div class="absolute inset-0 flex items-center justify-center bg-black/90 z-50">
               <div class="text-center max-w-md px-4">
-                <h2 class="text-3xl font-bold mb-4">Location Permission Required</h2>
-                <p class="text-gray-400 mb-6">
-                  This app needs access to your location to calculate your speed using GPS.
+                <h2 class="text-3xl font-bold mb-4">📍 HUD Speedometer</h2>
+                <p class="text-gray-400 mb-4">
+                  This app uses your device's GPS to calculate your current speed.
                 </p>
-                <button 
+                <p class="text-yellow-400 text-sm mb-6">
+                  <strong>iPhone users:</strong> You must allow location access when prompted by iOS.
+                </p>
+                <button
                   onClick=${startTracking}
-                  class="px-8 py-4 bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors text-lg"
+                  class="px-8 py-4 bg-blue-600 rounded-lg hover:bg-blue-700 active:bg-blue-800 transition-colors text-lg font-semibold"
                 >
-                  Enable Location
+                  Start Speedometer
                 </button>
+                ${error.value && html`
+                  <div class="mt-4 text-red-400 text-sm">
+                    ${error.value}
+                  </div>
+                `}
               </div>
             </div>
           `}


### PR DESCRIPTION
iOS Safari requires user interaction to request location permissions.
The page was auto-starting tracking on load, which doesn't work on iPhone.

Changes:
- Remove auto-start tracking on page load
- Show prominent "Start Speedometer" button that requires user click
- Add iPhone-specific guidance in the permission prompt
- Consolidate error messages into the permission prompt
- Improve button styling with active states for mobile

This ensures the geolocation permission prompt is triggered by a user
gesture, which is required on iOS devices.