### PR TITLE
Add Bluesky short URL redirect handler to 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,7 +17,20 @@ permalink: /404.html
     
     <script>
         document.addEventListener("DOMContentLoaded", function() {
-            
+
+            /* Check for short Bluesky URL: /bsky/{postid} -> redirect to bsky.app */
+            const bskyMatch = window.location.pathname.match(/^\/bsky\/([a-z2-7]{13})$/);
+            if (bskyMatch) {
+                const postId = bskyMatch[1];
+                const bskyUrl = `https://bsky.app/profile/austegard.com/post/${postId}`;
+                const message = document.getElementById('message');
+                if (message) {
+                    message.innerHTML = `<h1>Redirecting to Bluesky</h1><p>Taking you to <a href="${bskyUrl}">${bskyUrl}</a>...</p>`;
+                }
+                setTimeout(() => { window.location.href = bskyUrl; }, 1500);
+                return;
+            }
+
             fetch('/sitemap.xml')
                 .then(response => {
                     if (!response.ok) {


### PR DESCRIPTION
## Summary
Added functionality to the 404 error page to intercept and redirect short Bluesky URLs to their full destinations on bsky.app.

## Key Changes
- Implemented pattern matching for short Bluesky URLs in the format `/bsky/{postid}`
- Validates post IDs using base32 character set (13 characters: a-z, 2-7)
- Constructs full Bluesky profile post URL and redirects users after a 1.5 second delay
- Displays a user-friendly "Redirecting to Bluesky" message during the redirect
- Maintains existing sitemap fallback behavior for non-matching 404 requests

## Implementation Details
- Uses regex pattern `/^\/bsky\/([a-z2-7]{13})$/` to match valid Bluesky post IDs
- Redirects to `https://bsky.app/profile/austegard.com/post/{postId}`
- Includes a brief delay and visual feedback before redirect to ensure users see the redirect message
- Early return prevents execution of subsequent 404 handling logic when a match is found

https://claude.ai/code/session_01RsDSVsgPGBapd7Mw2j83zr