### PR TITLE
fix: Make histogram bars display as proper vertical bar chart

### DIFF
--- a/fun-and-games/car-dashboard-demo.html
+++ b/fun-and-games/car-dashboard-demo.html
@@ -181,13 +181,14 @@
 
       .histogram-row {
         height: 8%;
-        min-height: 40px;
-        padding: 0.3rem 1rem;
+        min-height: 50px;
+        padding: 0.3rem 1rem 0.2rem;
       }
 
       .histogram-label,
       .histogram-value {
-        font-size: 1.7vmin;
+        font-size: 1.6vmin;
+        line-height: 1.1;
       }
 
       .status-row {
@@ -279,9 +280,9 @@
       justify-content: space-around;
       align-items: flex-end;
       height: 10%;
-      min-height: 50px;
+      min-height: 60px;
       border-top: 1px solid #222;
-      padding: 0.5rem 1rem;
+      padding: 0.5rem 1rem 0.3rem;
       gap: 0.5rem;
     }
 
@@ -290,7 +291,17 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      height: 100%;
       gap: 0.25rem;
+    }
+
+    .histogram-bar-container {
+      flex: 1;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      position: relative;
     }
 
     .histogram-bar-fill {
@@ -301,16 +312,18 @@
       min-height: 2px;
     }
 
-    .histogram-label {
-      font-size: 2vmin;
-      color: #666;
-      white-space: nowrap;
-    }
-
     .histogram-value {
       font-size: 2vmin;
       color: #888;
       font-variant-numeric: tabular-nums;
+      line-height: 1.2;
+    }
+
+    .histogram-label {
+      font-size: 2vmin;
+      color: #666;
+      white-space: nowrap;
+      line-height: 1.2;
     }
   </style>
 </head>
@@ -373,22 +386,30 @@
     <!-- Speed Histogram -->
     <div class="histogram-row">
       <div class="histogram-bar">
-        <div class="histogram-bar-fill" id="hist-bar-0" style="height: 0%"></div>
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-0" style="height: 0%"></div>
+        </div>
         <div class="histogram-value" id="hist-val-0">0%</div>
         <div class="histogram-label">0-25</div>
       </div>
       <div class="histogram-bar">
-        <div class="histogram-bar-fill" id="hist-bar-1" style="height: 0%"></div>
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-1" style="height: 0%"></div>
+        </div>
         <div class="histogram-value" id="hist-val-1">0%</div>
         <div class="histogram-label">25-50</div>
       </div>
       <div class="histogram-bar">
-        <div class="histogram-bar-fill" id="hist-bar-2" style="height: 0%"></div>
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-2" style="height: 0%"></div>
+        </div>
         <div class="histogram-value" id="hist-val-2">0%</div>
         <div class="histogram-label">50-70</div>
       </div>
       <div class="histogram-bar">
-        <div class="histogram-bar-fill" id="hist-bar-3" style="height: 0%"></div>
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-3" style="height: 0%"></div>
+        </div>
         <div class="histogram-value" id="hist-val-3">0%</div>
         <div class="histogram-label">70+</div>
       </div>

--- a/fun-and-games/car-dashboard.html
+++ b/fun-and-games/car-dashboard.html
@@ -211,13 +211,14 @@
 
       .histogram-row {
         height: 8%;
-        min-height: 40px;
-        padding: 0.3rem 1rem;
+        min-height: 50px;
+        padding: 0.3rem 1rem 0.2rem;
       }
 
       .histogram-label,
       .histogram-value {
-        font-size: 1.8vmin;
+        font-size: 1.6vmin;
+        line-height: 1.1;
       }
 
       .status-row {
@@ -317,9 +318,9 @@
       justify-content: space-around;
       align-items: flex-end;
       height: 10%;
-      min-height: 50px;
+      min-height: 60px;
       border-top: 1px solid #222;
-      padding: 0.5rem 1rem;
+      padding: 0.5rem 1rem 0.3rem;
       gap: 0.5rem;
     }
 
@@ -328,7 +329,17 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      height: 100%;
       gap: 0.25rem;
+    }
+
+    .histogram-bar-container {
+      flex: 1;
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      position: relative;
     }
 
     .histogram-bar-fill {
@@ -339,16 +350,18 @@
       min-height: 2px;
     }
 
-    .histogram-label {
-      font-size: 2vmin;
-      color: #666;
-      white-space: nowrap;
-    }
-
     .histogram-value {
       font-size: 2vmin;
       color: #888;
       font-variant-numeric: tabular-nums;
+      line-height: 1.2;
+    }
+
+    .histogram-label {
+      font-size: 2vmin;
+      color: #666;
+      white-space: nowrap;
+      line-height: 1.2;
     }
 
     /* Settings Panel */
@@ -496,22 +509,30 @@
     <!-- Speed Histogram -->
     <div class="histogram-row">
       <div class="histogram-bar">
-        <div class="histogram-bar-fill" id="hist-bar-0" style="height: 0%"></div>
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-0" style="height: 0%"></div>
+        </div>
         <div class="histogram-value" id="hist-val-0">0%</div>
         <div class="histogram-label">0-25</div>
       </div>
       <div class="histogram-bar">
-        <div class="histogram-bar-fill" id="hist-bar-1" style="height: 0%"></div>
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-1" style="height: 0%"></div>
+        </div>
         <div class="histogram-value" id="hist-val-1">0%</div>
         <div class="histogram-label">25-50</div>
       </div>
       <div class="histogram-bar">
-        <div class="histogram-bar-fill" id="hist-bar-2" style="height: 0%"></div>
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-2" style="height: 0%"></div>
+        </div>
         <div class="histogram-value" id="hist-val-2">0%</div>
         <div class="histogram-label">50-70</div>
       </div>
       <div class="histogram-bar">
-        <div class="histogram-bar-fill" id="hist-bar-3" style="height: 0%"></div>
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-3" style="height: 0%"></div>
+        </div>
         <div class="histogram-value" id="hist-val-3">0%</div>
         <div class="histogram-label">70+</div>
       </div>


### PR DESCRIPTION
Fixed the histogram visualization to show bars that grow upward:

Changes:
- Added histogram-bar-container wrapper for proper flex layout
- Made histogram-bar use full height with flex: 1
- Bars now grow from bottom using justify-content: flex-end
- Increased min-height from 50px to 60px for better visibility
- Adjusted padding and line-height for cleaner display
- Bars animate smoothly with height transitions

The histogram now displays as an actual bar chart where bars grow/shrink based on the percentage of time spent in each speed range, instead of just showing flat lines.