### PR TITLE
🧹 Remove debug log from BlueReport.js

### DIFF
--- a/bsky/BlueReport.js
+++ b/bsky/BlueReport.js
@@ -131,7 +131,6 @@ class BlueReportStore {
                 console.log('No new events to process');
                 return;
             }
-            console.log(`Processed into ${events.length} events`);
 
             await this.storeEvents(events);
             await this.aggregateData();


### PR DESCRIPTION
🎯 **What:** Removed the self-contained `console.log` statement (`Processed into ${events.length} events`) from `bsky/BlueReport.js:134`.
💡 **Why:** The log statement was only used for debugging and was safe to remove. Removing it improves the cleanliness and maintainability of the codebase without changing the application's behavior.
✅ **Verification:** Verified that the removal of the specific log statement was precise and did not introduce functional regressions. `npm test` passed successfully.
✨ **Result:** Improved code health by removing unnecessary debug logging.

---
*PR created automatically by Jules for task [3762667521691094496](https://jules.google.com/task/3762667521691094496) started by @oaustegard*