### PR TITLE
feat: Increase histogram granularity to 8 buckets with 10mph increments

### DIFF
--- a/fun-and-games/car-dashboard-demo.html
+++ b/fun-and-games/car-dashboard-demo.html
@@ -390,27 +390,55 @@
           <div class="histogram-bar-fill" id="hist-bar-0" style="height: 0%"></div>
         </div>
         <div class="histogram-value" id="hist-val-0">0%</div>
-        <div class="histogram-label">0-25</div>
+        <div class="histogram-label">0-10</div>
       </div>
       <div class="histogram-bar">
         <div class="histogram-bar-container">
           <div class="histogram-bar-fill" id="hist-bar-1" style="height: 0%"></div>
         </div>
         <div class="histogram-value" id="hist-val-1">0%</div>
-        <div class="histogram-label">25-50</div>
+        <div class="histogram-label">10-20</div>
       </div>
       <div class="histogram-bar">
         <div class="histogram-bar-container">
           <div class="histogram-bar-fill" id="hist-bar-2" style="height: 0%"></div>
         </div>
         <div class="histogram-value" id="hist-val-2">0%</div>
-        <div class="histogram-label">50-70</div>
+        <div class="histogram-label">20-30</div>
       </div>
       <div class="histogram-bar">
         <div class="histogram-bar-container">
           <div class="histogram-bar-fill" id="hist-bar-3" style="height: 0%"></div>
         </div>
         <div class="histogram-value" id="hist-val-3">0%</div>
+        <div class="histogram-label">30-40</div>
+      </div>
+      <div class="histogram-bar">
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-4" style="height: 0%"></div>
+        </div>
+        <div class="histogram-value" id="hist-val-4">0%</div>
+        <div class="histogram-label">40-50</div>
+      </div>
+      <div class="histogram-bar">
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-5" style="height: 0%"></div>
+        </div>
+        <div class="histogram-value" id="hist-val-5">0%</div>
+        <div class="histogram-label">50-60</div>
+      </div>
+      <div class="histogram-bar">
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-6" style="height: 0%"></div>
+        </div>
+        <div class="histogram-value" id="hist-val-6">0%</div>
+        <div class="histogram-label">60-70</div>
+      </div>
+      <div class="histogram-bar">
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-7" style="height: 0%"></div>
+        </div>
+        <div class="histogram-value" id="hist-val-7">0%</div>
         <div class="histogram-label">70+</div>
       </div>
     </div>
@@ -475,11 +503,15 @@
       movingTime: 0,        // ms
 
       // Speed histogram: time spent in each range (ms)
-      speedHistogram: [0, 0, 0, 0], // [0-25, 25-50, 50-70, 70+]
+      speedHistogram: [0, 0, 0, 0, 0, 0, 0, 0], // [0-10, 10-20, 20-30, 30-40, 40-50, 50-60, 60-70, 70+]
       speedRanges: [
-        { min: 0, max: 25 },
-        { min: 25, max: 50 },
-        { min: 50, max: 70 },
+        { min: 0, max: 10 },
+        { min: 10, max: 20 },
+        { min: 20, max: 30 },
+        { min: 30, max: 40 },
+        { min: 40, max: 50 },
+        { min: 50, max: 60 },
+        { min: 60, max: 70 },
         { min: 70, max: Infinity }
       ],
 
@@ -510,8 +542,8 @@
       maxSpeedDisplay: document.getElementById('max-speed-display'),
 
       // Histogram
-      histBars: [0, 1, 2, 3].map(i => document.getElementById(`hist-bar-${i}`)),
-      histVals: [0, 1, 2, 3].map(i => document.getElementById(`hist-val-${i}`)),
+      histBars: [0, 1, 2, 3, 4, 5, 6, 7].map(i => document.getElementById(`hist-bar-${i}`)),
+      histVals: [0, 1, 2, 3, 4, 5, 6, 7].map(i => document.getElementById(`hist-val-${i}`)),
     };
 
     // ============================================================================
@@ -585,7 +617,7 @@
         state.tripDistance = 0;
         state.maxSpeed = 0;
         state.movingTime = 0;
-        state.speedHistogram = [0, 0, 0, 0];
+        state.speedHistogram = [0, 0, 0, 0, 0, 0, 0, 0];
         state.altitudeHistory = [];
         state.tripStartTime = Date.now();
       }

--- a/fun-and-games/car-dashboard.html
+++ b/fun-and-games/car-dashboard.html
@@ -513,27 +513,55 @@
           <div class="histogram-bar-fill" id="hist-bar-0" style="height: 0%"></div>
         </div>
         <div class="histogram-value" id="hist-val-0">0%</div>
-        <div class="histogram-label">0-25</div>
+        <div class="histogram-label">0-10</div>
       </div>
       <div class="histogram-bar">
         <div class="histogram-bar-container">
           <div class="histogram-bar-fill" id="hist-bar-1" style="height: 0%"></div>
         </div>
         <div class="histogram-value" id="hist-val-1">0%</div>
-        <div class="histogram-label">25-50</div>
+        <div class="histogram-label">10-20</div>
       </div>
       <div class="histogram-bar">
         <div class="histogram-bar-container">
           <div class="histogram-bar-fill" id="hist-bar-2" style="height: 0%"></div>
         </div>
         <div class="histogram-value" id="hist-val-2">0%</div>
-        <div class="histogram-label">50-70</div>
+        <div class="histogram-label">20-30</div>
       </div>
       <div class="histogram-bar">
         <div class="histogram-bar-container">
           <div class="histogram-bar-fill" id="hist-bar-3" style="height: 0%"></div>
         </div>
         <div class="histogram-value" id="hist-val-3">0%</div>
+        <div class="histogram-label">30-40</div>
+      </div>
+      <div class="histogram-bar">
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-4" style="height: 0%"></div>
+        </div>
+        <div class="histogram-value" id="hist-val-4">0%</div>
+        <div class="histogram-label">40-50</div>
+      </div>
+      <div class="histogram-bar">
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-5" style="height: 0%"></div>
+        </div>
+        <div class="histogram-value" id="hist-val-5">0%</div>
+        <div class="histogram-label">50-60</div>
+      </div>
+      <div class="histogram-bar">
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-6" style="height: 0%"></div>
+        </div>
+        <div class="histogram-value" id="hist-val-6">0%</div>
+        <div class="histogram-label">60-70</div>
+      </div>
+      <div class="histogram-bar">
+        <div class="histogram-bar-container">
+          <div class="histogram-bar-fill" id="hist-bar-7" style="height: 0%"></div>
+        </div>
+        <div class="histogram-value" id="hist-val-7">0%</div>
         <div class="histogram-label">70+</div>
       </div>
     </div>
@@ -599,11 +627,15 @@
       lastUpdateTime: null,
 
       // Speed histogram: time spent in each range (ms)
-      speedHistogram: [0, 0, 0, 0], // [0-25, 25-50, 50-70, 70+]
+      speedHistogram: [0, 0, 0, 0, 0, 0, 0, 0], // [0-10, 10-20, 20-30, 30-40, 40-50, 50-60, 60-70, 70+]
       speedRanges: [
-        { min: 0, max: 25 },
-        { min: 25, max: 50 },
-        { min: 50, max: 70 },
+        { min: 0, max: 10 },
+        { min: 10, max: 20 },
+        { min: 20, max: 30 },
+        { min: 30, max: 40 },
+        { min: 40, max: 50 },
+        { min: 50, max: 60 },
+        { min: 60, max: 70 },
         { min: 70, max: Infinity }
       ],
 
@@ -650,8 +682,8 @@
       gpsAccuracy: document.getElementById('gps-accuracy'),
 
       // Histogram
-      histBars: [0, 1, 2, 3].map(i => document.getElementById(`hist-bar-${i}`)),
-      histVals: [0, 1, 2, 3].map(i => document.getElementById(`hist-val-${i}`)),
+      histBars: [0, 1, 2, 3, 4, 5, 6, 7].map(i => document.getElementById(`hist-bar-${i}`)),
+      histVals: [0, 1, 2, 3, 4, 5, 6, 7].map(i => document.getElementById(`hist-val-${i}`)),
 
       // Settings
       resetTripBtn: document.getElementById('reset-trip-btn')
@@ -746,7 +778,7 @@
       state.tripStartTime = Date.now();
       state.maxSpeed = 0;
       state.movingTime = 0;
-      state.speedHistogram = [0, 0, 0, 0];
+      state.speedHistogram = [0, 0, 0, 0, 0, 0, 0, 0];
       state.altitudeHistory = [];
       updateDisplay();
     }


### PR DESCRIPTION
Changed speed histogram from 4 to 8 buckets for better detail:

Old buckets: 0-25, 25-50, 50-70, 70+
New buckets: 0-10, 10-20, 20-30, 30-40, 40-50, 50-60, 60-70, 70+

This provides much finer granularity for speed distribution tracking, making it easier to see exactly how time is spent across different speed ranges during a trip.

Changes:
- Updated speedHistogram array to 8 elements
- Updated speedRanges with 10mph increments
- Added 4 additional histogram bars to the UI
- Updated DOM references and reset function
- Applied to both real GPS and demo dashboards