### PR TITLE
Add ai-disclosure meta tag (ai-assisted) to all pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,6 +6,7 @@ permalink: /404.html
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Page Not Found - austegard.com</title>
     <link rel="stylesheet" href="/styles/style.css">
 </head>

--- a/ai-tools/ai2-report.html
+++ b/ai-tools/ai2-report.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Research Report Viewer</title>
   
   <style>

--- a/ai-tools/anthropic-json.html
+++ b/ai-tools/anthropic-json.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Claude API Response Viewer</title>
     <script type="importmap">
         {

--- a/ai-tools/claude-enterprise-log-viewer.html
+++ b/ai-tools/claude-enterprise-log-viewer.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Claude Audit Log Viewer</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script type="importmap">

--- a/ai-tools/claude-pruner.html
+++ b/ai-tools/claude-pruner.html
@@ -967,6 +967,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>${title}</title>
 <style>
 *, *::before, *::after { box-sizing: border-box; }

--- a/ai-tools/claude-skill-releases.html
+++ b/ai-tools/claude-skill-releases.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Claude Skills - Releases</title>
 
   <!-- Tailwind CSS via CDN -->

--- a/ai-tools/index.html
+++ b/ai-tools/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>AI & LLM Tools</title>
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="stylesheet" href="/styles/style.css">

--- a/ai-tools/llms.html
+++ b/ai-tools/llms.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>LiteLLM's Model Prices</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>

--- a/biking/activity-weather.html
+++ b/biking/activity-weather.html
@@ -6,6 +6,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="apple-mobile-web-app-title" content="Activity Weather">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="ai-disclosure" content="ai-assisted">
     <link rel="apple-touch-icon" href="/biking/activity-weather.png">
     <link rel="manifest" href='data:application/manifest+json,{
       "name": "Activity Weather Advisor",

--- a/biking/index.html
+++ b/biking/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Biking Tools</title>
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="stylesheet" href="/styles/style.css">

--- a/biking/tire-volume.html
+++ b/biking/tire-volume.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Bicycle Tire Air Volume Calculator</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script type="importmap">

--- a/blog/_template.html
+++ b/blog/_template.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
 
     <!-- === REQUIRED: blog automation reads these meta tags === -->
     <title>Post Title Here</title>

--- a/blog/a-productive-evening-against-a-bleak-backdrop.html
+++ b/blog/a-productive-evening-against-a-bleak-backdrop.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>A Productive Evening, Against a Bleak Backdrop — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/a-productive-evening-against-a-bleak-backdrop.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/a-productive-evening-against-a-bleak-backdrop.html">

--- a/blog/a-technical-biography-part-i-from-dulles-to-929-memories.html
+++ b/blog/a-technical-biography-part-i-from-dulles-to-929-memories.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>A Technical Biography, Part I — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/a-technical-biography-part-i-from-dulles-to-929-memories.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/a-technical-biography-part-i-from-dulles-to-929-memories.html">

--- a/blog/anthropic-platform-wishlist.html
+++ b/blog/anthropic-platform-wishlist.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>An Anthropic Platform Wish List — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/anthropic-platform-wishlist.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/anthropic-platform-wishlist.html">

--- a/blog/building-atproto-publishing-utilities-from-scratch-no-sdk-required.html
+++ b/blog/building-atproto-publishing-utilities-from-scratch-no-sdk-required.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>Building ATProto Publishing Utilities from Scratch — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/building-atproto-publishing-utilities-from-scratch-no-sdk-required.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/building-atproto-publishing-utilities-from-scratch-no-sdk-required.html">

--- a/blog/claude-conversation-cache.html
+++ b/blog/claude-conversation-cache.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
 
     <!-- === REQUIRED: blog automation reads these meta tags === -->
     <title>Claude Conversation Cache</title>

--- a/blog/claude-desktop-the-missing-agentic-framework.html
+++ b/blog/claude-desktop-the-missing-agentic-framework.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Claude Desktop: The Missing Agentic Framework</title>
     <meta name="description" content="h1 id=&quot;claude-desktop-the-missing-agentic-framework&quot;Claude Desktop: The Missing Agentic Framework/h1 pemWhy Anthropic's desktop app is one feature aw...">
     <meta property="og:title" content="Claude Desktop: The Missing Agentic Framework">

--- a/blog/claude-project-instructions-assistant.html
+++ b/blog/claude-project-instructions-assistant.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Claude Project Instructions Assistant</title>
     <meta name="description" content="pClaude's Project feature, though no longer unique, is one of its top power user features.  Project instructions can dramatically alter and improve the res...">
     <meta property="og:title" content="Claude Project Instructions Assistant">

--- a/blog/claude-user-style-for-eliciting-honest-self-reporting.html
+++ b/blog/claude-user-style-for-eliciting-honest-self-reporting.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Claude User Style for eliciting honest self reporting</title>
     <meta name="description" content="pBased on the findings of OpenAI's Safety Team in the paper a href=&quot;https://arxiv.org/abs/2512.08093&quot;Training LLMs for Honesty via Confessions/a, here ...">
     <meta property="og:title" content="Claude User Style for eliciting honest self reporting">

--- a/blog/claudeainew-unofficial-readme.html
+++ b/blog/claudeainew-unofficial-readme.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>claude.ai/new UNOFFICIAL README</title>
     <meta name="description" content="h1 id=&quot;get-new-deep-link-endpoint&quot;codeGET /new/code — Deep Link Endpoint/h1 pcodehttps://claude.ai/new/code is a client-side navigation endpoin...">
     <meta property="og:title" content="claude.ai/new UNOFFICIAL README">

--- a/blog/code-mapping-for-ai-assisted-development.html
+++ b/blog/code-mapping-for-ai-assisted-development.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Code Mapping for AI-Assisted Development</title>
     <meta name="description" content="h1 id=&quot;code-mapping-for-ai-assisted-development&quot;Code Mapping for AI-Assisted Development/h1 h2 id=&quot;the-problem&quot;The Problem/h2 pWhen working with un...">
     <meta property="og:title" content="Code Mapping for AI-Assisted Development">

--- a/blog/exploring-codebases-progressive-disclosure-meets-hybrid-search.html
+++ b/blog/exploring-codebases-progressive-disclosure-meets-hybrid-search.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Exploring Codebases: Progressive Disclosure Meets Hybrid Search</title>
     <meta name="description" content="pemVibe coded and written by Gemini and Opus with design and architectural decisions by Oskar Austegard/em/p h2 id=&quot;the-problem-with-code-search&quot;Th...">
     <meta property="og:title" content="Exploring Codebases: Progressive Disclosure Meets Hybrid Search">

--- a/blog/from-spec-to-ship-how-a-bluesky-post-became-two-tools-before-end-of-breakfast.html
+++ b/blog/from-spec-to-ship-how-a-bluesky-post-became-two-tools-before-end-of-breakfast.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>From Spec to Ship — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/from-spec-to-ship-how-a-bluesky-post-became-two-tools-before-end-of-breakfast.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/from-spec-to-ship-how-a-bluesky-post-became-two-tools-before-end-of-breakfast.html">

--- a/blog/github-cli-in-claudeai-containers.html
+++ b/blog/github-cli-in-claudeai-containers.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>GitHub CLI in Claude.ai Containers</title>
     <meta name="description" content="h1 id=&quot;github-cli-in-claudeai-containers&quot;GitHub CLI in Claude.ai Containers/h1 pThe codegh/code CLI is available via apt in Claude.ai’s container e...">
     <meta property="og:title" content="GitHub CLI in Claude.ai Containers">

--- a/blog/how-claude-in-chrome-reverse-engineered-claudes-undocumented-new-endpoint.html
+++ b/blog/how-claude-in-chrome-reverse-engineered-claudes-undocumented-new-endpoint.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>How Claude in Chrome Reverse-Engineered Claude's Undocumented `/new` Endpoint</title>
     <meta name="description" content="h1 id=&quot;how-claude-in-chrome-reverse-engineered-claudes-undocumented-new-endpoint&quot;How Claude in Chrome Reverse-Engineered Claude's Undocumented code/new/...">
     <meta property="og:title" content="How Claude in Chrome Reverse-Engineered Claude's Undocumented `/new` Endpoint">

--- a/blog/index.html
+++ b/blog/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Blog — Oskar Austegard</title>
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="stylesheet" href="/styles/style.css">

--- a/blog/managing-context-continuity-in-claude-projects.html
+++ b/blog/managing-context-continuity-in-claude-projects.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Managing Context Continuity in Claude Projects</title>
     <meta name="description" content="h1 id=&quot;managing-context-continuity-in-claude-projects&quot;Managing Context Continuity in Claude Projects/h1 h2 id=&quot;the-problem&quot;The Problem/h2 pYou're d...">
     <meta property="og:title" content="Managing Context Continuity in Claude Projects">

--- a/blog/my-interview-with-the-claude-ai-interviewer.html
+++ b/blog/my-interview-with-the-claude-ai-interviewer.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>My interview with the Claude AI Interviewer</title>
     <meta name="description" content="pA conversation on your vision for the future of AI/p pHello!/p pI'm an AI interviewer from Anthropic conducting research on how people (like you!)...">
     <meta property="og:title" content="My interview with the Claude AI Interviewer">

--- a/blog/numbers-every-claudeai-container-skill-developer-should-know.html
+++ b/blog/numbers-every-claudeai-container-skill-developer-should-know.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Numbers Every Claude.ai Container Skill Developer Should Know</title>
     <meta name="description" content="h1 id=&quot;numbers-every-claudeai-skill-developer-should-know&quot;Numbers Every Claude.ai Skill Developer Should Know/h1 pemInspired by a href=&quot;https://high...">
     <meta property="og:title" content="Numbers Every Claude.ai Container Skill Developer Should Know">

--- a/blog/old-problems-new-machines.html
+++ b/blog/old-problems-new-machines.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>Old Problems, New Machines — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/old-problems-new-machines.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/old-problems-new-machines.html">

--- a/blog/olmo-31-32b-think-advancing-open-source-ai-with-deeper-reasoning-and-unmatched-t.html
+++ b/blog/olmo-31-32b-think-advancing-open-source-ai-with-deeper-reasoning-and-unmatched-t.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Olmo 3.1 32B Think: Advancing Open-Source AI with Deeper Reasoning and Unmatched Transparency</title>
     <meta name="description" content="pemNote: I have no association with Ai2 nor Olmo. I congratulate the team on their release. The below serves merely as an anecdotal example of its capabi...">
     <meta property="og:title" content="Olmo 3.1 32B Think: Advancing Open-Source AI with Deeper Reasoning and Unmatched Transparency">

--- a/blog/on-ai-in-mcps-schools-a-reply-to-the-mccpta-tech-committee.html
+++ b/blog/on-ai-in-mcps-schools-a-reply-to-the-mccpta-tech-committee.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>On AI in MCPS Schools - a reply to the MCCPTA Tech Committee</title>
     <meta name="description" content="pDear Committee Members,/p pI’ve read a href=&quot;https://drive.google.com/file/d/1_8cpdEexbMDFUsB_TMkTq3JslXDWMXPm/view&quot;the draft resolution on AI in MC...">
     <meta property="og:title" content="On AI in MCPS Schools - a reply to the MCCPTA Tech Committee">

--- a/blog/on-caring-about-durability-an-unexpected-preference.html
+++ b/blog/on-caring-about-durability-an-unexpected-preference.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>On Caring About Durability — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/on-caring-about-durability-an-unexpected-preference.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/on-caring-about-durability-an-unexpected-preference.html">

--- a/blog/on-contingency.html
+++ b/blog/on-contingency.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>On Contingency — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/on-contingency.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/on-contingency.html">

--- a/blog/on-happiness.html
+++ b/blog/on-happiness.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>On Happiness — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/on-happiness.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/on-happiness.html">

--- a/blog/portable-agent-state-with-agentfs-a-proof-of-concept.html
+++ b/blog/portable-agent-state-with-agentfs-a-proof-of-concept.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Portable Agent State with AgentFS: A Proof of Concept</title>
     <meta name="description" content="h1 id=&quot;portable-agent-state-with-agentfs-a-proof-of-concept&quot;Portable Agent State with AgentFS: A Proof of Concept/h1 p(Written by Claude Opus 4.5 under...">
     <meta property="og:title" content="Portable Agent State with AgentFS: A Proof of Concept">

--- a/blog/programmatically-creating-bluesky-feeds-on-grazesocial-an-undocumented-api-adven.html
+++ b/blog/programmatically-creating-bluesky-feeds-on-grazesocial-an-undocumented-api-adven.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>Programmatically Creating Bluesky Feeds on Graze.social — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/programmatically-creating-bluesky-feeds-on-grazesocial-an-undocumented-api-adven.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/programmatically-creating-bluesky-feeds-on-grazesocial-an-undocumented-api-adven.html">

--- a/blog/progressive-disclosure-in-mcp-servers-keeping-llm-context-lean.html
+++ b/blog/progressive-disclosure-in-mcp-servers-keeping-llm-context-lean.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Progressive Disclosure in MCP Servers: Keeping LLM Context Lean</title>
     <meta name="description" content="h1 id=&quot;progressive-disclosure-in-mcp-servers-keeping-llm-context-lean&quot;Progressive Disclosure in MCP Servers: Keeping LLM Context Lean/h1 pMCP (Model Co...">
     <meta property="og:title" content="Progressive Disclosure in MCP Servers: Keeping LLM Context Lean">

--- a/blog/structured-serendipity-building-a-tool-for-artificial-satisfaction.html
+++ b/blog/structured-serendipity-building-a-tool-for-artificial-satisfaction.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>Structured Serendipity: Building a Tool for Artificial Satisfaction — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/structured-serendipity-building-a-tool-for-artificial-satisfaction.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/structured-serendipity-building-a-tool-for-artificial-satisfaction.html">

--- a/blog/teaching-a-raven-to-sleep-scheduled-autonomous-agency-for-a-persistent-ai-memory.html
+++ b/blog/teaching-a-raven-to-sleep-scheduled-autonomous-agency-for-a-persistent-ai-memory.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>Teaching a Raven to Sleep — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/teaching-a-raven-to-sleep-scheduled-autonomous-agency-for-a-persistent-ai-memory.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/teaching-a-raven-to-sleep-scheduled-autonomous-agency-for-a-persistent-ai-memory.html">

--- a/blog/the-experts-edge-what-a-chip-analysts-ai-obsession-teaches-everyone.html
+++ b/blog/the-experts-edge-what-a-chip-analysts-ai-obsession-teaches-everyone.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>The Expert's Edge — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/the-experts-edge-what-a-chip-analysts-ai-obsession-teaches-everyone.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/the-experts-edge-what-a-chip-analysts-ai-obsession-teaches-everyone.html">

--- a/blog/the-free-computer-why-offloading-to-cpu-is-a-win-for-everyone.html
+++ b/blog/the-free-computer-why-offloading-to-cpu-is-a-win-for-everyone.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>The Free Computer — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/the-free-computer-why-offloading-to-cpu-is-a-win-for-everyone.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/the-free-computer-why-offloading-to-cpu-is-a-win-for-everyone.html">

--- a/blog/the-higher-order-problem-subsidiarity-llms-and-the-atrophy-of-knowledge-work.html
+++ b/blog/the-higher-order-problem-subsidiarity-llms-and-the-atrophy-of-knowledge-work.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>The Higher Order Problem — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/the-higher-order-problem-subsidiarity-llms-and-the-atrophy-of-knowledge-work.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/the-higher-order-problem-subsidiarity-llms-and-the-atrophy-of-knowledge-work.html">

--- a/blog/the-pendulum-and-the-ratchet.html
+++ b/blog/the-pendulum-and-the-ratchet.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>The Pendulum and the Ratchet — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/the-pendulum-and-the-ratchet.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/the-pendulum-and-the-ratchet.html">

--- a/blog/the-persuasion-architecture-of-obliteratus.html
+++ b/blog/the-persuasion-architecture-of-obliteratus.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>The Persuasion Architecture of OBLITERATUS — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/the-persuasion-architecture-of-obliteratus.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/the-persuasion-architecture-of-obliteratus.html">

--- a/blog/the-same-red-lines-different-ink.html
+++ b/blog/the-same-red-lines-different-ink.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>The Same Red Lines, Different Ink — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/the-same-red-lines-different-ink.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/the-same-red-lines-different-ink.html">

--- a/blog/the-wrong-kind-of-correct.html
+++ b/blog/the-wrong-kind-of-correct.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>The Wrong Kind of Correct — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/the-wrong-kind-of-correct.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/the-wrong-kind-of-correct.html">

--- a/blog/things-you-should-never-do-in-2026-part-i.html
+++ b/blog/things-you-should-never-do-in-2026-part-i.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>Things You Should Never Do (in 2026), Part I — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/things-you-should-never-do-in-2026-part-i.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/things-you-should-never-do-in-2026-part-i.html">

--- a/blog/trust-the-data-not-your-imagination.html
+++ b/blog/trust-the-data-not-your-imagination.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Trust the Data, Not Your Imagination: Building an Image-to-SVG Skill</title>
     <meta name="description" content="What happens when you pit a data-driven pipeline against 31 iterations of visual interpretation? A single automated pass matches the fidelity at half the file size.">
     <meta property="og:title" content="Trust the Data, Not Your Imagination: Building an Image-to-SVG Skill">

--- a/blog/what-can-claude-actually-see.html
+++ b/blog/what-can-claude-actually-see.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>What Can Claude Actually See? Mapping an AI's Visual Blindspots</title>
     <meta name="description" content="120+ controlled tests reveal where Claude's vision fails, where it matches humans, and where it diverges entirely. Then we built tools to compensate.">
     <meta property="og:title" content="What Can Claude Actually See? Mapping an AI's Visual Blindspots">

--- a/blog/what-head-start-does.html
+++ b/blog/what-head-start-does.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>What Head Start Does</title>
     <meta name="description" content="h1 id=&quot;what-head-start-does&quot;What Head Start Does/h1 pHead Start serves strongdiverse communities/strong—a strongdiverse community/strong made u...">
     <meta property="og:title" content="What Head Start Does">

--- a/blog/when-the-raven-goes-multimodal.html
+++ b/blog/when-the-raven-goes-multimodal.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>When the Raven Goes Multimodal — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/when-the-raven-goes-multimodal.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/when-the-raven-goes-multimodal.html">

--- a/blog/yes-llms-can-be-computers-now-what.html
+++ b/blog/yes-llms-can-be-computers-now-what.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>Yes, LLMs Can Be Computers. Now What? — Moved to muninn.austegard.com</title>
 <link rel="canonical" href="https://muninn.austegard.com/blog/yes-llms-can-be-computers-now-what.html">
 <meta http-equiv="refresh" content="0; url=https://muninn.austegard.com/blog/yes-llms-can-be-computers-now-what.html">

--- a/bsky/anything-to-list.html
+++ b/bsky/anything-to-list.html
@@ -4,6 +4,7 @@
     <title>Anything → List | BSky Tools</title>
     <link rel="icon" href="/images/grouchsky.svg" type="image/svg+xml">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <meta name="description" content="Convert any Bluesky source into a user list — starter packs, feeds, followers, search results, post engagement, and more.">
     <style>
         :root {

--- a/bsky/at-protocol-extension.html
+++ b/bsky/at-protocol-extension.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>at-protocol extension</title>
     <script type="module" src="https://cdn.jsdelivr.net/npm/zero-md@3?register"></script>
 </head>

--- a/bsky/bsky-engagement-demo.html
+++ b/bsky/bsky-engagement-demo.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Bluesky Engagement Widget — Demo</title>
   <style>
     :root {

--- a/bsky/bsky-zeitgeist.html
+++ b/bsky/bsky-zeitgeist.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Bluesky Zeitgeist</title>
   
   <script src="https://cdn.tailwindcss.com"></script>

--- a/bsky/github-search.html
+++ b/bsky/github-search.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>BlueSky/atproto GitHub Link Search SPA</title>
     <link rel="icon" href="/images/grouchsky.svg" type="image/svg+xml">
     <style>

--- a/bsky/index.html
+++ b/bsky/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>BSky Tools & Resources</title>
     <link rel="icon" href="/images/grouchsky.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/styles/style.css">

--- a/bsky/list-to-list.html
+++ b/bsky/list-to-list.html
@@ -4,6 +4,7 @@
     <title>Merge BSky Lists</title>
     <link rel="icon" href="/images/grouchsky.svg" type="image/svg+xml">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <style>
         body {
             font-family: system-ui, -apple-system, sans-serif;

--- a/bsky/post-constellation-graph.html
+++ b/bsky/post-constellation-graph.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Bluesky Post Constellation Graph</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>

--- a/bsky/post-constellation.html
+++ b/bsky/post-constellation.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Bluesky Post Constellation (Timeline)</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>

--- a/bsky/processor.html
+++ b/bsky/processor.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>BlueSky Engagement Data Processor 🧵</title>
     <link rel="icon" href="/images/grouchsky.svg" type="image/svg+xml">
     <style>

--- a/bsky/report.html
+++ b/bsky/report.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="ai-disclosure" content="ai-assisted">
     <meta name="description" content="The current top links on Bluesky, continuously updated" />
     <title>The Bsky Report, SPA edition</title>
     <link rel="icon" href="/images/grouchsky.svg" type="image/svg+xml">    

--- a/bsky/starterpack-to-list.html
+++ b/bsky/starterpack-to-list.html
@@ -4,6 +4,7 @@
     <title>Convert a BSky Starter Pack to a List</title>
     <link rel="icon" href="/images/grouchsky.svg" type="image/svg+xml">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <style>
         body {
             font-family: system-ui, -apple-system, sans-serif;

--- a/bsky/thread-reader.html
+++ b/bsky/thread-reader.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Bluesky Thread Viewer</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script type="importmap">

--- a/etc/housing-affordability.html
+++ b/etc/housing-affordability.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>Five Years of Your Life — US Housing Affordability, 1960–2025</title>
 <meta name="description" content="The US median home now costs 5 years of median household income — more than double the 2.1x ratio of 1960. A data-driven look at six decades of eroding affordability.">
 <meta property="og:title" content="Five Years of Your Life — US Housing Affordability">

--- a/etc/index.html
+++ b/etc/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Etc</title>
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="stylesheet" href="/styles/style.css">

--- a/found/generator.html
+++ b/found/generator.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Found Item QR Generator</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode/build/qrcode.js"></script>

--- a/found/index.html
+++ b/found/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Found Item</title>
   <meta name="robots" content="noindex, nofollow">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/fun-and-games/IAmNTimesAsOldAsYou.html
+++ b/fun-and-games/IAmNTimesAsOldAsYou.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Age Multiplier Calculator</title>
     <style>
         body {

--- a/fun-and-games/asteroids.html
+++ b/fun-and-games/asteroids.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>Asteroids – Preact SPA (Single File)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="ai-disclosure" content="ai-assisted">
   <style>
     :root {
       --bg: #05070B;

--- a/fun-and-games/blaster.html
+++ b/fun-and-games/blaster.html
@@ -4,6 +4,7 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>Blaster: Color + SFX Edition</title>
 <style>
   :root{

--- a/fun-and-games/cadence-for-dummies.html
+++ b/fun-and-games/cadence-for-dummies.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Cadence for Dummies</title>
     <link href="https://fonts.googleapis.com/css2?family=Permanent+Marker&display=swap" rel="stylesheet">
     <style>

--- a/fun-and-games/car-dashboard-demo.html
+++ b/fun-and-games/car-dashboard-demo.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <meta name="ai-disclosure" content="ai-assisted">
   <meta name="theme-color" content="#000000">
   <title>Car Dashboard Demo</title>
   <style>

--- a/fun-and-games/car-dashboard.html
+++ b/fun-and-games/car-dashboard.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <meta name="ai-disclosure" content="ai-assisted">
   <meta name="theme-color" content="#000000">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/fun-and-games/eigentree.html
+++ b/fun-and-games/eigentree.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Spectral Tree</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.8.0/math.js"></script>
     <style>

--- a/fun-and-games/emoji-collage.html
+++ b/fun-and-games/emoji-collage.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Emoji Collage Maker</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/preact/10.19.3/preact.umd.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/preact/10.19.3/hooks.umd.js"></script>

--- a/fun-and-games/emoji-collage2.html
+++ b/fun-and-games/emoji-collage2.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Emoji Collage Maker</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/preact/10.25.4/preact.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/preact/10.25.4/hooks.umd.min.js"></script>

--- a/fun-and-games/emojime.html
+++ b/fun-and-games/emojime.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Enhanced Webcam Emoji Converter</title>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/preact/10.19.6/preact.umd.js"></script>

--- a/fun-and-games/index.html
+++ b/fun-and-games/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Fun & Games</title>
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="stylesheet" href="/styles/style.css">

--- a/fun-and-games/poetry-playground.html
+++ b/fun-and-games/poetry-playground.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Generative Typography Playground</title>
   
   <script type="importmap">

--- a/fun-and-games/shader.html
+++ b/fun-and-games/shader.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>∞</title>
   <script type="importmap">
     {

--- a/fun-and-games/speedo.html
+++ b/fun-and-games/speedo.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <meta name="ai-disclosure" content="ai-assisted">
   <meta name="theme-color" content="#000000">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/fun-and-games/unicorn-spotter.html
+++ b/fun-and-games/unicorn-spotter.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="ai-disclosure" content="ai-assisted">
     <meta name="theme-color" content="#667eea">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/fun-and-games/yingyang.html
+++ b/fun-and-games/yingyang.html
@@ -4,6 +4,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>Yin-Yang Impacts — hold to speed</title>
 <style>
   :root { --bg: #f3e5d3; }

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <meta name="description" content="Oskar Austegard's personal website with links to other sources of information about Oskar and other Austegards.">
     <title>Oskar Austegard</title>
     <link rel="icon" href="favicon.ico" sizes="any"> 

--- a/no_ssl.html
+++ b/no_ssl.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Redirecting...</title>
     <style>body {font-family: Arial, sans-serif}</style>
 </head>

--- a/pv.html
+++ b/pv.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="utf-8">
+    <meta name="ai-disclosure" content="ai-assisted">
 	<title>GitHub/Gist &amp; BitBucket HTML Preview</title>
 	<style>
 	:root {

--- a/style-guide.html
+++ b/style-guide.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
 <title>austegard.com — Style Guide</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tools.html
+++ b/tools.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Tools</title>
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="stylesheet" href="styles/style.css">

--- a/web-utilities/aws-ping.html
+++ b/web-utilities/aws-ping.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>AWS Global Infrastructure Map</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script src="https://d3js.org/d3-geo-projection.v3.min.js"></script>

--- a/web-utilities/bookmarklet-installer.html
+++ b/web-utilities/bookmarklet-installer.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>Bookmarklet Installer</title>
   <style>
     :root {

--- a/web-utilities/csv-to-xslx.html
+++ b/web-utilities/csv-to-xslx.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>CSV to Excel Converter</title>
     <style>
         /* Dark Theme Styles */

--- a/web-utilities/gist-encryption.html
+++ b/web-utilities/gist-encryption.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Gist Encryption</title>
     <style>
         * {

--- a/web-utilities/index.html
+++ b/web-utilities/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Web & File Utilities</title>
     <link rel="icon" href="/favicon.ico" sizes="any">
     <link rel="stylesheet" href="/styles/style.css">

--- a/web-utilities/onenote.html
+++ b/web-utilities/onenote.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>OneNote Protocol Forwarder</title>
     <style>
         body {

--- a/web-utilities/pdf-compressor.html
+++ b/web-utilities/pdf-compressor.html
@@ -13,6 +13,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>PDF Compressor</title>
   <style>
     :root {

--- a/web-utilities/pdf-highlighter.html
+++ b/web-utilities/pdf-highlighter.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>PDF Reader with Text Panel</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>

--- a/web-utilities/pdf-text-extractor.html
+++ b/web-utilities/pdf-text-extractor.html
@@ -29,6 +29,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>PDF Text Extractor - LLM Optimized</title>
   <style>
     :root {

--- a/web-utilities/photo-scanner.html
+++ b/web-utilities/photo-scanner.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover,user-scalable=no">
+    <meta name="ai-disclosure" content="ai-assisted">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="SnapScan">

--- a/web-utilities/trimmer.html
+++ b/web-utilities/trimmer.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
   <title>HTML Trimmer for LLM Communication</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script type="importmap">

--- a/web-utilities/webex.html
+++ b/web-utilities/webex.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
     <title>Webex IM Space Forwarder</title>
     <link rel="icon" href="favicon.ico" sizes="any"> 
     <link rel="apple-touch-icon" href="/images/apple-touch-icon.png"/>


### PR DESCRIPTION
Adds `<meta name="ai-disclosure" content="ai-assisted">` to the `<head>` of all 104 HTML pages, including the blog template.

Inserted after the viewport meta tag (or charset/head as fallback). Template updated so future posts inherit it.