### PR TITLE
Add reverse thread traversal for BlueSky posts

### DIFF
--- a/bsky/processor.html
+++ b/bsky/processor.html
@@ -338,7 +338,7 @@
             </div>
 
             <div id="post-tab" class="tab-content active">
-                <p>Given the URL of a post will extract the responses or (max 100) quote posts to the original post from the public Bluesky API.<br>
+                <p>Given the URL of a post will extract the responses, (max 100) quote posts, or trace the conversation back to its root.<br>
                     Data is deidentified and reduced, then made available in JSON for further analysis.
                     <small>(<a href="https://github.com/oaustegard/oaustegard.github.io/blob/main/bsky/processor.html" target="_blank">Code</a> | <a href="https://github.com/oaustegard/oaustegard.github.io/blob/main/bsky/processor_README.md" target="_blank">README</a>)</small>
                 </p>
@@ -400,6 +400,7 @@
                     <div class="input-group" style="gap: 0.5rem;">
                         <button type="submit" id="process-replies">Process Replies</button>
                         <button type="submit" id="process-quotes">Process Quotes</button>
+                        <button type="submit" id="process-reverse">Trace to Root</button>
                     </div>
                 </form>
             </div>
@@ -536,6 +537,7 @@
               const quoteFilters = document.getElementById('quote-filters');
               const processRepliesBtn = document.getElementById('process-replies');
               const processQuotesBtn = document.getElementById('process-quotes');
+              const processReverseBtn = document.getElementById('process-reverse');
 
               /* Show appropriate filter group when hovering over buttons */
               processRepliesBtn.addEventListener('mouseenter', () => {
@@ -546,6 +548,11 @@
               processQuotesBtn.addEventListener('mouseenter', () => {
                 replyFilters.style.display = 'none';
                 quoteFilters.style.display = 'block';
+              });
+
+              processReverseBtn.addEventListener('mouseenter', () => {
+                replyFilters.style.display = 'none';
+                quoteFilters.style.display = 'none';
               });
 
               /* Show UI regardless of partial initialization */


### PR DESCRIPTION
Adds a "Trace to Root" feature that traverses from a leaf post up to
the root of the conversation, presenting posts in chronological order.
This allows users to see the full context of a conversation branch
leading to any specific reply.

https://claude.ai/code/session_016DNuqs2DmJA8bG4i4WqjP1