### PR TITLE
Disable zoom and fix text size on orientation change

### DIFF
--- a/fun-and-games/speedo.html
+++ b/fun-and-games/speedo.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <meta name="theme-color" content="#000000">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -19,6 +19,8 @@
 
     html {
       background: #000;
+      -webkit-text-size-adjust: 100%;
+      text-size-adjust: 100%;
     }
 
     body {
@@ -91,7 +93,7 @@
     }
 
     #speed-display {
-      font-size: 25rem;
+      font-size: 35vmin;
       font-weight: bold;
       line-height: 1;
       font-variant-numeric: tabular-nums;
@@ -100,7 +102,7 @@
     }
 
     #unit-display {
-      font-size: 5rem;
+      font-size: 8vmin;
       color: #888;
       margin-top: 1.5rem;
     }
@@ -114,37 +116,6 @@
     /* Hide error by default */
     #error-message:empty {
       display: none;
-    }
-
-    @media (max-width: 768px) {
-      #speed-display {
-        font-size: 18rem;
-      }
-
-      #unit-display {
-        font-size: 4rem;
-      }
-    }
-
-    @media (max-width: 480px) {
-      #speed-display {
-        font-size: 15rem;
-      }
-
-      #unit-display {
-        font-size: 3.5rem;
-      }
-    }
-
-    /* Landscape mode - use larger sizing */
-    @media (orientation: landscape) {
-      #speed-display {
-        font-size: 40vmin;
-      }
-
-      #unit-display {
-        font-size: 10vmin;
-      }
     }
   </style>
 </head>


### PR DESCRIPTION
- Add maximum-scale=1.0 and user-scalable=no to viewport
- Add text-size-adjust: 100% to prevent iOS auto-adjustment
- Use consistent vmin units for all screen sizes
- Remove conflicting media queries that caused text growth