### PR TITLE
Optimize branch preview: skip Jekyll, deploy source directly to Cloudflare

### DIFF
--- a/.github/workflows/branch-preview.yml
+++ b/.github/workflows/branch-preview.yml
@@ -1,4 +1,6 @@
-# Build and deploy preview sites for non-main branches
+# Deploy source files directly to a single Cloudflare Pages preview branch.
+# Skips Jekyll build entirely - the site is pure HTML/JS/CSS with no real templating.
+# Only 404.html has Jekyll front matter (stripped inline); everything else deploys as-is.
 name: Branch Preview
 
 on:
@@ -9,56 +11,59 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
-# Cancel in-progress runs for the same branch
+# Single group: we deploy to one fixed 'preview' branch, so concurrent runs would overwrite each other
 concurrency:
-  group: preview-${{ github.ref }}
+  group: cloudflare-preview
   cancel-in-progress: true
 
 jobs:
-  build-preview:
+  deploy-preview:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-          bundler-cache: true
-
-      - name: Cache Jekyll
-        uses: actions/cache@v4
-        with:
-          path: |
-            .jekyll-cache
-            _site
-          key: ${{ runner.os }}-jekyll-preview-${{ hashFiles('**/*.md', '**/*.html', '_config.yml') }}
-
-      - name: Get branch name
-        id: branch
+      - name: Prepare deploy directory
         run: |
-          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-          echo "name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          mkdir -p /tmp/cloudflare-deploy
+          rsync -a \
+            --exclude='.git/' \
+            --exclude='.github/' \
+            --exclude='.claude/' \
+            --exclude='Gemfile' \
+            --exclude='Gemfile.lock' \
+            --exclude='_config.yml' \
+            --exclude='_MAP.md' \
+            --exclude='_site/' \
+            --exclude='package.json' \
+            --exclude='package-lock.json' \
+            --exclude='playwright.config.js' \
+            --exclude='tests/' \
+            --exclude='AGENTS.md' \
+            --exclude='CLAUDE.md' \
+            --exclude='README.md' \
+            --exclude='LICENSE' \
+            ./ /tmp/cloudflare-deploy/
+          # Strip Jekyll front matter from 404.html (only HTML file that has it)
+          python3 -c "
+          import re
+          with open('/tmp/cloudflare-deploy/404.html', 'r') as f:
+              content = f.read()
+          content = re.sub(r'^---\n.*?\n---\n', '', content, flags=re.DOTALL)
+          with open('/tmp/cloudflare-deploy/404.html', 'w') as f:
+              f.write(content)
+          "
 
-      - name: Build with Jekyll
-        run: bundle exec jekyll build --baseurl ""
-        env:
-          JEKYLL_ENV: preview
-          PAGES_REPO_NWO: ${{ github.repository }}
-          JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
       - name: Deploy to Cloudflare Pages
         id: deploy
         run: |
           set +e
-          OUTPUT=$(npx wrangler pages deploy ./_site \
+          OUTPUT=$(npx wrangler pages deploy /tmp/cloudflare-deploy \
             --project-name austegard \
-            --branch "${{ steps.branch.outputs.name }}" \
+            --branch preview \
             2>&1)
           EXIT_CODE=$?
           echo "$OUTPUT"
@@ -72,55 +77,11 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      - name: Comment on PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const previewUrl = '${{ steps.deploy.outputs.url }}';
-            const branchName = '${{ steps.branch.outputs.name }}';
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('<!-- branch-preview -->')
-            );
-
-            const body = `<!-- branch-preview -->
-            ## 🔍 Preview Deployment
-
-            | Branch | Preview URL | Status |
-            |--------|-------------|--------|
-            | \`${branchName}\` | ${previewUrl} | ✅ Ready |
-
-            > Preview updates automatically on each push to this branch.
-            `;
-
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-            }
-
-      - name: Output preview URL
+      - name: Summary
         run: |
-          echo "## 🔍 Preview Deployed!" >> $GITHUB_STEP_SUMMARY
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          echo "## Preview Deployed!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`${{ steps.branch.outputs.name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Source branch:** \`${BRANCH}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Preview URL:** ${{ steps.deploy.outputs.url }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Remove Ruby/Jekyll setup and build steps (~90s savings per run)
- Use rsync to prepare a clean deploy directory, excluding dev/config files
- Strip Jekyll front matter from 404.html inline (it's the only HTML file that has it)
- Deploy to a single fixed 'preview' branch instead of per-branch deployments
- Change concurrency group to single 'cloudflare-preview' (one target branch)
- Remove PR comment step (solo dev, workflow summary is sufficient)
- Wrangler's content-hash-based incremental uploads remain in effect

https://claude.ai/code/session_01MoTdNxAVGvpiGkFsWfJauX