### PR TITLE
Replace strudel-composer with redirect to Claude artifact

### DIFF
--- a/fun-and-games/strudel-composer.html
+++ b/fun-and-games/strudel-composer.html
@@ -2,58 +2,10 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Strudel Composer — austegard.com</title>
-<meta name="description" content="AI-powered English to Strudel live-coding music translator">
-<style>
-  * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { background: #08080d; min-height: 100vh; display: flex; flex-direction: column; }
-  .header {
-    padding: 16px 24px;
-    background: #111118;
-    border-bottom: 1px solid #26263a;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-  .header h1 {
-    font-family: 'Courier New', monospace;
-    font-size: 18px;
-    font-weight: 600;
-    color: #c084d8;
-  }
-  .header span {
-    font-size: 13px;
-    color: #6a6a80;
-    font-style: italic;
-  }
-  .header a {
-    margin-left: auto;
-    font-size: 12px;
-    color: #6ecfcf;
-    text-decoration: none;
-    font-family: 'Courier New', monospace;
-  }
-  .header a:hover { text-decoration: underline; }
-  iframe {
-    flex: 1;
-    width: 100%;
-    border: none;
-    background: #08080d;
-  }
-</style>
+<meta http-equiv="refresh" content="0;url=https://claude.ai/public/artifacts/8901ab14-7b94-4024-96a3-dd4474f2154e">
+<title>Strudel Composer — Redirecting</title>
 </head>
-<body>
-  <div class="header">
-    <h1>&#42828; strudel composer</h1>
-    <span>english &rarr; live code</span>
-    <a href="strudel-composer_README.md">about</a>
-  </div>
-  <iframe
-    src="https://claude.site/public/artifacts/8901ab14-7b94-4024-96a3-dd4474f2154e/embed"
-    title="Strudel Composer"
-    allow="clipboard-write; autoplay"
-    allowfullscreen>
-  </iframe>
+<body style="background:#08080d;color:#6a6a80;font-family:monospace;padding:40px">
+<p>Redirecting to <a href="https://claude.ai/public/artifacts/8901ab14-7b94-4024-96a3-dd4474f2154e" style="color:#c084d8">Strudel Composer</a>...</p>
 </body>
 </html>


### PR DESCRIPTION
Replaces the 880K inline HTML with a simple meta-refresh redirect to the Claude-hosted artifact where the API proxy actually works.