### PR TITLE
Add gist encryption/decryption tool with pv.html integration

### DIFF
--- a/web-utilities/gist-encryption.html
+++ b/web-utilities/gist-encryption.html
@@ -1,0 +1,588 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gist Encryption/Decryption</title>
+    <style>
+        :root {
+            --bg-color: #ffffff;
+            --text-color: #333333;
+            --border-color: #ddd;
+            --input-bg: #f9f9f9;
+            --button-bg: #007bff;
+            --button-hover: #0056b3;
+            --button-text: #ffffff;
+            --success-bg: #d4edda;
+            --success-border: #c3e6cb;
+            --success-text: #155724;
+            --error-bg: #f8d7da;
+            --error-border: #f5c6cb;
+            --error-text: #721c24;
+        }
+
+        [data-theme="dark"] {
+            --bg-color: #1a1a1a;
+            --text-color: #e0e0e0;
+            --border-color: #444;
+            --input-bg: #2a2a2a;
+            --button-bg: #0d6efd;
+            --button-hover: #0a58ca;
+            --success-bg: #1e4620;
+            --success-border: #2d5f2e;
+            --success-text: #a3d5a5;
+            --error-bg: #5a1a1a;
+            --error-border: #7a2a2a;
+            --error-text: #f5b5ba;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            line-height: 1.6;
+        }
+
+        h1 {
+            margin-bottom: 10px;
+        }
+
+        .description {
+            color: var(--text-color);
+            opacity: 0.8;
+            margin-bottom: 30px;
+            font-size: 14px;
+        }
+
+        .theme-toggle {
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            display: flex;
+            gap: 5px;
+            background: var(--input-bg);
+            border: 1px solid var(--border-color);
+            border-radius: 5px;
+            padding: 5px;
+            z-index: 1000;
+        }
+
+        .theme-toggle button {
+            padding: 5px 10px;
+            border: 1px solid var(--border-color);
+            background: var(--input-bg);
+            color: var(--text-color);
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 11px;
+        }
+
+        .theme-toggle button.active {
+            background: var(--button-bg);
+            color: var(--button-text);
+            font-weight: bold;
+        }
+
+        .section {
+            margin-bottom: 30px;
+            padding: 20px;
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            background: var(--input-bg);
+        }
+
+        .section h2 {
+            margin-top: 0;
+            font-size: 20px;
+        }
+
+        .form-group {
+            margin-bottom: 15px;
+        }
+
+        label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: 500;
+        }
+
+        input[type="text"],
+        textarea {
+            width: 100%;
+            padding: 10px;
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            background: var(--bg-color);
+            color: var(--text-color);
+            font-family: inherit;
+            font-size: 14px;
+        }
+
+        textarea {
+            min-height: 150px;
+            font-family: 'Courier New', monospace;
+            resize: vertical;
+        }
+
+        button {
+            padding: 10px 20px;
+            border: none;
+            border-radius: 4px;
+            background: var(--button-bg);
+            color: var(--button-text);
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 500;
+            margin-right: 10px;
+            transition: background 0.2s;
+        }
+
+        button:hover {
+            background: var(--button-hover);
+        }
+
+        button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        .result-box {
+            margin-top: 15px;
+            padding: 15px;
+            border: 1px solid var(--success-border);
+            border-radius: 4px;
+            background: var(--success-bg);
+            color: var(--success-text);
+            display: none;
+            word-break: break-all;
+        }
+
+        .result-box.error {
+            border-color: var(--error-border);
+            background: var(--error-bg);
+            color: var(--error-text);
+        }
+
+        .result-box.show {
+            display: block;
+        }
+
+        .result-box h3 {
+            margin-top: 0;
+            font-size: 16px;
+        }
+
+        .result-box pre {
+            background: var(--bg-color);
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+            margin: 10px 0;
+        }
+
+        .copy-btn {
+            background: #28a745;
+            margin-top: 10px;
+        }
+
+        .copy-btn:hover {
+            background: #218838;
+        }
+
+        .info-box {
+            padding: 15px;
+            background: #e7f3ff;
+            border: 1px solid #b3d9ff;
+            border-radius: 4px;
+            margin-top: 20px;
+            font-size: 14px;
+        }
+
+        [data-theme="dark"] .info-box {
+            background: #1a3a52;
+            border-color: #2a5a82;
+        }
+
+        code {
+            background: var(--bg-color);
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-family: 'Courier New', monospace;
+        }
+
+        .hidden {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="theme-toggle">
+        <button data-theme="light">Light</button>
+        <button data-theme="auto">Auto</button>
+        <button data-theme="dark">Dark</button>
+    </div>
+
+    <h1>Gist Encryption/Decryption</h1>
+    <p class="description">
+        Encrypt text with AES-256-GCM to securely share via GitHub Gists.
+        The encryption key never leaves your browser and can be shared via URL fragment (e.g., <code>pv.html?gistid#key=...</code>).
+    </p>
+
+    <div class="section">
+        <h2>Encrypt</h2>
+        <form id="encrypt-form">
+            <div class="form-group">
+                <label for="encrypt-salt">Salt (optional metadata, not encrypted):</label>
+                <input type="text" id="encrypt-salt" placeholder="e.g., version, description">
+            </div>
+            <div class="form-group">
+                <label for="encrypt-text">Text to Encrypt:</label>
+                <textarea id="encrypt-text" placeholder="Enter your text here..." required></textarea>
+            </div>
+            <button type="submit">🔒 Encrypt</button>
+            <button type="button" id="clear-encrypt">Clear</button>
+        </form>
+
+        <div id="encrypt-result" class="result-box">
+            <h3>Encryption Successful!</h3>
+            <p><strong>Encryption Key (keep this secret):</strong></p>
+            <pre id="encrypt-key-display"></pre>
+            <button type="button" class="copy-btn" data-copy="key">Copy Key</button>
+
+            <p style="margin-top: 20px;"><strong>Encrypted Text (save this to a gist):</strong></p>
+            <pre id="encrypt-output-display"></pre>
+            <button type="button" class="copy-btn" data-copy="encrypted">Copy Encrypted Text</button>
+
+            <p style="margin-top: 20px;"><strong>PV.html URL with key:</strong></p>
+            <pre id="pv-url-display"></pre>
+            <button type="button" class="copy-btn" data-copy="pv-url">Copy PV URL</button>
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Decrypt</h2>
+        <form id="decrypt-form">
+            <div class="form-group">
+                <label for="decrypt-key">Encryption Key:</label>
+                <input type="text" id="decrypt-key" placeholder="Paste the encryption key here..." required>
+            </div>
+            <div class="form-group">
+                <label for="decrypt-text">Encrypted Text:</label>
+                <textarea id="decrypt-text" placeholder="Paste the encrypted text (JSON format)..." required></textarea>
+            </div>
+            <button type="submit">🔓 Decrypt</button>
+            <button type="button" id="clear-decrypt">Clear</button>
+        </form>
+
+        <div id="decrypt-result" class="result-box">
+            <h3>Decryption Successful!</h3>
+            <p><strong>Salt:</strong> <span id="decrypt-salt-display"></span></p>
+            <p><strong>Decrypted Text:</strong></p>
+            <pre id="decrypt-output-display"></pre>
+            <button type="button" class="copy-btn" data-copy="decrypted">Copy Decrypted Text</button>
+        </div>
+
+        <div id="decrypt-error" class="result-box error">
+            <h3>Decryption Failed</h3>
+            <p id="decrypt-error-message"></p>
+        </div>
+    </div>
+
+    <div class="info-box">
+        <h3>How to use:</h3>
+        <ol>
+            <li><strong>Encrypt:</strong> Enter your text and click "Encrypt". Save the key somewhere safe (it's not recoverable).</li>
+            <li><strong>Share:</strong> Copy the encrypted text and paste it into a GitHub Gist.</li>
+            <li><strong>View:</strong> Share the gist URL with the key in the fragment: <code>https://austegard.com/pv.html?gistid#key=YOUR_KEY</code></li>
+            <li><strong>Decrypt:</strong> Or manually decrypt by pasting the key and encrypted text above.</li>
+        </ol>
+        <p><strong>Technical details:</strong> Uses AES-256-GCM encryption via the Web Crypto API. All encryption/decryption happens in your browser - no data is sent to any server.</p>
+    </div>
+
+    <script>
+        // Theme management
+        const themeManager = {
+            current: localStorage.getItem('gist-crypto-theme') || 'auto',
+
+            init() {
+                this.apply();
+                this.setupControls();
+            },
+
+            apply() {
+                const theme = this.current;
+                let effectiveTheme = theme;
+
+                if (theme === 'auto') {
+                    effectiveTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                }
+
+                if (effectiveTheme === 'dark') {
+                    document.documentElement.setAttribute('data-theme', 'dark');
+                } else {
+                    document.documentElement.removeAttribute('data-theme');
+                }
+
+                document.querySelectorAll('.theme-toggle button').forEach(btn => {
+                    btn.classList.toggle('active', btn.dataset.theme === theme);
+                });
+            },
+
+            set(theme) {
+                this.current = theme;
+                localStorage.setItem('gist-crypto-theme', theme);
+                this.apply();
+            },
+
+            setupControls() {
+                document.querySelectorAll('.theme-toggle button').forEach(btn => {
+                    btn.addEventListener('click', () => this.set(btn.dataset.theme));
+                });
+
+                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+                    if (this.current === 'auto') this.apply();
+                });
+            }
+        };
+
+        // Crypto utilities
+        const crypto = {
+            async generateKey() {
+                const key = await window.crypto.subtle.generateKey(
+                    { name: 'AES-GCM', length: 256 },
+                    true,
+                    ['encrypt', 'decrypt']
+                );
+                const exported = await window.crypto.subtle.exportKey('raw', key);
+                return {
+                    key,
+                    keyString: this.arrayBufferToBase64(exported)
+                };
+            },
+
+            async importKey(keyString) {
+                const keyData = this.base64ToArrayBuffer(keyString);
+                return await window.crypto.subtle.importKey(
+                    'raw',
+                    keyData,
+                    { name: 'AES-GCM', length: 256 },
+                    false,
+                    ['encrypt', 'decrypt']
+                );
+            },
+
+            async encrypt(text, salt = '') {
+                const { key, keyString } = await this.generateKey();
+                const iv = window.crypto.getRandomValues(new Uint8Array(12)); // 96 bits
+                const encoder = new TextEncoder();
+                const data = encoder.encode(text);
+
+                const encrypted = await window.crypto.subtle.encrypt(
+                    { name: 'AES-GCM', iv },
+                    key,
+                    data
+                );
+
+                return {
+                    keyString,
+                    encrypted: {
+                        salt,
+                        iv: this.arrayBufferToBase64(iv),
+                        data: this.arrayBufferToBase64(encrypted)
+                    }
+                };
+            },
+
+            async decrypt(keyString, encryptedData) {
+                const key = await this.importKey(keyString);
+                const iv = this.base64ToArrayBuffer(encryptedData.iv);
+                const data = this.base64ToArrayBuffer(encryptedData.data);
+
+                const decrypted = await window.crypto.subtle.decrypt(
+                    { name: 'AES-GCM', iv },
+                    key,
+                    data
+                );
+
+                const decoder = new TextDecoder();
+                return {
+                    salt: encryptedData.salt || '',
+                    text: decoder.decode(decrypted)
+                };
+            },
+
+            arrayBufferToBase64(buffer) {
+                const bytes = new Uint8Array(buffer);
+                let binary = '';
+                for (let i = 0; i < bytes.byteLength; i++) {
+                    binary += String.fromCharCode(bytes[i]);
+                }
+                return btoa(binary);
+            },
+
+            base64ToArrayBuffer(base64) {
+                const binary = atob(base64);
+                const bytes = new Uint8Array(binary.length);
+                for (let i = 0; i < binary.length; i++) {
+                    bytes[i] = binary.charCodeAt(i);
+                }
+                return bytes.buffer;
+            }
+        };
+
+        // UI handlers
+        const ui = {
+            init() {
+                // Encrypt form
+                document.getElementById('encrypt-form').addEventListener('submit', async (e) => {
+                    e.preventDefault();
+                    const salt = document.getElementById('encrypt-salt').value;
+                    const text = document.getElementById('encrypt-text').value;
+
+                    try {
+                        const { keyString, encrypted } = await crypto.encrypt(text, salt);
+                        const encryptedJson = JSON.stringify(encrypted, null, 2);
+
+                        document.getElementById('encrypt-key-display').textContent = keyString;
+                        document.getElementById('encrypt-output-display').textContent = encryptedJson;
+                        document.getElementById('pv-url-display').textContent =
+                            'Paste encrypted text into a gist, then use:\nhttps://austegard.com/pv.html?YOUR_GIST_ID#key=' + keyString;
+                        document.getElementById('encrypt-result').classList.add('show');
+                    } catch (error) {
+                        alert('Encryption failed: ' + error.message);
+                    }
+                });
+
+                // Decrypt form
+                document.getElementById('decrypt-form').addEventListener('submit', async (e) => {
+                    e.preventDefault();
+                    const keyString = document.getElementById('decrypt-key').value.trim();
+                    const encryptedText = document.getElementById('decrypt-text').value.trim();
+
+                    document.getElementById('decrypt-result').classList.remove('show');
+                    document.getElementById('decrypt-error').classList.remove('show');
+
+                    try {
+                        const encrypted = JSON.parse(encryptedText);
+                        const { salt, text } = await crypto.decrypt(keyString, encrypted);
+
+                        document.getElementById('decrypt-salt-display').textContent = salt || '(none)';
+                        document.getElementById('decrypt-output-display').textContent = text;
+                        document.getElementById('decrypt-result').classList.add('show');
+                    } catch (error) {
+                        document.getElementById('decrypt-error-message').textContent = error.message;
+                        document.getElementById('decrypt-error').classList.add('show');
+                    }
+                });
+
+                // Clear buttons
+                document.getElementById('clear-encrypt').addEventListener('click', () => {
+                    document.getElementById('encrypt-form').reset();
+                    document.getElementById('encrypt-result').classList.remove('show');
+                });
+
+                document.getElementById('clear-decrypt').addEventListener('click', () => {
+                    document.getElementById('decrypt-form').reset();
+                    document.getElementById('decrypt-result').classList.remove('show');
+                    document.getElementById('decrypt-error').classList.remove('show');
+                });
+
+                // Copy buttons
+                document.querySelectorAll('.copy-btn').forEach(btn => {
+                    btn.addEventListener('click', async () => {
+                        const type = btn.dataset.copy;
+                        let text = '';
+
+                        if (type === 'key') {
+                            text = document.getElementById('encrypt-key-display').textContent;
+                        } else if (type === 'encrypted') {
+                            text = document.getElementById('encrypt-output-display').textContent;
+                        } else if (type === 'pv-url') {
+                            text = document.getElementById('pv-url-display').textContent;
+                        } else if (type === 'decrypted') {
+                            text = document.getElementById('decrypt-output-display').textContent;
+                        }
+
+                        try {
+                            await navigator.clipboard.writeText(text);
+                            const originalText = btn.textContent;
+                            btn.textContent = '✓ Copied!';
+                            setTimeout(() => {
+                                btn.textContent = originalText;
+                            }, 2000);
+                        } catch (error) {
+                            alert('Failed to copy: ' + error.message);
+                        }
+                    });
+                });
+            }
+        };
+
+        // Client-side API (similar to claude-pruner)
+        window.addEventListener('message', async (event) => {
+            // Accept messages from same origin or austegard.com
+            if (event.origin !== window.location.origin &&
+                !event.origin.includes('austegard.com')) {
+                return;
+            }
+
+            if (event.data.type === 'gist-encrypt') {
+                try {
+                    const { keyString, encrypted } = await crypto.encrypt(
+                        event.data.text,
+                        event.data.salt || ''
+                    );
+                    event.source.postMessage({
+                        type: 'gist-encrypt-result',
+                        success: true,
+                        key: keyString,
+                        encrypted: encrypted
+                    }, event.origin);
+                } catch (error) {
+                    event.source.postMessage({
+                        type: 'gist-encrypt-result',
+                        success: false,
+                        error: error.message
+                    }, event.origin);
+                }
+            } else if (event.data.type === 'gist-decrypt') {
+                try {
+                    const result = await crypto.decrypt(event.data.key, event.data.encrypted);
+                    event.source.postMessage({
+                        type: 'gist-decrypt-result',
+                        success: true,
+                        salt: result.salt,
+                        text: result.text
+                    }, event.origin);
+                } catch (error) {
+                    event.source.postMessage({
+                        type: 'gist-decrypt-result',
+                        success: false,
+                        error: error.message
+                    }, event.origin);
+                }
+            }
+        });
+
+        // Check for URL parameters (auto-populate decrypt form)
+        window.addEventListener('DOMContentLoaded', () => {
+            themeManager.init();
+            ui.init();
+
+            const params = new URLSearchParams(window.location.search);
+            const key = params.get('key') || window.location.hash.replace(/^#key=/, '');
+
+            if (key) {
+                document.getElementById('decrypt-key').value = key;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/web-utilities/gist-encryption_README.md
+++ b/web-utilities/gist-encryption_README.md
@@ -1,0 +1,186 @@
+# Gist Encryption/Decryption Tool
+
+A client-side encryption/decryption tool for securely sharing content via GitHub Gists. All encryption and decryption happens in your browser - no data is sent to any server.
+
+## Features
+
+- **AES-256-GCM Encryption**: Industry-standard encryption using the Web Crypto API
+- **Client-Side Only**: All cryptographic operations happen in your browser
+- **Gist Integration**: Designed to work seamlessly with GitHub Gists and the pv.html viewer
+- **URL Fragment Keys**: Share decryption keys safely via URL fragments (never transmitted to servers)
+- **Optional Salt**: Include unencrypted metadata with your encrypted content
+- **Theme Support**: Light, dark, and auto themes
+
+## How to Use
+
+### Encrypting Content
+
+1. Visit [austegard.com/web-utilities/gist-encryption.html](https://austegard.com/web-utilities/gist-encryption.html)
+2. Optionally enter a salt (metadata that won't be encrypted, like version or description)
+3. Enter the text you want to encrypt
+4. Click "🔒 Encrypt"
+5. **Save the encryption key** - you won't be able to decrypt without it!
+6. Copy the encrypted text (JSON format)
+7. Create a new GitHub Gist and paste the encrypted text
+
+### Sharing Encrypted Gists
+
+After creating a gist with encrypted content:
+
+1. Get your gist ID (e.g., `a1902d995b5c6157a9eaf69afa355723`)
+2. Share using the pv.html viewer with the key in the URL fragment:
+   ```
+   https://austegard.com/pv.html?a1902d995b5c6157a9eaf69afa355723#key=YOUR_ENCRYPTION_KEY
+   ```
+
+The key after the `#` is never sent to any server - it stays in the browser only.
+
+### Decrypting Content
+
+**Option 1: Via pv.html (Automatic)**
+- Visit the pv.html URL with the key fragment (as shown above)
+- The content will be automatically decrypted and displayed
+
+**Option 2: Manual Decryption**
+1. Visit the gist-encryption tool
+2. Scroll to the "Decrypt" section
+3. Paste the encryption key
+4. Paste the encrypted text (JSON)
+5. Click "🔓 Decrypt"
+
+## Client-Side API
+
+The tool supports programmatic encryption/decryption via the `postMessage` API, similar to the Claude Pruner tool.
+
+### Encrypting via API
+
+```javascript
+// Open the tool in a hidden iframe or popup
+const cryptoWindow = window.open('https://austegard.com/web-utilities/gist-encryption.html');
+
+// Wait for it to load, then send encryption request
+window.addEventListener('message', (event) => {
+    if (event.data.type === 'gist-encrypt-result') {
+        if (event.data.success) {
+            console.log('Key:', event.data.key);
+            console.log('Encrypted:', event.data.encrypted);
+        } else {
+            console.error('Encryption failed:', event.data.error);
+        }
+    }
+});
+
+cryptoWindow.postMessage({
+    type: 'gist-encrypt',
+    text: 'Your secret text here',
+    salt: 'optional metadata'
+}, 'https://austegard.com');
+```
+
+### Decrypting via API
+
+```javascript
+window.addEventListener('message', (event) => {
+    if (event.data.type === 'gist-decrypt-result') {
+        if (event.data.success) {
+            console.log('Salt:', event.data.salt);
+            console.log('Decrypted text:', event.data.text);
+        } else {
+            console.error('Decryption failed:', event.data.error);
+        }
+    }
+});
+
+cryptoWindow.postMessage({
+    type: 'gist-decrypt',
+    key: 'YOUR_ENCRYPTION_KEY',
+    encrypted: {
+        salt: 'metadata',
+        iv: 'base64-encoded-iv',
+        data: 'base64-encoded-ciphertext'
+    }
+}, 'https://austegard.com');
+```
+
+## Technical Details
+
+### Encryption Algorithm
+
+- **Algorithm**: AES-256-GCM (Galois/Counter Mode)
+- **Key Size**: 256 bits
+- **IV Size**: 96 bits (12 bytes)
+- **Authentication**: Built-in with GCM mode
+
+### Encrypted Format
+
+Encrypted content is stored as JSON:
+
+```json
+{
+  "salt": "optional metadata (plaintext)",
+  "iv": "base64-encoded initialization vector",
+  "data": "base64-encoded encrypted content"
+}
+```
+
+### Security Considerations
+
+✅ **Secure:**
+- Uses industry-standard AES-256-GCM encryption
+- Keys are randomly generated using `crypto.getRandomValues()`
+- All operations use the Web Crypto API
+- Keys in URL fragments are never sent to servers
+- No server-side processing or storage
+
+⚠️ **Important:**
+- **The encryption key is not recoverable** - if you lose it, the data cannot be decrypted
+- URL fragments can appear in browser history
+- Anyone with the key can decrypt the content
+- For highly sensitive data, consider additional security measures
+
+## Workflow Example
+
+1. **Create encrypted content:**
+   ```
+   Visit: https://austegard.com/web-utilities/gist-encryption.html
+   Enter text: "My secret notes"
+   Click: Encrypt
+   Copy: Key and encrypted JSON
+   ```
+
+2. **Create a GitHub Gist:**
+   ```
+   Visit: https://gist.github.com
+   Create new gist: paste encrypted JSON
+   Note the gist ID: a1902d995b5c6157a9eaf69afa355723
+   ```
+
+3. **Share securely:**
+   ```
+   Share URL: https://austegard.com/pv.html?a1902d995b5c6157a9eaf69afa355723#key=Abc123...
+
+   The recipient clicks the link and sees the decrypted content automatically!
+   ```
+
+## Inspiration
+
+This tool was inspired by [agentexport](https://github.com/nicosuave/agentexport), which uses similar encryption techniques for sharing AI agent conversations.
+
+## Privacy
+
+- **All encryption/decryption happens in your browser**
+- No data is sent to austegard.com servers
+- No analytics or tracking
+- Open source - inspect the code yourself
+
+## Browser Support
+
+Requires a modern browser with Web Crypto API support:
+- Chrome 37+
+- Firefox 34+
+- Safari 11+
+- Edge 12+
+
+## License
+
+Part of the oaustegard.github.io project. See repository for license details.


### PR DESCRIPTION
- Create new web-utilities/gist-encryption.html tool for encrypting/decrypting text
  - Uses AES-256-GCM encryption via Web Crypto API
  - Supports optional salt metadata
  - Provides client-side API via postMessage (similar to claude-pruner)
  - Includes light/dark/auto theme support

- Add decryption support to pv.html gist viewer
  - Detects encrypted content (JSON with iv/data fields)
  - Extracts decryption key from URL hash (#key=...)
  - Automatically decrypts content when key is provided
  - Shows helpful error when content is encrypted but no key provided

- Add comprehensive README documentation
  - Usage instructions for encryption and decryption
  - Client-side API examples
  - Security considerations and technical details
  - Workflow examples

Inspired by https://github.com/nicosuave/agentexport encryption pattern.
All encryption/decryption happens client-side - no data sent to servers.