### PR TITLE
Fix viewport culling leaving nodes permanently hidden with dangling e…

### DIFF
--- a/bsky/post-constellation-graph.html
+++ b/bsky/post-constellation-graph.html
@@ -904,6 +904,23 @@
             .style('transform-origin', '0 0');
           // Redraw edges on canvas immediately on zoom/pan
           drawEdges();
+
+          // Re-evaluate culling when user pans/zooms (sim may be stopped)
+          if (cardEls) {
+            const bounds = getViewportBounds();
+            cardEls.each(function(d) {
+              const visible = isInViewport(d.x, d.y, bounds);
+              if (visible) {
+                if (this.style.display === 'none') {
+                  this.style.display = '';
+                  this.style.left = d.x + 'px';
+                  this.style.top = d.y + 'px';
+                }
+              } else {
+                if (this.style.display !== 'none') this.style.display = 'none';
+              }
+            });
+          }
         });
 
       svg.call(zoom);
@@ -1048,6 +1065,23 @@
             if (el.style.display !== 'none') el.style.display = 'none';
           }
         });
+      });
+
+      // Final pass when simulation settles to fix any stale visibility states
+      sim.on('end', () => {
+        const bounds = getViewportBounds();
+        cardEls.each(function(d) {
+          const el = this;
+          const visible = isInViewport(d.x, d.y, bounds);
+          el.style.left = d.x + 'px';
+          el.style.top = d.y + 'px';
+          if (visible) {
+            if (el.style.display === 'none') el.style.display = '';
+          } else {
+            if (el.style.display !== 'none') el.style.display = 'none';
+          }
+        });
+        drawEdges();
       });
 
       // Add legend


### PR DESCRIPTION
…dges

The tick handler's throttle could skip the final visibility update before the simulation settled, leaving cards stuck with display:none even when within the viewport. Additionally, panning/zooming after the simulation stopped never re-evaluated culling, so hidden cards remained invisible.

- Add sim 'end' handler for a final unthrottled visibility correction pass
- Add culling re-evaluation in the zoom/pan handler so cards are shown when the user scrolls to reveal them after the simulation stops

https://claude.ai/code/session_01DBGSJ1bepEDnqKtj6BzJ64