### PR TITLE
Fix blog deploy race condition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,12 @@ on:
       - '.gitignore'
       - '_MAP.md'
       - 'README*'
+  # Re-deploy after Build blog commits updated index/feed.
+  # Without this, the push-triggered deploy races Build blog and ships stale index.
+  workflow_run:
+    workflows: ["Build blog"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -28,6 +34,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Skip if Build blog failed (workflow_run triggers on any conclusion)
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Problem

When a blog post is pushed to main, both **Build blog** and **Deploy to GitHub Pages** trigger simultaneously. Deploy checks out the repo before Build blog has committed the updated `index.html`/`feed.xml`, so it ships stale content.

Build blog's commit (via `GITHUB_TOKEN`) doesn't trigger a new Deploy run — GitHub suppresses workflow triggers from `github-actions[bot]` to prevent infinite loops.

## Fix

Add a `workflow_run` trigger to `deploy.yml` so Deploy re-runs after Build blog completes successfully. This means:

1. Blog post push → both trigger in parallel (Deploy ships stale index)
2. Build blog commits updated index/feed
3. Deploy triggers again via `workflow_run` and deploys correct state

The `if` condition on the build job skips the redeploy when Build blog fails.

## Same issue on muninn.austegard.com?

Worth checking — the repos have matching workflow structure.