### PR TITLE
Add landing page and demo mode to Claude Pruner

### DIFF
--- a/ai-tools/claude-pruner.html
+++ b/ai-tools/claude-pruner.html
@@ -233,6 +233,149 @@
             color: #666;
             margin: 10px 0;
         }
+
+        /* Landing page styles */
+        .landing {
+            max-width: 720px;
+            margin: 0 auto;
+            padding: 60px 20px;
+            text-align: center;
+            color: #333;
+        }
+
+        .landing h1 {
+            font-size: 2em;
+            margin-bottom: 0.25em;
+            color: #1a1a1a;
+        }
+
+        .landing .subtitle {
+            font-size: 1.1em;
+            color: #666;
+            margin-bottom: 2em;
+        }
+
+        .landing .features {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 16px;
+            text-align: left;
+            margin: 2em 0;
+        }
+
+        .landing .feature {
+            padding: 16px;
+            background: #f8f9fa;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+        }
+
+        .landing .feature strong {
+            display: block;
+            margin-bottom: 4px;
+            color: #1a1a1a;
+        }
+
+        .landing .feature span {
+            font-size: 0.9em;
+            color: #666;
+        }
+
+        .landing .actions {
+            margin: 2.5em 0;
+            display: flex;
+            gap: 12px;
+            justify-content: center;
+            flex-wrap: wrap;
+        }
+
+        .landing .btn {
+            display: inline-block;
+            padding: 12px 24px;
+            border-radius: 6px;
+            text-decoration: none;
+            font-weight: 600;
+            font-size: 1em;
+            transition: background 0.15s, transform 0.1s;
+        }
+
+        .landing .btn:active {
+            transform: scale(0.97);
+        }
+
+        .landing .btn-primary {
+            background: #7B1FA2;
+            color: white;
+            cursor: pointer;
+            border: none;
+        }
+
+        .landing .btn-primary:hover {
+            background: #6A1B9A;
+        }
+
+        .landing .btn-secondary {
+            background: white;
+            color: #333;
+            border: 1px solid #ccc;
+        }
+
+        .landing .btn-secondary:hover {
+            background: #f5f5f5;
+        }
+
+        .landing .privacy {
+            display: inline-block;
+            margin-top: 1em;
+            padding: 10px 20px;
+            background: #e8f5e9;
+            border-radius: 6px;
+            font-size: 0.9em;
+            color: #2e7d32;
+            font-weight: 500;
+        }
+
+        .landing .how-it-works {
+            margin-top: 2.5em;
+            text-align: left;
+        }
+
+        .landing .how-it-works h2 {
+            font-size: 1.2em;
+            margin-bottom: 0.75em;
+        }
+
+        .landing .how-it-works ol {
+            padding-left: 1.5em;
+            line-height: 1.8;
+            color: #555;
+        }
+
+        .landing .how-it-works a {
+            color: #7B1FA2;
+        }
+
+        .landing footer {
+            margin-top: 3em;
+            font-size: 0.85em;
+            color: #999;
+        }
+
+        .landing footer a {
+            color: #7B1FA2;
+        }
+
+        .loading-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(255,255,255,0.85);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 1000;
+            font-size: 1.2em;
+            color: #7B1FA2;
+        }
     </style>
     <script>
         /* Utility functions */
@@ -879,14 +1022,88 @@
             }
         }
 
+        function loadDemo() {
+            const overlay = document.createElement('div');
+            overlay.className = 'loading-overlay';
+            overlay.textContent = 'Loading demo conversation\u2026';
+            document.body.appendChild(overlay);
+
+            fetch('claude-pruner-demo.json')
+                .then(response => {
+                    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                    return response.json();
+                })
+                .then(data => {
+                    info('Demo data loaded successfully');
+                    document.body.innerHTML = '';
+                    setupInterface(data);
+                })
+                .catch(err => {
+                    error(`Failed to load demo: ${err.message}`);
+                    overlay.textContent = 'Failed to load demo data.';
+                    setTimeout(() => overlay.remove(), 3000);
+                });
+        }
+
+        // Check for ?demo query parameter on load
+        document.addEventListener('DOMContentLoaded', () => {
+            const params = new URLSearchParams(window.location.search);
+            if (params.has('demo')) {
+                info('Demo mode triggered via query parameter');
+                loadDemo();
+            }
+        });
+
         // Log initial message
         info('Claude Pruner initialized, waiting for data...');
     </script>
 </head>
 <body>
-    <h1>Waiting for Claude.ai conversation data...</h1>
-    <p>See the <a href="https://github.com/oaustegard/bookmarklets/blob/main/claude_pruner_README.md">README</a> for how this works, 
-        or <a href="https://github.com/oaustegard/oaustegard.github.io/edit/main/claude-pruner.html">view the code</a>.</p>
-    <p><b>All processing happens locally in your browser, no data is sent to any servers.</b></p>
+    <div class="landing">
+        <h1>Claude Pruner</h1>
+        <p class="subtitle">Selectively prune and export Claude.ai conversations &mdash; messages, artifacts, tool usage, and thinking steps.</p>
+
+        <div class="features">
+            <div class="feature">
+                <strong>Granular Selection</strong>
+                <span>Toggle individual messages, tool calls, and thinking blocks on or off.</span>
+            </div>
+            <div class="feature">
+                <strong>Bulk Controls</strong>
+                <span>Quickly toggle all human, assistant, tool, or thinking content at once.</span>
+            </div>
+            <div class="feature">
+                <strong>Copy &amp; Download</strong>
+                <span>Export your pruned conversation as structured text to clipboard or file.</span>
+            </div>
+            <div class="feature">
+                <strong>Token Estimates</strong>
+                <span>Live word count and estimated token usage as you select content.</span>
+            </div>
+        </div>
+
+        <div class="actions">
+            <button class="btn btn-primary" onclick="loadDemo()">Try the Demo</button>
+            <a class="btn btn-secondary" href="https://github.com/oaustegard/bookmarklets/blob/main/claude_pruner_README.md">Get the Bookmarklet</a>
+        </div>
+
+        <div class="privacy">All processing happens locally in your browser &mdash; no data is sent to any server.</div>
+
+        <div class="how-it-works">
+            <h2>How It Works</h2>
+            <ol>
+                <li>Install the <a href="https://github.com/oaustegard/bookmarklets/blob/main/claude_pruner_README.md">companion bookmarklet</a> in your browser.</li>
+                <li>Open any conversation on <strong>claude.ai</strong> and click the bookmarklet.</li>
+                <li>This page opens with your conversation broken into its components.</li>
+                <li>Click items to deselect them, use bulk toggles, then copy or download the result.</li>
+            </ol>
+        </div>
+
+        <footer>
+            Created by <a href="https://github.com/oaustegard">Oskar Austegard</a>
+            &middot; <a href="https://github.com/oaustegard/oaustegard.github.io/blob/main/ai-tools/claude-pruner.html">Source</a>
+            &middot; <a href="claude-pruner_README.md">README</a>
+        </footer>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
This PR adds a professional landing page to Claude Pruner and introduces a demo mode that allows users to try the tool without needing to install the bookmarklet first.

## Key Changes
- **Landing page UI**: Replaced the minimal "waiting for data" message with a full-featured landing page that includes:
  - Clear value proposition and feature highlights
  - Call-to-action buttons for demo and bookmarklet installation
  - "How It Works" section with step-by-step instructions
  - Privacy assurance messaging
  - Footer with links to source code and documentation

- **Demo mode functionality**: 
  - Added `loadDemo()` function that fetches `claude-pruner-demo.json` and initializes the interface with sample data
  - Implemented query parameter detection (`?demo`) to automatically trigger demo mode on page load
  - Added loading overlay with visual feedback during demo data fetch
  - Includes error handling with user-friendly messages

- **Comprehensive styling**: Added extensive CSS for the landing page including:
  - Responsive grid layout for feature cards
  - Styled buttons with hover and active states
  - Privacy badge with green accent
  - Professional typography and spacing
  - Loading overlay styling

## Implementation Details
- The landing page uses a centered, max-width layout (720px) for optimal readability
- Demo mode is non-intrusive—users can still access the tool via the bookmarklet as before
- The loading overlay provides clear feedback during demo data loading
- All existing functionality remains unchanged; the landing page is purely additive

https://claude.ai/code/session_01GhV8zuZRCx2jqb8BNQvtTR