### PR TITLE
🧹 Remove debug logging from 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,7 +17,6 @@ permalink: /404.html
     
     <script>
         document.addEventListener("DOMContentLoaded", function() {
-            console.log('404 page loaded, searching for redirect...');
             
             fetch('/sitemap.xml')
                 .then(response => {
@@ -27,7 +26,6 @@ permalink: /404.html
                     return response.text();
                 })
                 .then(xmlText => {
-                    console.log('Sitemap fetched successfully');
                     
                     /* Parse the XML */
                     const parser = new DOMParser();
@@ -48,17 +46,14 @@ permalink: /404.html
                         }
                     }
                     
-                    console.log('Found', fileList.length, 'pages in sitemap');
                     
                     const path = window.location.pathname;
                     const params = window.location.search;
                     const filename = path.split('/').pop();
                     
-                    console.log('Looking for:', { path, filename, params });
 
                     if (filename) {
                         const matches = fileList.filter(file => file.endsWith('/' + filename));
-                        console.log('Found matches:', matches);
                         
                         if (matches.length > 0) {
                             const newPath = matches[0];
@@ -66,7 +61,6 @@ permalink: /404.html
                             if (message) {
                                 message.innerHTML = `We found it! You are being redirected to <a href="${newPath}${params}">${newPath}</a>...`;
                             }
-                            console.log('Redirecting to:', newPath + params);
                             setTimeout(() => {
                                 window.location.href = `${newPath}${params}`;
                             }, 3000);
@@ -85,7 +79,6 @@ permalink: /404.html
                 });
 
             function showNotFoundMessage(filename, fullPath) {
-                console.log('No matches found, showing not found message');
                 
                 const message = document.getElementById('message');
                 if (!message) return;


### PR DESCRIPTION
🎯 **What:** Removed multiple debug `console.log` statements from `404.html`.
💡 **Why:** To improve code health, readability, and maintainability by cleaning up unnecessary debug output in a production-facing file, adhering to the repository pattern of removing `console.log` while preserving `console.error` and `console.warn`.
✅ **Verification:** Visually verified removal via `git diff` and `grep`. Ran a headless Chromium Playwright script intercepting console messages to confirm no `console.log` messages were printed on page load, while the expected 404 errors successfully emitted `console.error`. Full existing Playwright test suite passed.
✨ **Result:** A cleaner `404.html` with removed debug logs.

---
*PR created automatically by Jules for task [4246157943455701904](https://jules.google.com/task/4246157943455701904) started by @oaustegard*