### PR TITLE
refactor: Simplify bookmarklet installer by removing grid view and stats

### DIFF
--- a/web-utilities/bookmarklet-installer.html
+++ b/web-utilities/bookmarklet-installer.html
@@ -73,61 +73,6 @@
       margin-bottom: 1rem;
     }
 
-    .stats-dashboard {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-      gap: 1rem;
-      margin: 1.5rem 0;
-    }
-
-    .stat-card {
-      background: var(--bg-card);
-      border: 1px solid var(--border-color);
-      border-radius: 8px;
-      padding: 1rem;
-      text-align: center;
-      box-shadow: 0 2px 4px var(--shadow);
-    }
-
-    .stat-number {
-      font-size: 2rem;
-      font-weight: bold;
-      color: var(--accent-primary);
-    }
-
-    .stat-label {
-      font-size: 0.875rem;
-      color: var(--text-secondary);
-      margin-top: 0.25rem;
-    }
-
-    .view-toggle {
-      display: flex;
-      gap: 0.5rem;
-      margin: 1rem 0;
-      flex-wrap: wrap;
-    }
-
-    .view-toggle button {
-      padding: 0.5rem 1rem;
-      border: 1px solid var(--border-color);
-      background: var(--bg-secondary);
-      color: var(--text-primary);
-      border-radius: 4px;
-      cursor: pointer;
-      transition: all 0.2s;
-    }
-
-    .view-toggle button.active {
-      background: var(--accent-primary);
-      color: white;
-      border-color: var(--accent-primary);
-    }
-
-    .view-toggle button:hover:not(.active) {
-      background: var(--border-color);
-    }
-
     .filters-section {
       background: var(--bg-secondary);
       padding: 1.5rem;
@@ -213,63 +158,6 @@
       background-color: var(--border-color);
     }
 
-    .grid-view {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-      gap: 1rem;
-      margin: 1.5rem 0;
-    }
-
-    .bookmarklet-card {
-      background: var(--bg-card);
-      border: 1px solid var(--border-color);
-      border-radius: 8px;
-      padding: 1.25rem;
-      cursor: pointer;
-      transition: all 0.2s;
-      box-shadow: 0 2px 4px var(--shadow);
-    }
-
-    .bookmarklet-card:hover {
-      box-shadow: 0 4px 12px var(--shadow);
-      border-color: var(--accent-primary);
-      transform: translateY(-2px);
-    }
-
-    .bookmarklet-card.selected {
-      border-color: var(--accent-primary);
-      border-width: 2px;
-      padding: calc(1.25rem - 1px);
-    }
-
-    .card-title {
-      font-weight: 600;
-      font-size: 1.125rem;
-      margin: 0 0 0.5rem 0;
-      color: var(--text-primary);
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-
-    .card-description {
-      font-size: 0.875rem;
-      color: var(--text-secondary);
-      margin: 0 0 1rem 0;
-      line-height: 1.5;
-      display: -webkit-box;
-      -webkit-line-clamp: 3;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-    }
-
-    .card-footer {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      align-items: center;
-    }
-
     .badge {
       display: inline-flex;
       align-items: center;
@@ -298,14 +186,6 @@
     .badge-warning {
       background: var(--badge-orange);
       color: white;
-    }
-
-    .list-view {
-      display: none;
-    }
-
-    .list-view.active {
-      display: block;
     }
 
     .metadata-info {
@@ -511,16 +391,8 @@
         padding: 10px;
       }
 
-      .grid-view {
-        grid-template-columns: 1fr;
-      }
-
       .filter-row {
         grid-template-columns: 1fr;
-      }
-
-      .stats-dashboard {
-        grid-template-columns: repeat(2, 1fr);
       }
     }
   </style>
@@ -530,16 +402,6 @@
 <body>
   <div class="container">
     <h1>📚 Bookmarklet Installer</h1>
-
-    <!-- Stats Dashboard -->
-    <div id="statsDashboard" class="stats-dashboard"></div>
-
-    <!-- View Toggle -->
-    <div class="view-toggle">
-      <button id="gridViewBtn" class="active">Grid View</button>
-      <button id="listViewBtn">List View</button>
-      <button id="installViewBtn">Install Mode</button>
-    </div>
 
     <!-- Filters Section -->
     <div class="filters-section">
@@ -566,11 +428,8 @@
       </div>
     </div>
 
-    <!-- Grid View -->
-    <div id="gridView" class="grid-view"></div>
-
-    <!-- List/Install View -->
-    <div id="installView" class="list-view">
+    <!-- Install View -->
+    <div id="installView">
       <div class="input-group">
         <label for="bookmarkletSelect">Select a Bookmarklet from
           <a href="https://github.com/oaustegard/bookmarklets" target="_blank">github.com/oaustegard/bookmarklets</a>
@@ -663,7 +522,6 @@
       const state = {
         bookmarklets: [],
         filteredBookmarklets: [],
-        currentView: 'grid',
         selectedBookmarklet: null,
         currentMetadata: null
       };
@@ -672,20 +530,10 @@
          DOM ELEMENTS
          ============================================ */
       const elements = {
-        // Views
-        gridView: document.getElementById('gridView'),
-        installView: document.getElementById('installView'),
-        gridViewBtn: document.getElementById('gridViewBtn'),
-        listViewBtn: document.getElementById('listViewBtn'),
-        installViewBtn: document.getElementById('installViewBtn'),
-
         // Filters & Search
         searchInput: document.getElementById('searchInput'),
         domainFilter: document.getElementById('domainFilter'),
         sortSelect: document.getElementById('sortSelect'),
-
-        // Stats
-        statsDashboard: document.getElementById('statsDashboard'),
 
         // Install view
         select: document.getElementById('bookmarkletSelect'),
@@ -846,8 +694,6 @@
 
           populateDropdown();
           populateDomainFilter();
-          renderStats();
-          renderGridView();
 
           // Handle URL parameter
           const urlBookmarklet = getBookmarkletFromURL();
@@ -855,9 +701,6 @@
             const matching = bookmarklets.find(b => b.filename === urlBookmarklet);
             if (matching) {
               selectBookmarklet(matching);
-              if (state.currentView === 'grid') {
-                switchView('install');
-              }
             }
           }
         } catch (error) {
@@ -868,90 +711,6 @@
       /* ============================================
          UI RENDERING
          ============================================ */
-      function renderStats() {
-        const total = state.bookmarklets.length;
-        const withMetadata = state.bookmarklets.filter(b => b.hasMetadata).length;
-        const withReadme = state.bookmarklets.filter(b => b.hasReadme).length;
-        const allDomains = new Set();
-        state.bookmarklets.forEach(b => {
-          b.metadata.domainList.forEach(d => allDomains.add(d));
-        });
-
-        elements.statsDashboard.innerHTML = `
-          <div class="stat-card">
-            <div class="stat-number">${total}</div>
-            <div class="stat-label">Total Bookmarklets</div>
-          </div>
-          <div class="stat-card">
-            <div class="stat-number">${withMetadata}</div>
-            <div class="stat-label">With Metadata</div>
-          </div>
-          <div class="stat-card">
-            <div class="stat-number">${withReadme}</div>
-            <div class="stat-label">With README</div>
-          </div>
-          <div class="stat-card">
-            <div class="stat-number">${allDomains.size}</div>
-            <div class="stat-label">Domains Covered</div>
-          </div>
-        `;
-      }
-
-      function renderGridView() {
-        if (state.filteredBookmarklets.length === 0) {
-          elements.gridView.innerHTML = '<div class="no-results">No bookmarklets found matching your filters.</div>';
-          return;
-        }
-
-        elements.gridView.innerHTML = state.filteredBookmarklets.map(bookmarklet => {
-          const displayTitle = bookmarklet.metadata.title || formatNameFromFilename(bookmarklet.name);
-          const description = bookmarklet.metadata.description || 'No description available';
-          const badges = [];
-
-          if (bookmarklet.hasMetadata) {
-            badges.push('<span class="badge badge-metadata">✨ Metadata</span>');
-          }
-          if (bookmarklet.hasReadme) {
-            badges.push('<span class="badge badge-readme">📄 README</span>');
-          }
-
-          const domainBadges = bookmarklet.metadata.domainList
-            .slice(0, 3)
-            .map(domain => `<span class="badge badge-domain">🌐 ${domain}</span>`)
-            .join('');
-
-          const moreDomains = bookmarklet.metadata.domainList.length > 3
-            ? `<span class="badge badge-domain">+${bookmarklet.metadata.domainList.length - 3} more</span>`
-            : '';
-
-          const selectedClass = state.selectedBookmarklet?.filename === bookmarklet.filename ? 'selected' : '';
-
-          return `
-            <div class="bookmarklet-card ${selectedClass}" data-filename="${bookmarklet.filename}">
-              <div class="card-title">${displayTitle}</div>
-              <div class="card-description">${description}</div>
-              <div class="card-footer">
-                ${badges.join('')}
-                ${domainBadges}
-                ${moreDomains}
-              </div>
-            </div>
-          `;
-        }).join('');
-
-        // Add click handlers
-        document.querySelectorAll('.bookmarklet-card').forEach(card => {
-          card.addEventListener('click', () => {
-            const filename = card.dataset.filename;
-            const bookmarklet = state.bookmarklets.find(b => b.filename === filename);
-            if (bookmarklet) {
-              selectBookmarklet(bookmarklet);
-              switchView('install');
-            }
-          });
-        });
-      }
-
       function renderMetadataInfo(bookmarklet) {
         if (!bookmarklet || !bookmarklet.hasMetadata) {
           elements.metadataInfo.classList.add('hidden');
@@ -960,6 +719,14 @@
 
         const metadata = bookmarklet.metadata;
         let html = '<h3>📋 Bookmarklet Information</h3>';
+
+        // Show filename
+        html += `
+          <div class="metadata-row">
+            <div class="metadata-label">File</div>
+            <div class="metadata-value"><code>${bookmarklet.filename}</code></div>
+          </div>
+        `;
 
         if (metadata.title) {
           html += `
@@ -1001,7 +768,6 @@
             const domain = tag.dataset.domain;
             elements.domainFilter.value = domain;
             applyFilters();
-            switchView('grid');
           });
         });
       }
@@ -1009,7 +775,7 @@
       function populateDropdown() {
         elements.select.innerHTML = '<option value="">-- Select a bookmarklet --</option>';
 
-        state.bookmarklets.forEach(bookmarklet => {
+        state.filteredBookmarklets.forEach(bookmarklet => {
           const option = document.createElement('option');
           option.value = bookmarklet.filename;
 
@@ -1018,7 +784,7 @@
           if (bookmarklet.hasReadme) indicators.push('📄');
 
           const displayName = bookmarklet.metadata.title || formatNameFromFilename(bookmarklet.name);
-          option.textContent = `${displayName} ${indicators.join(' ')}`;
+          option.textContent = `${displayName} - ${bookmarklet.filename} ${indicators.join(' ')}`;
 
           elements.select.appendChild(option);
         });
@@ -1108,35 +874,7 @@
         });
 
         state.filteredBookmarklets = filtered;
-        renderGridView();
-      }
-
-      /* ============================================
-         VIEW SWITCHING
-         ============================================ */
-      function switchView(view) {
-        state.currentView = view;
-
-        // Update buttons
-        elements.gridViewBtn.classList.remove('active');
-        elements.listViewBtn.classList.remove('active');
-        elements.installViewBtn.classList.remove('active');
-
-        // Update views
-        if (view === 'grid') {
-          elements.gridViewBtn.classList.add('active');
-          elements.gridView.style.display = 'grid';
-          elements.installView.classList.remove('active');
-        } else if (view === 'list' || view === 'install') {
-          if (view === 'list') {
-            elements.listViewBtn.classList.add('active');
-          } else {
-            elements.installViewBtn.classList.add('active');
-          }
-          elements.gridView.style.display = 'none';
-          elements.installView.classList.add('active');
-          elements.installView.style.display = 'block';
-        }
+        populateDropdown();
       }
 
       /* ============================================
@@ -1164,7 +902,6 @@
 
         await updateBookmarklet();
         updateURLState(bookmarklet.filename);
-        renderGridView(); // Re-render to update selected state
       }
 
       async function createBookmarkletUrl(code) {
@@ -1328,11 +1065,6 @@
          EVENT LISTENERS
          ============================================ */
 
-      // View switching
-      elements.gridViewBtn.addEventListener('click', () => switchView('grid'));
-      elements.listViewBtn.addEventListener('click', () => switchView('list'));
-      elements.installViewBtn.addEventListener('click', () => switchView('install'));
-
       // Filtering
       elements.searchInput.addEventListener('input', applyFilters);
       elements.domainFilter.addEventListener('change', applyFilters);
@@ -1350,7 +1082,6 @@
           hideWarning();
           await updateBookmarklet();
           updateURLState(null);
-          renderGridView();
           return;
         }
 
@@ -1418,7 +1149,6 @@
           updateSourceLinks(null);
           renderMetadataInfo(null);
           await updateBookmarklet();
-          renderGridView();
         }
       });
 


### PR DESCRIPTION
Removed performative/non-essential UI elements per user feedback:

Removed:
- Grid view with card layout
- Statistics dashboard (total bookmarklets, metadata counts, domains)
- View toggle buttons (Grid View, List View, Install Mode)
- All associated CSS and JavaScript for grid rendering
- View switching functionality

Enhanced:
- Dropdown now shows filename alongside title for easy GitHub correlation Format: "Title - filename.js ✨ 📄"
- Metadata info panel now displays filename at the top
- Domain tags in metadata still clickable for filtering

Simplified:
- Single install-focused interface (no view switching)
- Filters (search, domain, sort) now update dropdown directly
- Cleaner, more focused user experience
- Reduced JavaScript complexity and state management

The installer now focuses purely on its core purpose: selecting and installing bookmarklets with powerful filtering capabilities.