### PR TITLE
Document Update Code Maps GitHub Actions workflow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,11 @@ python .claude/skills/mapping-codebases/scripts/codemap.py .
 git add '*/_MAP.md'
 ```
 
-**Best practice**: Regenerate maps just before committing code changes that affect module interfaces.
+#### Update Code Maps workflow (GitHub Actions)
+
+You can run the **Update Code Maps** workflow from GitHub Actions. It lives in `.github/workflows/update-code-maps.yml` and currently runs via `workflow_dispatch` (manual).
+
+**Best practice**: Regenerate maps just before committing code changes that affect module interfaces. You can also use the Update Code Maps workflow after changes that alter imports/exports, in addition to the local `codemap.py` command.
 
 ## Dev Environment Tips
 


### PR DESCRIPTION
### Motivation

- Make it explicit how to run the repository's code-map regeneration using GitHub Actions from the existing developer guidance. 
- Call out the workflow filename and that it uses a manual trigger so contributors know how to invoke it. 
- Ensure contributors know the Actions workflow is an alternative to the local regeneration command when imports/exports change. 

### Description

- Added an `Update Code Maps workflow (GitHub Actions)` subsection to `AGENTS.md` under the "Maintaining Code Maps" section. 
- Documented the workflow path as `.github/workflows/update-code-maps.yml` and noted it currently runs via `workflow_dispatch` (manual). 
- Expanded the best-practice guidance to mention using the Update Code Maps workflow in addition to the local `python .claude/skills/mapping-codebases/scripts/codemap.py .` command after changes that alter imports/exports. 
- Modified file: `AGENTS.md`.

### Testing

- No automated tests were run because this is a documentation-only change. 
- No build or runtime verification was required for the edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963fe8ed2108324b55f88ba42a2895c)