### PR TITLE
chore: add main push trigger for Update Code Maps and document it

### DIFF
--- a/.github/workflows/update-codemaps.yml
+++ b/.github/workflows/update-codemaps.yml
@@ -2,6 +2,9 @@ name: Update Code Maps
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,11 @@ This repository uses **code maps** (`_MAP.md` files) to provide navigable overvi
 
 **IMPORTANT**: When you modify code that affects exports or imports, you MUST regenerate the maps.
 
+#### GitHub Action: Update Code Maps
+
+- Trigger the "Update Code Maps" workflow from the Actions tab to regenerate maps and auto-commit updates.
+- The workflow also runs automatically on pushes to `main`.
+
 #### When to regenerate:
 - ✅ After adding/removing exported functions, classes, or variables
 - ✅ After adding/removing import statements


### PR DESCRIPTION
### Motivation
- Ensure code map regeneration runs automatically when changes reach the `main` branch to keep `_MAP.md` files up to date.
- Make it explicit in docs how to trigger the map regeneration and that the action auto-runs on `main` pushes.

### Description
- Add a `push` trigger for the `main` branch to `.github/workflows/update-codemaps.yml` so the `Update Code Maps` workflow runs on pushes to `main`.
- Add a `GitHub Action: Update Code Maps` section to `AGENTS.md` documenting how to trigger the workflow from the Actions tab and noting it also runs automatically on `main` pushes.
- The workflow continues to generate code maps and auto-commit changed `*_MAP.md` files when differences are found.

### Testing
- No automated tests were run because this change only updates a GitHub Actions workflow and documentation.
- Repository changes were committed locally and prepared for a PR; no CI test executions were performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963fc7f61548324817f1df0033e5822)