### PR TITLE
🧹 [Code Health] Remove debug logging in BlueReport.js

### DIFF
--- a/bsky/BlueReport.js
+++ b/bsky/BlueReport.js
@@ -124,7 +124,6 @@ class BlueReportStore {
                 console.error('Failed to fetch posts or invalid response format');
                 return;
             }
-            console.log(`Fetched ${posts.length} posts`);
 
             const events = await this.processEvents(posts);
             if (!Array.isArray(events) || events.length === 0) {


### PR DESCRIPTION
🎯 **What:** Removed a debug log statement (`console.log(\`Fetched ${posts.length} posts\`);`) around line 127 in `bsky/BlueReport.js`.
💡 **Why:** To improve code health and maintainability by cleaning up unnecessary console output.
✅ **Verification:** Verified that the specific log statement was removed correctly using `sed` and `cat`. Ran `npx playwright test` to ensure no related functionality broke. Reverted unintended `package.json` and `package-lock.json` changes.
✨ **Result:** The codebase is cleaner and free of the specified debug log.

---
*PR created automatically by Jules for task [1389497425840784146](https://jules.google.com/task/1389497425840784146) started by @oaustegard*