### PR TITLE
Fix quote posts overlapping reply grid and center grid under seed card

### DIFF
--- a/bsky/post-constellation.html
+++ b/bsky/post-constellation.html
@@ -482,9 +482,9 @@
         // Grid children's subtrees are suppressed — user can expand them individually
         const gi = gridInfo.get(uri);
         if (gi) {
-          const parentW = stw.get(uri);
           const gridW = gi.cols * CARD_W + (gi.cols - 1) * H_GAP;
-          const startX = x + parentW / 2 - gridW / 2;
+          // Center the grid under the parent CARD, not the subtree
+          const startX = x + CARD_W / 2 - gridW / 2;
           const startY = y + CARD_H + V_GAP;
           for (let i = 0; i < ch.length; i++) {
             const col = i % gi.cols;
@@ -523,7 +523,14 @@
         pos.set(quotedChain[i], { x: -(i + 1) * QUOTE_X_OFF, y: -(i + 1) * QUOTE_Y_STEP });
       }
 
-      // Quote posts (lower-right, sorted chronologically, grid if many)
+      // Quote posts (lower-right of the entire reply tree, sorted chronologically)
+      // Find the rightmost edge of all positioned nodes so quotes don't overlap replies
+      let replyMaxX = 0;
+      for (const p of pos.values()) {
+        if (p.x + CARD_W > replyMaxX) replyMaxX = p.x + CARD_W;
+      }
+      const qpStartX = replyMaxX + 56; // gap between reply tree and quote column
+
       const qpList = [];
       for (const edge of edges) {
         if (edge.type === 'quote' && edge.to === seedUri && nodes.get(edge.from)?.type === 'quote-post')
@@ -541,13 +548,13 @@
           const col = i % qCols;
           const row = Math.floor(i / qCols);
           pos.set(qpList[i], {
-            x: QUOTE_X_OFF + col * (CARD_W + H_GAP),
+            x: qpStartX + col * (CARD_W + H_GAP),
             y: (row + 1) * (CARD_H + V_GAP),
           });
         }
       } else {
         for (let i = 0; i < qpList.length; i++) {
-          pos.set(qpList[i], { x: QUOTE_X_OFF, y: (i + 1) * (CARD_H + V_GAP) });
+          pos.set(qpList[i], { x: qpStartX, y: (i + 1) * (CARD_H + V_GAP) });
         }
       }
 


### PR DESCRIPTION
Two positioning bugs fixed:
- Quote posts now placed to the right of the entire reply tree extent instead of at a fixed offset from the seed (which landed inside the grid)
- Grid children centered under the parent CARD (using CARD_W) instead of the parent subtree width, so the seed card sits visually centered above its reply grid

https://claude.ai/code/session_012kjUkPbY18XruGU4eyrkxk