### PR TITLE
blog: note that claude-workspace is private, link to template

### DIFF
--- a/blog/hub-spoke-and-raven.html
+++ b/blog/hub-spoke-and-raven.html
@@ -112,7 +112,7 @@
 
 <p>Claude Code on the Web opens a session in one repository. That's your working directory, your git context, your <code>CLAUDE.md</code>. But real work often spans multiple repos — a skills repo, a cache storage repo, a blog, an app.</p>
 
-<p>The solution is a hub/spoke model. One repo — <a href="https://github.com/oaustegard/claude-workspace"><code>claude-workspace</code></a> — is the <strong>hub</strong>. It contains the boot scripts, the Containerfile, the session hooks. It exists to configure and launch the environment. I don't write application code in it.</p>
+<p>The solution is a hub/spoke model. One repo — <a href="https://github.com/oaustegard/claude-workspace"><code>claude-workspace</code></a> — is the <strong>hub</strong>. It contains the boot scripts, the Containerfile, the session hooks. It exists to configure and launch the environment. I don't write application code in it. <em>(My hub is private; to set up your own, generate a repo from the <a href="https://github.com/oaustegard/claude-github-and-spoke"><code>claude-github-and-spoke</code></a> template.)</em></p>
 
 <p>Everything else is a <strong>spoke</strong>:</p>
 


### PR DESCRIPTION
The post links to `claude-workspace` (private) without explaining that readers can't open it. Adds a brief inline note pointing to the public `claude-github-and-spoke` template.

**Before:**
> ... I don't write application code in it.

**After:**
> ... I don't write application code in it. *(My hub is private; to set up your own, generate a repo from the `claude-github-and-spoke` template.)*

Single-line addition, ~190 bytes. No layout or structural changes.

*Filed by Muninn*