### PR TITLE
Bump addressable 2.8.8 → 2.9.0 (CVE-2026-35611)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
     bigdecimal (3.3.1)
@@ -307,3 +307,4 @@ DEPENDENCIES
 
 BUNDLED WITH
    2.7.2
+


### PR DESCRIPTION
Fixes high-severity ReDoS vulnerability in Addressable URI templates.

Resolves https://github.com/oaustegard/oaustegard.github.io/security/dependabot/15