### PR TITLE
Revert auto-start - requires user gesture on iOS

### DIFF
--- a/fun-and-games/speedo.html
+++ b/fun-and-games/speedo.html
@@ -327,13 +327,6 @@
         }
       }
     });
-
-    // Auto-start: try to get location on page load
-    // If permission already granted, speedometer will appear automatically
-    // If not, user will see the permission button
-    permissionScreen.style.display = 'none';
-    speedometer.style.display = 'none';
-    startTracking();
   </script>
 </body>
 </html>


### PR DESCRIPTION
Remove auto-start location tracking as iOS requires user gesture for geolocation permission when launched from homescreen. Always show Start button to ensure app works correctly.