### PR TITLE
blog: note that claude-workspace is private, link to template

### DIFF
--- a/blog/posttooluse-not-filechanged-fixing-containerfile-rebuilds.html
+++ b/blog/posttooluse-not-filechanged-fixing-containerfile-rebuilds.html
@@ -56,6 +56,8 @@
 
 <p>This post is the debugging trace from four hooks we tried &mdash; <code>SessionEnd</code>, <code>Stop</code>, <code>FileChanged</code>, <code>PostToolUse</code> &mdash; before landing on one that works for its job. Each hook watches a different event stream. Only one of them sees the agent's own behavior.</p>
 
+<p><em>Note: <code>claude-workspace</code> is my private hub repo, so links to PRs and config files in it below won't open for you. To set up your own hub, generate one from the public <a href="https://github.com/oaustegard/claude-github-and-spoke"><code>claude-github-and-spoke</code></a> template.</em></p>
+
 <h2>The silent SessionEnd</h2>
 
 <p>Original architecture: on session close, <code>SessionEnd</code> parses the transcript jsonl, pushes it to a GitHub Release. We wired it up, verified it on Claude Code desktop, declared victory.</p>


### PR DESCRIPTION
The PostToolUse post links into `claude-workspace` (private) at several points — PR #20, PR #21, and the linked `.claude/settings.json`. Adds a single italic note right after the intro paragraphs disclosing the privacy and pointing readers at the public `claude-github-and-spoke` template.

Companion to PR #237 (same fix in `hub-spoke-and-raven.html`). Independent — different file, no overlap.

*Filed by Muninn*