### PR TITLE
Fix balls initialization error in yin-yang game

### DIFF
--- a/fun-and-games/yingyang.html
+++ b/fun-and-games/yingyang.html
@@ -34,6 +34,12 @@ const mctx = mask.getContext('2d', { willReadFrequently: true });
 
 let DPR=1, W=0, H=0, cx=0, cy=0, R=0;
 
+// --- balls ---
+const balls = [
+  { color:'#fff', r:0, x:0, y:0, vx:0, vy:0 }, // white dot
+  { color:'#000', r:0, x:0, y:0, vx:0, vy:0 }  // black dot
+];
+
 function resize(){
   DPR = Math.max(1, window.devicePixelRatio||1);
   const sideCSS = Math.min(innerWidth, innerHeight)*0.92;
@@ -82,12 +88,6 @@ function gradAt(x,y){ // central differences on mask alpha (as vec pointing towa
   const len = Math.hypot(gx,gy)||1;
   return [gx/len, gy/len];
 }
-
-// --- balls ---
-const balls = [
-  { color:'#fff', r:0, x:0, y:0, vx:0, vy:0 }, // white dot
-  { color:'#000', r:0, x:0, y:0, vx:0, vy:0 }  // black dot
-];
 
 function resetBalls(){
   balls[0].x=cx; balls[0].y=cy - R/2;      // white in black lobe


### PR DESCRIPTION
Moved balls array declaration before resize() function to prevent temporal dead zone error. The resize() function references balls at line 50, but it was being called at line 52 before balls was declared at the original line 87.