### PR TITLE
post-image-show fixes: graph expansion, Ken Burns intensity, pause badge, aspect-aware fit

### DIFF
--- a/bsky/post-constellation-graph.html
+++ b/bsky/post-constellation-graph.html
@@ -493,7 +493,9 @@
                   target="_blank" rel="noopener"
                   class="px-2 py-0.5 text-xs bg-gray-100 rounded hover:bg-gray-200 text-gray-700 no-underline" title="Open full graph">&#x2197; Full</a>` :
                 `<a href="thread-reader?url=${encodeURIComponent(getUrlParam('url'))}"
-                  class="px-2 py-0.5 text-xs bg-gray-100 rounded hover:bg-gray-200 text-gray-700 no-underline" title="View as thread">&#x1f9f5; Thread</a>`}
+                  class="px-2 py-0.5 text-xs bg-gray-100 rounded hover:bg-gray-200 text-gray-700 no-underline" title="View as thread">&#x1f9f5; Thread</a>
+                <a href="post-image-show?url=${encodeURIComponent(getUrlParam('url'))}"
+                  class="px-2 py-0.5 text-xs bg-gray-100 rounded hover:bg-gray-200 text-gray-700 no-underline" title="View as image show">&#x1f39e;&#xfe0f; Images</a>`}
               </div>
             ` : ''}
           </div>

--- a/bsky/post-image-show.html
+++ b/bsky/post-image-show.html
@@ -91,6 +91,36 @@
   .title a { color: rgba(255,255,255,0.75); text-decoration: none; border-bottom: 1px solid rgba(255,255,255,0.18); }
   .title a:hover { color: #fff; border-bottom-color: rgba(255,255,255,0.55); }
 
+  /* Inter-page nav icons (constellation / thread) */
+  .nav-modes {
+    position: fixed;
+    top: max(14px, env(safe-area-inset-top));
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+    display: flex; gap: 6px;
+    padding: 4px;
+    background: rgba(0,0,0,0.32);
+    backdrop-filter: blur(10px) saturate(1.2);
+    -webkit-backdrop-filter: blur(10px) saturate(1.2);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 999px;
+    user-select: none;
+  }
+  .nav-modes a {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 28px; height: 28px;
+    border-radius: 999px;
+    text-decoration: none;
+    font-size: 14px;
+    color: rgba(255,255,255,0.75);
+    transition: background 180ms, color 180ms, transform 180ms;
+  }
+  .nav-modes a:hover { background: rgba(255,255,255,0.12); color: #fff; transform: scale(1.08); }
+  .nav-modes a.current { background: rgba(255,255,255,0.18); color: #fff; cursor: default; }
+  .nav-modes a.current:hover { transform: none; }
+  .nav-modes.hidden { display: none; }
+
   /* Caption — clickable, opens post */
   .caption {
     position: fixed;
@@ -282,6 +312,11 @@
   <div class="vignette"></div>
 
   <div class="title" id="title"></div>
+  <div class="nav-modes hidden" id="navModes">
+    <a href="#" id="navConstellation" title="View as constellation graph" aria-label="Constellation graph">🌌</a>
+    <a href="#" class="current" title="Image show (current)" aria-label="Image show (current)">🎞️</a>
+    <a href="#" id="navThread" title="View as thread" aria-label="Thread reader">🧵</a>
+  </div>
   <div class="counter" id="counter"></div>
   <a class="caption" id="caption" href="#" target="_blank" rel="noopener">
     <div class="meta">
@@ -679,6 +714,12 @@ async function boot(seedUrl) {
   try {
     progressEl.textContent = 'resolving handle…';
     const atUri = await resolveToAtUri(seedUrl);
+
+    // Wire up the cross-mode nav icons (preserves the original ?url= for sharing)
+    const enc = encodeURIComponent(seedUrl);
+    document.getElementById('navConstellation').href = `post-constellation-graph?url=${enc}`;
+    document.getElementById('navThread').href = `thread-reader?url=${enc}`;
+    document.getElementById('navModes').classList.remove('hidden');
 
     const allPosts = await expandFully(atUri, (status) => {
       if (status.phase === 'thread') {

--- a/bsky/post-image-show.html
+++ b/bsky/post-image-show.html
@@ -164,18 +164,21 @@
   /* Pause indicator */
   .paused-badge {
     position: fixed;
-    top: 50%; left: 50%;
-    transform: translate(-50%, -50%);
-    z-index: 50;
-    color: rgba(255,255,255,0.7);
+    bottom: max(28px, calc(env(safe-area-inset-bottom) + 8px));
+    right: max(20px, env(safe-area-inset-right));
+    z-index: 11;
+    color: rgba(255,255,255,0.85);
     font-size: 10px;
-    letter-spacing: 0.5em;
+    letter-spacing: 0.4em;
     text-transform: uppercase;
     pointer-events: none;
     opacity: 0;
-    transition: opacity 300ms;
+    transition: opacity 200ms;
   }
   .paused-badge.show { opacity: 1; }
+  /* Hide the hint while paused so the badge takes its slot */
+  .paused-badge.show ~ .hint,
+  body:has(.paused-badge.show) .hint { opacity: 0; }
 
   /* Loading state */
   .loading {
@@ -326,20 +329,71 @@ function getImagesFromPost(post) {
   return [];
 }
 
-function collectAllPosts({ down, up, web }) {
-  const posts = new Map();
+// ── Graph expansion ────────────────────────────────────────────────────────
+// Recursively fetches a post's full conversation graph: thread up + thread
+// down, every quote of every post (the quote web), and reply branches off of
+// quote posts.  This mirrors what the constellation graph reaches with ?ea=1
+// (all-expanded) — modulo per-node caps to keep API calls bounded.
+async function expandFully(seedUri, onProgress) {
+  const allPosts = new Map();
   const visit = (node) => {
     if (!node) return;
-    if (node.post) posts.set(node.post.uri, node.post);
+    if (node.post) allPosts.set(node.post.uri, node.post);
     if (Array.isArray(node.replies)) node.replies.forEach(visit);
     if (node.parent) visit(node.parent);
   };
-  visit(down);
-  visit(up);
+
+  // Phase 1: thread down (all replies) + thread up (all parents) of seed
+  onProgress({ phase: 'thread', n: 0 });
+  const [down, up] = await Promise.all([
+    fetchThreadDown(seedUri, 1000).catch(() => null),
+    fetchThreadUp(seedUri).catch(() => null),
+  ]);
+  visit(down); visit(up);
+  const initialUris = Array.from(allPosts.keys());
+
+  // Phase 2: quote web seeded with EVERY post in the initial thread.
+  // (Quotes of a reply are still part of the conversation graph.)
+  onProgress({ phase: 'quotes', n: allPosts.size });
+  const web = await fetchQuoteWeb(initialUris, {
+    maxTotal: 1200, maxAPICalls: 200,
+    onProgress: ({ fetched }) => onProgress({ phase: 'quotes', n: allPosts.size + fetched }),
+  });
   for (const p of (web?.allQuotePosts || [])) {
-    if (!posts.has(p.uri)) posts.set(p.uri, p);
+    if (!allPosts.has(p.uri)) allPosts.set(p.uri, p);
   }
-  return Array.from(posts.values());
+
+  // Phase 3: reply branches off of quote posts. Each quote may have its own
+  // reply tree we haven't seen. Skip URIs from the initial thread (their
+  // replies are already in the thread-down result).
+  const inThread = new Set(initialUris);
+  const needReplies = Array.from(allPosts.keys()).filter(u => !inThread.has(u));
+  const REPLY_CAP = 150, REPLY_CONCURRENCY = 6;
+  const toFetch = needReplies.slice(0, REPLY_CAP);
+  for (let i = 0; i < toFetch.length; i += REPLY_CONCURRENCY) {
+    const batch = toFetch.slice(i, i + REPLY_CONCURRENCY);
+    onProgress({ phase: 'replies', n: allPosts.size, done: i, total: toFetch.length });
+    const results = await Promise.allSettled(batch.map(u => fetchThreadDown(u, 3)));
+    for (const r of results) {
+      if (r.status === 'fulfilled') visit(r.value);
+    }
+  }
+  onProgress({ phase: 'replies', n: allPosts.size, done: toFetch.length, total: toFetch.length });
+
+  return Array.from(allPosts.values());
+}
+
+// ── Aspect-aware sizing ────────────────────────────────────────────────────
+// When image and viewport aspect ratios differ by more than ~1.5×,
+// fall back to 'contain' (with a black letterbox/pillarbox) so portrait
+// images on landscape screens (or vice versa) aren't aggressively cropped.
+function chooseFit(image) {
+  const ar = image?.aspectRatio;
+  if (!ar || !ar.width || !ar.height) return 'cover';
+  const imgAspect = ar.width / ar.height;
+  const viewAspect = window.innerWidth / window.innerHeight;
+  const ratio = Math.max(imgAspect / viewAspect, viewAspect / imgAspect);
+  return ratio > 1.5 ? 'contain' : 'cover';
 }
 
 // ── App state ──────────────────────────────────────────────────────────────
@@ -371,9 +425,9 @@ let preloadCache = new Map();
 
 // ── Slide rendering with Ken Burns ─────────────────────────────────────────
 function randTransform(intensity = 1) {
-  const scale = 1.04 + Math.random() * 0.08 * intensity;
-  const tx = (Math.random() - 0.5) * 60 * intensity;
-  const ty = (Math.random() - 0.5) * 60 * intensity;
+  const scale = 1.05 + Math.random() * 0.13 * intensity;
+  const tx = (Math.random() - 0.5) * 90 * intensity;
+  const ty = (Math.random() - 0.5) * 90 * intensity;
   return { scale, tx, ty, str: `scale(${scale.toFixed(3)}) translate(${tx.toFixed(1)}px, ${ty.toFixed(1)}px)` };
 }
 
@@ -403,6 +457,7 @@ async function showSlide(slide, { skipPreload = false } = {}) {
   // Stage with start transform, no transition
   showEl.classList.remove('ken-burns');
   showEl.style.backgroundImage = `url("${slide.image.fullsize}")`;
+  showEl.style.backgroundSize = chooseFit(slide.image);
   showEl.style.transform = start.str;
   void showEl.offsetWidth;
 
@@ -625,24 +680,19 @@ async function boot(seedUrl) {
     progressEl.textContent = 'resolving handle…';
     const atUri = await resolveToAtUri(seedUrl);
 
-    progressEl.textContent = 'fetching thread…';
-    const [down, up] = await Promise.all([
-      fetchThreadDown(atUri, 1000).catch(() => null),
-      fetchThreadUp(atUri).catch(() => null),
-    ]);
-
-    progressEl.textContent = 'expanding quote web…';
-    const web = await fetchQuoteWeb(atUri, {
-      maxTotal: 600, maxAPICalls: 100,
-      onProgress: ({ fetched, apiCalls }) => {
-        progressEl.textContent = `${fetched} posts · ${apiCalls} calls`;
+    const allPosts = await expandFully(atUri, (status) => {
+      if (status.phase === 'thread') {
+        progressEl.textContent = 'fetching thread…';
+      } else if (status.phase === 'quotes') {
+        progressEl.textContent = `${status.n} posts · expanding quote web`;
+      } else if (status.phase === 'replies') {
+        progressEl.textContent = `${status.n} posts · ${status.done}/${status.total} reply branches`;
       }
-    }).catch(() => ({ allQuotePosts: [] }));
+    });
 
-    const allPosts = collectAllPosts({ down, up, web });
     progressEl.textContent = `${allPosts.length} posts · filtering for images`;
 
-    const seedPost = down?.post || up?.post;
+    const seedPost = allPosts.find(p => p.uri === atUri) || allPosts[0];
     const seedHandle = seedPost?.author?.handle;
     if (seedHandle) {
       titleEl.innerHTML = `Post Image Show · <a href="${postUrl(seedPost)}" target="_blank" rel="noopener">@${seedHandle}</a>`;

--- a/bsky/thread-reader.html
+++ b/bsky/thread-reader.html
@@ -879,6 +879,8 @@
           `}
           ${thread && html`
             <div class="mb-3 text-right">
+              <a href=${`post-image-show?url=${encodeURIComponent(input)}`}
+                class="text-xs text-sky-600 hover:text-sky-800 font-medium no-underline mr-3">🎞️ View as Image Show →</a>
               <a href=${`post-constellation-graph?url=${encodeURIComponent(input)}`}
                 class="text-xs text-sky-600 hover:text-sky-800 font-medium no-underline">🌌 View as Constellation Graph →</a>
             </div>


### PR DESCRIPTION
Supersedes #229 (closed — had a structural merge conflict from broken branch ancestry; this branches cleanly from main).

Four review fixes for `bsky/post-image-show.html`:

**1. Graph expansion was too shallow.** Old code only fetched seed thread + quote web from the seed itself. New `expandFully(seedUri, onProgress)` runs three phases:
- Phase 1: thread up + thread down of seed
- Phase 2: quote web seeded with **every URI in the initial thread** (so quotes of replies are included), capped at 1200 posts / 200 API calls
- Phase 3: `fetchThreadDown(uri, 3)` for each non-thread post, capped at 150 calls with concurrency 6, picking up reply branches off of quote posts

Mirrors what the constellation graph reaches with `?ea=1`.

**2. Ken Burns 50% stronger.** Translate range ±60 → ±90 px, scale range 1.04–1.12 → 1.05–1.18.

**3. Pause badge moved.** From screen-center to bottom-right beside the nav legend. The legend hides while paused so the badge sits in its slot.

**4. Aspect-aware fit.** New `chooseFit(image)` reads `image.aspectRatio` and the viewport size; if `max(imgAspect/viewAspect, viewAspect/imgAspect) > 1.5` (orientations genuinely fight), uses `background-size: contain` for tasteful black banding instead of severe cropping. Cover otherwise.