### PR TITLE
Add instructions and homescreen install hint

### DIFF
--- a/fun-and-games/speedo.html
+++ b/fun-and-games/speedo.html
@@ -56,8 +56,25 @@
 
     #permission-screen p {
       font-size: 1.1rem;
-      margin-bottom: 2rem;
+      margin-bottom: 1rem;
       color: #aaa;
+    }
+
+    #permission-screen .instructions {
+      font-size: 0.9rem;
+      color: #888;
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+
+    #permission-screen .install-hint {
+      font-size: 0.85rem;
+      color: #666;
+      margin-bottom: 1.5rem;
+      padding: 1rem;
+      border: 1px solid #333;
+      border-radius: 0.5rem;
+      background: #111;
     }
 
     #start-button {
@@ -133,6 +150,15 @@
   <div id="permission-screen">
     <h1>Speedometer</h1>
     <p>Uses GPS to display your current speed</p>
+    <div class="instructions">
+      <strong>Controls:</strong><br>
+      Single tap speed = Toggle HUD mirror mode<br>
+      Double tap speed = Rotate 180°
+    </div>
+    <div id="install-hint" class="install-hint" style="display: none;">
+      For best experience, add this page to your homescreen:<br>
+      <strong>Safari:</strong> Tap Share → Add to Home Screen
+    </div>
     <button id="start-button">Start</button>
     <div id="error-message"></div>
   </div>
@@ -156,6 +182,17 @@
     const speedDisplay = document.getElementById('speed-display');
     const errorMessage = document.getElementById('error-message');
     const startButton = document.getElementById('start-button');
+    const installHint = document.getElementById('install-hint');
+
+    // Detect if running in standalone mode (added to homescreen)
+    const isStandalone = window.matchMedia('(display-mode: standalone)').matches ||
+                        window.navigator.standalone ||
+                        document.referrer.includes('android-app://');
+
+    // Show install hint only if NOT in standalone mode
+    if (!isStandalone) {
+      installHint.style.display = 'block';
+    }
 
     // Convert m/s to mph
     function toMph(metersPerSecond) {


### PR DESCRIPTION
- Show tap gesture controls on start screen
- Detect if running in browser vs standalone mode
- Display "add to homescreen" hint only in browser
- Explain single tap (HUD mirror) and double tap (rotate 180°)