### PR TITLE
Scale initial zoom level based on graph size

### DIFF
--- a/bsky/post-constellation-graph.html
+++ b/bsky/post-constellation-graph.html
@@ -1087,11 +1087,26 @@
         sim.alpha(0.5).restart();
       });
 
-      // Center view
+      // Initial zoom: fit all nodes, but cap scale so small graphs don't over-zoom
       setTimeout(() => {
+        let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+        for (const n of data.nodes) {
+          if (n.x < minX) minX = n.x;
+          if (n.y < minY) minY = n.y;
+          if (n.x > maxX) maxX = n.x;
+          if (n.y > maxY) maxY = n.y;
+        }
+        const pad = 250;
+        minX -= pad; minY -= pad; maxX += pad; maxY += pad;
+        const dx = maxX - minX || 1, dy = maxY - minY || 1;
+        const fitScale = Math.min(width / dx, height / dy);
+        // Cap: never zoom in more than 1.0, and treat ~100 nodes as the "full" density
+        const maxScale = Math.min(1.0, 100 / Math.max(nodeCount, 1));
+        const scale = Math.min(fitScale, maxScale) * 0.9;
+        const cx = (minX + maxX) / 2, cy = (minY + maxY) / 2;
         svg.transition().duration(500).call(
           zoom.transform,
-          d3.zoomIdentity.translate(width / 2, height / 2).scale(0.7)
+          d3.zoomIdentity.translate(width / 2 - cx * scale, height / 2 - cy * scale).scale(scale)
         );
       }, 100);
 


### PR DESCRIPTION
Fit all nodes in view on load instead of using a fixed 0.7 scale. Cap maximum zoom to 1.0 and scale down for larger graphs (using ~100 nodes as the reference density), so big graphs start zoomed out enough to see the full constellation.

https://claude.ai/code/session_01WJgGXD9jzHMJHGvRzeeCo5