### PR TITLE
fix: Improve landscape mode layout to prevent overlapping

### DIFF
--- a/fun-and-games/car-dashboard-demo.html
+++ b/fun-and-games/car-dashboard-demo.html
@@ -98,6 +98,7 @@
       justify-content: center;
       align-items: center;
       height: 10%;
+      min-height: 40px;
     }
 
     #clock {
@@ -140,8 +141,64 @@
       justify-content: space-around;
       align-items: center;
       height: 12%;
+      min-height: 60px;
       border-top: 1px solid #222;
       padding-top: 0.5rem;
+    }
+
+    /* Landscape mode adjustments */
+    @media (orientation: landscape) {
+      .top-row {
+        height: 8%;
+        min-height: 35px;
+      }
+
+      #clock {
+        font-size: 4vmin;
+      }
+
+      #speed-display {
+        font-size: 26vmin;
+      }
+
+      #unit-display {
+        font-size: 5.5vmin;
+      }
+
+      .info-row {
+        height: 10%;
+        min-height: 45px;
+        padding-top: 0.3rem;
+      }
+
+      .info-value {
+        font-size: 3.8vmin;
+      }
+
+      .info-label {
+        font-size: 1.9vmin;
+      }
+
+      .histogram-row {
+        height: 8%;
+        min-height: 40px;
+        padding: 0.3rem 1rem;
+      }
+
+      .histogram-label,
+      .histogram-value {
+        font-size: 1.7vmin;
+      }
+
+      .status-row {
+        height: 6%;
+        min-height: 30px;
+        padding-top: 0.3rem;
+      }
+
+      .status-item {
+        font-size: 2.2vmin;
+      }
     }
 
     .info-item {
@@ -168,6 +225,7 @@
       justify-content: space-between;
       align-items: center;
       height: 8%;
+      min-height: 35px;
       padding-top: 0.5rem;
       border-top: 1px solid #222;
     }
@@ -221,6 +279,7 @@
       justify-content: space-around;
       align-items: flex-end;
       height: 10%;
+      min-height: 50px;
       border-top: 1px solid #222;
       padding: 0.5rem 1rem;
       gap: 0.5rem;

--- a/fun-and-games/car-dashboard.html
+++ b/fun-and-games/car-dashboard.html
@@ -128,6 +128,7 @@
       justify-content: center;
       align-items: center;
       height: 10%;
+      min-height: 40px;
     }
 
     #clock {
@@ -170,8 +171,64 @@
       justify-content: space-around;
       align-items: center;
       height: 12%;
+      min-height: 60px;
       border-top: 1px solid #222;
       padding-top: 0.5rem;
+    }
+
+    /* Landscape mode adjustments */
+    @media (orientation: landscape) {
+      .top-row {
+        height: 8%;
+        min-height: 35px;
+      }
+
+      #clock {
+        font-size: 4vmin;
+      }
+
+      #speed-display {
+        font-size: 28vmin;
+      }
+
+      #unit-display {
+        font-size: 6vmin;
+      }
+
+      .info-row {
+        height: 10%;
+        min-height: 45px;
+        padding-top: 0.3rem;
+      }
+
+      .info-value {
+        font-size: 4vmin;
+      }
+
+      .info-label {
+        font-size: 2vmin;
+      }
+
+      .histogram-row {
+        height: 8%;
+        min-height: 40px;
+        padding: 0.3rem 1rem;
+      }
+
+      .histogram-label,
+      .histogram-value {
+        font-size: 1.8vmin;
+      }
+
+      .status-row {
+        height: 6%;
+        min-height: 30px;
+        padding-top: 0.3rem;
+      }
+
+      .status-item {
+        font-size: 2.5vmin;
+      }
     }
 
     .info-item {
@@ -198,6 +255,7 @@
       justify-content: space-between;
       align-items: center;
       height: 8%;
+      min-height: 35px;
       padding-top: 0.5rem;
       border-top: 1px solid #222;
     }
@@ -259,6 +317,7 @@
       justify-content: space-around;
       align-items: flex-end;
       height: 10%;
+      min-height: 50px;
       border-top: 1px solid #222;
       padding: 0.5rem 1rem;
       gap: 0.5rem;


### PR DESCRIPTION
Added responsive layout adjustments for landscape orientation:

Changes:
- Added min-height constraints to all rows to prevent collapse
- Reduced row heights in landscape mode (clock 8%, info rows 10%, histogram 8%, status 6%)
- Scaled down font sizes in landscape orientation for better fit
- Reduced speed display from 38vmin to 28vmin in landscape (main), 35vmin to 26vmin (demo)
- Reduced padding and spacing in landscape mode
- All elements now fit properly without overlapping

This ensures the dashboard works well in both portrait and landscape orientations without content overlap.