### PR TITLE
🧹 Remove debug logging in 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,7 +17,6 @@ permalink: /404.html
     
     <script>
         document.addEventListener("DOMContentLoaded", function() {
-            console.log('404 page loaded, searching for redirect...');
             
             fetch('/sitemap.xml')
                 .then(response => {
@@ -27,7 +26,6 @@ permalink: /404.html
                     return response.text();
                 })
                 .then(xmlText => {
-                    console.log('Sitemap fetched successfully');
                     
                     /* Parse the XML */
                     const parser = new DOMParser();
@@ -48,17 +46,14 @@ permalink: /404.html
                         }
                     }
                     
-                    console.log('Found', fileList.length, 'pages in sitemap');
                     
                     const path = window.location.pathname;
                     const params = window.location.search;
                     const filename = path.split('/').pop();
                     
-                    console.log('Looking for:', { path, filename, params });
 
                     if (filename) {
                         const matches = fileList.filter(file => file.endsWith('/' + filename));
-                        console.log('Found matches:', matches);
                         
                         if (matches.length > 0) {
                             const newPath = matches[0];
@@ -66,7 +61,6 @@ permalink: /404.html
                             if (message) {
                                 message.innerHTML = `We found it! You are being redirected to <a href="${newPath}${params}">${newPath}</a>...`;
                             }
-                            console.log('Redirecting to:', newPath + params);
                             setTimeout(() => {
                                 window.location.href = `${newPath}${params}`;
                             }, 3000);
@@ -85,7 +79,6 @@ permalink: /404.html
                 });
 
             function showNotFoundMessage(filename, fullPath) {
-                console.log('No matches found, showing not found message');
                 
                 const message = document.getElementById('message');
                 if (!message) return;


### PR DESCRIPTION
🎯 **What:** Removed debug `console.log` statements from `404.html`.
💡 **Why:** Improves code readability and codebase health. The logs were used for testing development features (redirect searching from sitemap), and are safe to delete in production as they were self-contained. `console.error` and `console.warn` have been correctly kept for critical runtime observability.
✅ **Verification:** Playwright tests run locally and verified manual behavior is completely identical and there is no breakage of existing functionality. 
✨ **Result:** Cleaned up `404.html` from unneeded debug logging statements.

---
*PR created automatically by Jules for task [1818634603716903945](https://jules.google.com/task/1818634603716903945) started by @oaustegard*