### PR TITLE
Audit tool folders for missing README files

### DIFF
--- a/ai-tools/claude-skill-releases_README.md
+++ b/ai-tools/claude-skill-releases_README.md
@@ -1,0 +1,141 @@
+# Claude Skills - Releases Viewer
+
+A web application that fetches and displays all releases from the [oaustegard/claude-skills](https://github.com/oaustegard/claude-skills) GitHub repository, providing an organized and searchable interface for browsing Claude skills and downloading them.
+
+## Overview
+
+This tool provides a user-friendly interface for exploring Claude skills releases, with real-time data fetched directly from the GitHub API. It offers multiple viewing modes, automatic table of contents generation, and download links for all available skills.
+
+## Features
+
+### Real-Time GitHub Integration
+- Fetches latest release data from GitHub API on every page load
+- Displays release names, descriptions, and publication dates
+- Shows download counts and file information
+- Automatically updates when new releases are published
+
+### Dual Sorting Modes
+- **Alphabetical (A-Z)**: Sort releases by name for easy browsing
+- **Latest**: Sort by publication date to see newest releases first
+- Sort mode persisted in URL for shareable links
+- Toggle between modes with single click
+
+### Interactive Table of Contents
+- Fixed sidebar navigation on larger screens
+- Automatic scroll tracking highlights current section
+- Click any release name to jump directly to it
+- Smooth scrolling for better user experience
+- Responsive - hides on mobile/tablet screens
+
+### Rich Release Display
+- Markdown-rendered descriptions for proper formatting
+- Publication timestamps in local time zone
+- Truncated descriptions (stops at horizontal rule `---`)
+- Automatic header removal for cleaner display
+- Visual download buttons for each .zip asset
+
+### Download Management
+- Lists all .zip files available for each release
+- Direct download links with clear visual buttons
+- Shows file names for easy identification
+- Indicates when no downloads are available
+
+### URL State Management
+- Current sort mode stored in URL query parameters
+- Shareable links maintain view preferences
+- Browser back/forward navigation support
+- Preserves state across sessions
+
+### Responsive Design
+- Tailwind CSS for modern, clean styling
+- Mobile-optimized layout
+- Adaptive table of contents (desktop only)
+- Touch-friendly interface elements
+
+## Usage
+
+1. **Open the Tool**: Navigate to the Claude Skills Releases page
+2. **Browse Releases**: Scroll through the list or use the table of contents
+3. **Switch Views**: Toggle between "A-Z" and "Latest" sorting modes
+4. **Navigate**: Click any item in the table of contents to jump to that release
+5. **Download**: Click download buttons to get .zip files for any skill
+6. **Share**: Copy the URL to share your current view (sort mode is preserved)
+7. **Return**: Use the "Back to AI Tools" link to navigate to the main tools page
+
+## Technical Details
+
+### Frontend Framework
+- **Preact**: Lightweight React alternative for efficient rendering
+- **Preact Signals**: Reactive state management
+- **HTM**: JSX-like syntax without build step
+- **Marked.js**: Markdown parsing and rendering
+- **Tailwind CSS**: Utility-first CSS framework
+
+### API Integration
+- Fetches from `https://api.github.com/repos/oaustegard/claude-skills/releases`
+- Handles API errors gracefully with user-friendly messages
+- No authentication required (uses public GitHub API)
+- Respects GitHub API rate limits
+
+### State Management
+- Reactive signals for releases data, loading, and error states
+- Computed values for sorted releases
+- Active section tracking via Intersection Observer
+- URL-based state persistence
+
+### Performance Optimizations
+- ESM module imports via CDN (no bundling required)
+- Efficient re-rendering with Preact
+- Lazy loading of external dependencies
+- Client-side filtering and sorting
+
+### Scroll Tracking
+- Intersection Observer API for active section detection
+- Automatic highlighting in table of contents
+- Optimized observer settings for smooth tracking
+- Disconnects observers on cleanup
+
+## Release Description Processing
+
+The tool intelligently processes release descriptions:
+1. Splits content at horizontal rules (`---`) to remove changelog details
+2. Removes the first markdown heading (typically `# skill-name`)
+3. Parses remaining markdown to HTML
+4. Renders with appropriate prose styling
+
+## Browser Compatibility
+
+- **Chrome/Edge**: Full support
+- **Firefox**: Full support
+- **Safari**: Full support (iOS 12+)
+- **Mobile browsers**: Responsive layout with touch support
+
+## Data Source
+
+All release data comes from the [oaustegard/claude-skills](https://github.com/oaustegard/claude-skills) repository, which contains various skills and utilities for use with Claude (Anthropic's AI assistant).
+
+## Privacy
+
+- No data collection or analytics
+- No cookies or local storage (except URL state)
+- Direct GitHub API calls (no proxy server)
+- All processing happens client-side
+
+## Error Handling
+
+- Loading states with animated spinner
+- Error messages for API failures
+- Graceful handling of missing data
+- User-friendly error displays with retry suggestions
+
+## Responsive Breakpoints
+
+- **Desktop (1024px+)**: Shows table of contents sidebar with content offset
+- **Tablet/Mobile (<1024px)**: Hides table of contents for more space
+- Smooth transitions between breakpoints
+
+## Credits
+
+- **Data Source**: [oaustegard/claude-skills](https://github.com/oaustegard/claude-skills)
+- **Libraries**: Preact, Preact Signals, HTM, Marked.js, Tailwind CSS
+- **Tool Creator**: Oskar Austegard ([@oaustegard](https://github.com/oaustegard))

--- a/fun-and-games/cadence-for-dummies_README.md
+++ b/fun-and-games/cadence-for-dummies_README.md
@@ -1,0 +1,99 @@
+# Cadence for Dummies
+
+An interactive educational tool styled as a "For Dummies" book that teaches users about cadence (rhythm in running, cycling, and music) and helps them calculate their personal cadence with a built-in calculator.
+
+## Overview
+
+Cadence for Dummies presents information in an engaging, book-like format with a distinctive yellow cover design reminiscent of the popular "For Dummies" book series. The tool combines educational content with practical utilities to help users understand, measure, and optimize their cadence for various activities.
+
+## Features
+
+### Interactive Book Design
+- Yellow cover with "For Dummies" style branding
+- Click-to-open interface revealing educational content
+- Responsive design that works on all screen sizes
+- Distinctive typography using "Permanent Marker" font
+
+### Educational Content
+- **What is Cadence?**: Clear explanation of cadence measurement in BPM/RPM
+- **Why It Matters**: Five key benefits including efficiency, injury reduction, and performance optimization
+- **How to Measure**: Step-by-step manual measurement guide using just a stopwatch
+- **Common Targets**: Reference values for running (160-180 SPM), cycling (80-100 RPM), and walking (100-120 SPM)
+
+### Cadence Calculator
+- Input fields for counts and time (in seconds)
+- Automatic calculation of BPM (beats per minute)
+- Real-time validation and error handling
+- Keyboard support (Enter key to calculate)
+- Results displayed with ±3% range for Spotify integration
+
+### Spotify Integration
+- Generates optimized Spotify AI Playlist prompts
+- Automatically calculates ±3% BPM range for music matching
+- Copy-ready prompt text for creating playlists that match your cadence
+- Instructions for using Spotify's AI Playlist Beta feature
+
+### User-Friendly Features
+- Clear step-by-step instructions with numbered visual guides
+- Formula display for manual calculations
+- Tip boxes with pro advice
+- Smooth scrolling and animations
+- Easter egg link to helpful YouTube tutorial
+
+## Usage
+
+1. **Open the Tool**: Click anywhere on the yellow book cover to open
+2. **Learn About Cadence**: Read through the educational sections
+3. **Calculate Your Cadence**:
+   - Enter the number of steps/beats/revolutions you counted
+   - Enter the time in seconds it took
+   - Click "Calculate My Cadence!" or press Enter
+4. **View Results**: Your cadence in BPM and recommended Spotify range
+5. **Create Playlist**: Use the generated Spotify prompt to create matching music
+6. **Close**: Click the "Close book" button to return to the cover
+
+## Manual Measurement Method
+
+The tool teaches a simple 5-step process:
+1. Open your phone's stopwatch
+2. Decide what to count (steps for running, pedal revolutions for cycling, beats for music)
+3. Choose your count (10, 20, or 30 repetitions recommended)
+4. Start counting and timing simultaneously
+5. Calculate using the formula: **Cadence (BPM) = (Count / Time in seconds) × 60**
+
+## Technical Details
+
+- Pure HTML, CSS, and JavaScript (no dependencies)
+- Responsive design with mobile-first approach
+- Custom CSS animations and transitions
+- Google Fonts integration (Permanent Marker)
+- Breakpoints at 768px and 480px for mobile optimization
+- Input validation and error handling
+- Auto-updating Spotify prompt based on calculations
+
+## Browser Compatibility
+
+- Works on all modern browsers (Chrome, Firefox, Safari, Edge)
+- Mobile-responsive for phones and tablets
+- Optimized for both portrait and landscape orientations
+
+## Educational Value
+
+The tool emphasizes five key benefits of understanding cadence:
+1. **Improve Efficiency**: Move with less wasted energy
+2. **Reduce Injury Risk**: Shorter strides with less joint impact
+3. **Match Music to Movement**: Make workouts more enjoyable
+4. **Track Progress**: Monitor form and technique improvements
+5. **Optimize Performance**: Fine-tune for maximum speed and endurance
+
+## Privacy
+
+- No data collection or external requests
+- All calculations performed locally in browser
+- No cookies or tracking
+
+## Credits
+
+- Design inspired by the "For Dummies" book series
+- Easter egg links to educational video content
+- Font: "Permanent Marker" by Google Fonts


### PR DESCRIPTION
…eases

Created comprehensive README documentation for two tools that were missing their *_README.md files:

- fun-and-games/cadence-for-dummies_README.md: Documents the interactive educational tool that teaches users about cadence in running/cycling/music, includes calculator and Spotify playlist integration

- ai-tools/claude-skill-releases_README.md: Documents the GitHub releases viewer for Claude skills with real-time API integration, dual sorting modes, and interactive table of contents

Both READMEs follow the established format and provide complete documentation of features, usage, technical details, and browser compatibility.