### PR TITLE
Restore full tree layout with adaptive compaction, remove grid

### DIFF
--- a/bsky/post-constellation.html
+++ b/bsky/post-constellation.html
@@ -191,10 +191,9 @@
     const LAYOUT_PAD = 100;
     const VIRT_BUFFER = 300; // px margin around viewport for virtualization
     const VIRT_THROTTLE = 80; // ms between viewRect updates during pan/zoom
-    const GRID_THRESHOLD = 8; // children above this count get grid layout
-    const GRID_COLS = 8; // max columns in grid layout
     const CLUSTER_ZOOM = 0.35; // below this zoom, render dots instead of full cards
     const QUOTE_BATCH = 25; // initial quote posts to show
+    const AUTO_COLLAPSE_CHILDREN = 20; // auto-collapse nodes with more direct children than this
     const API = 'https://public.api.bsky.app/xrpc/';
 
     // ── URL / API helpers ───────────────────────────────────────────────────────
@@ -435,41 +434,30 @@
       }
 
       // Subtree widths (bottom-up), respecting collapsed branches
-      // When a node has many children (>GRID_THRESHOLD), use grid layout:
-      //   children arranged in rows of GRID_COLS, which dramatically reduces canvas width
+      // Uses adaptive gap: when a node has many children, the gap between
+      // siblings shrinks so the tree stays compact while retaining its shape.
       const stw = new Map();
-      const gridInfo = new Map(); // uri -> { cols, rows } for grid-layout nodes
+      function siblingGap(count) {
+        // Smooth reduction: full gap for ≤4, down to 4px for very wide nodes
+        if (count <= 4) return H_GAP;
+        return Math.max(4, Math.round(H_GAP * 4 / count));
+      }
       function computeWidths(uri) {
         const node = nodes.get(uri);
         const ch = collapsedBranches.has(uri)
           ? []
           : (node?.children || []).filter(c => nodes.has(c));
         if (ch.length === 0) { stw.set(uri, CARD_W); return CARD_W; }
-
-        // For many children, use grid layout
-        if (ch.length > GRID_THRESHOLD) {
-          // In grid mode, each child gets a single-column slot (no subtree expansion)
-          const cols = Math.min(ch.length, GRID_COLS);
-          const rows = Math.ceil(ch.length / cols);
-          gridInfo.set(uri, { cols, rows });
-          // Still compute child widths (for their own subtrees if expanded later)
-          for (const c of ch) computeWidths(c);
-          const w = cols * CARD_W + (cols - 1) * H_GAP;
-          stw.set(uri, Math.max(CARD_W, w));
-          return stw.get(uri);
-        }
-
-        // Normal tree layout for reasonable child counts
         let total = 0;
         for (const c of ch) total += computeWidths(c);
-        total += (ch.length - 1) * H_GAP;
+        total += (ch.length - 1) * siblingGap(ch.length);
         const w = Math.max(CARD_W, total);
         stw.set(uri, w);
         return w;
       }
       computeWidths(seedUri);
 
-      // Assign reply positions (top-down), respecting collapsed branches and grid layout
+      // Assign reply positions (top-down), respecting collapsed branches
       function assignPos(uri, x, y) {
         pos.set(uri, { x, y });
         const node = nodes.get(uri);
@@ -477,35 +465,14 @@
           ? []
           : (node?.children || []).filter(c => nodes.has(c));
         if (ch.length === 0) return;
-
-        // Grid layout: arrange children in rows×cols grid
-        // Grid children's subtrees are suppressed — user can expand them individually
-        const gi = gridInfo.get(uri);
-        if (gi) {
-          const gridW = gi.cols * CARD_W + (gi.cols - 1) * H_GAP;
-          // Center the grid under the parent CARD, not the subtree
-          const startX = x + CARD_W / 2 - gridW / 2;
-          const startY = y + CARD_H + V_GAP;
-          for (let i = 0; i < ch.length; i++) {
-            const col = i % gi.cols;
-            const row = Math.floor(i / gi.cols);
-            pos.set(ch[i], {
-              x: startX + col * (CARD_W + H_GAP),
-              y: startY + row * (CARD_H + V_GAP),
-            });
-            // Don't recurse — grid children's subtrees stay collapsed in grid mode
-          }
-          return;
-        }
-
-        // Normal tree layout
-        const totalW = ch.reduce((s, c) => s + stw.get(c), 0) + (ch.length - 1) * H_GAP;
+        const gap = siblingGap(ch.length);
+        const totalW = ch.reduce((s, c) => s + stw.get(c), 0) + (ch.length - 1) * gap;
         let sx = x + CARD_W / 2 - totalW / 2;
         const cy = y + CARD_H + V_GAP;
         for (const c of ch) {
           const cw = stw.get(c);
           assignPos(c, sx + (cw - CARD_W) / 2, cy);
-          sx += cw + H_GAP;
+          sx += cw + gap;
         }
       }
       assignPos(seedUri, 0, 0);
@@ -541,21 +508,8 @@
         const tB = new Date(nodes.get(b)?.post?.record?.createdAt || 0);
         return tA - tB;
       });
-      if (qpList.length > GRID_THRESHOLD) {
-        // Grid layout for quote posts
-        const qCols = Math.min(qpList.length, 4);
-        for (let i = 0; i < qpList.length; i++) {
-          const col = i % qCols;
-          const row = Math.floor(i / qCols);
-          pos.set(qpList[i], {
-            x: qpStartX + col * (CARD_W + H_GAP),
-            y: (row + 1) * (CARD_H + V_GAP),
-          });
-        }
-      } else {
-        for (let i = 0; i < qpList.length; i++) {
-          pos.set(qpList[i], { x: qpStartX, y: (i + 1) * (CARD_H + V_GAP) });
-        }
+      for (let i = 0; i < qpList.length; i++) {
+        pos.set(qpList[i], { x: qpStartX, y: (i + 1) * (CARD_H + V_GAP) });
       }
 
       // Normalize positions
@@ -1003,11 +957,15 @@
           const g = buildGraph(atUri, down, up, qpResult.posts);
           setGraph(g);
 
-          // Auto-collapse seed's children if extremely wide (>40 direct replies)
-          const seedNode = g.nodes.get(atUri);
-          if (seedNode && seedNode.children.length > 40) {
-            setCollapsedBranches(new Set([atUri]));
+          // Auto-collapse any node with many direct children to keep initial view navigable.
+          // The user can expand them individually via the ▶ toggle.
+          const autoCollapsed = new Set();
+          for (const [uri, node] of g.nodes) {
+            if (node.children.length > AUTO_COLLAPSE_CHILDREN) {
+              autoCollapsed.add(uri);
+            }
           }
+          if (autoCollapsed.size > 0) setCollapsedBranches(autoCollapsed);
         } catch (e) { setError(e.message); }
         finally { setLoading(false); }
       }

--- a/bsky/post-constellation_README.md
+++ b/bsky/post-constellation_README.md
@@ -31,7 +31,8 @@ Each post is rendered as a card with avatar, author info, text preview, and enga
 - **Compact cards** with 2-line text preview; expand on click for full content and embeds
 - **SVG connection lines**: Solid blue for thread relationships, dashed orange with arrows for quotes
 - **Viewport virtualization**: Only cards and edges visible on screen (plus a 300px buffer) are rendered to the DOM, enabling smooth performance on large graphs
-- **Grid layout for wide nodes**: When a post has more than 8 direct replies, children are arranged in a compact grid (8 columns) instead of a single horizontal row, dramatically reducing canvas width (e.g., 94 replies: 2,400px vs 36,800px)
+- **Adaptive compaction**: When a node has many siblings, horizontal gaps shrink proportionally, keeping the tree shape while limiting spread
+- **Auto-collapse**: Nodes with more than 20 direct children start collapsed; click ▶ to expand and explore
 - **Zoom-aware rendering**: At low zoom levels (<0.35), cards are replaced with lightweight colored rectangles for fast rendering; zoom in to see full card content
 - **Branch collapse/expand**: Click the toggle on any reply node to collapse its subtree; shows descendant count so you know what's hidden
 - **Quote pagination**: Initial load fetches 25 quote posts; click "more quotes" in the toolbar to load additional batches
@@ -55,9 +56,9 @@ The layout uses a two-pass tree algorithm:
 1. **Bottom-up**: Compute subtree widths for each node in the reply tree
 2. **Top-down**: Assign x/y positions, centering children under their parent
 
-When a node has more than 8 children, the layout switches to **grid mode**: children are arranged in rows of up to 8 columns. Grid children's subtrees are suppressed in the grid view — use Re-seed to explore deeper threads.
+When a node has many siblings, horizontal gaps between them shrink adaptively (full 28px gap for ≤4 siblings, down to 4px for very wide groups), keeping the tree shape visible while limiting horizontal spread. Nodes with more than 20 direct children start collapsed to keep the initial view navigable.
 
-Ancestors are placed in a single column above the seed. Quoted posts step diagonally to the upper-left. Quote posts are arranged in a grid (up to 4 columns) to the lower-right.
+Ancestors are placed in a single column above the seed. Quoted posts step diagonally to the upper-left. Quote posts are arranged vertically to the lower-right, positioned past the rightmost edge of the reply tree.
 
 All positions are normalized so the minimum coordinate is padded from the canvas origin, ensuring no clipping.
 


### PR DESCRIPTION
The grid layout killed the constellation's visual richness — all the tree structure and time dimension was lost, children couldn't expand, and it looked like a spreadsheet.

Replaced with:
- Adaptive sibling gaps: shrink H_GAP proportionally when a node has many children (28px for ≤4, down to 4px for very many), keeping the tree shape while limiting horizontal spread
- Smarter auto-collapse: any node with >20 direct children starts collapsed (not just seed >40), user can expand via ▶ toggle
- Full subtree recursion restored: collapse/expand always works, no suppressed children

Keeps the good parts from previous commits: quote pagination, zoom-aware dot rendering, dynamic quote positioning to right of reply tree.

https://claude.ai/code/session_012kjUkPbY18XruGU4eyrkxk