### PR TITLE
Add tap-localizer to fun-and-games

### DIFF
--- a/fun-and-games/tap-localizer.html
+++ b/fun-and-games/tap-localizer.html
@@ -1,0 +1,728 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black">
+<meta name="apple-mobile-web-app-title" content="tap.loc">
+<meta name="ai-disclosure" content="ai-assisted">
+<link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAIAAACyr5FlAAAIbElEQVR42u2dP07kShDGBzQHeBd41oYTgETwsk24AwkpKQfgEBxgUlIS7kBCtgESHADNXmCP8IKRRpY9zNr196v2VyJAaLC7q3/+qqqnu3222WxWNNoxW69Wq91uR0fQBtZ13Tm9QPvOCAeNcPzNLrc3l9sb+oFw0AgHjXDQCAeNcNAIBw3f1nTB3j7uX+gEKgeNcNAIB41w0AgHjXDQWMri2vXnw9x/eb14JBxEYepFmsdlvUwgBOM6vmD/L02CcrbZbJpZQ/odEE4jF3y7YOu6rgU4jg5S8AghtIFwnBoSkMHAbNWC4MAfgOqIlISjXBpYNG8tBkfp6qBc48vA0UzRWKgjBeBoci6hRKeg4Wh+igm8g7hwHBzX/BQ1bE9BN1Ivh4x+H02+ALI1LOVYFBbgfcdSjiWTgSkhKMoRT8bV0+30D7/fPS/tCYFISMPcMYuGXFYQEMmHw9sLJ4CYNcBW1ynERzIcfv0/OpaGo+h9fQQ+MuFw6vlg2AJyBdc7JvKRBod5n+OZCGtDFh85cNj2FgEL7/ak8JEAhx8Z6Vi4Niyej2g4DHsIi4VfI4P5CIXDqm8lsHBqcCQfCdPnVmS83z2XIGPQVOVEXHBOGgTHHnlDMlbVzJaPmO9fIsKKnozSWHj0xeRhyw8resZbIsNQQgL0IyisiBlvjAwrPmKSD9+wolS/ve9awsK2g67BxbeUxSfjx/3PKR/72r4tkA9HOJQVuR8ZE4GIBEXTWb+ZD3c4cMg4ysTEkdb8bxgfZeDAIWM8rspBNb8gLB9d12Gd7GNIxmAUrYbwcJ3D9fe/6K//fvd89XR79XSLk4DbK4eYYquqtY+Fay5pfjuNB8zFA3FTkxUZX9u3ADIGN1Jmu2hFu7FyKGVD451gwfBrgNgVtuKBohyGZIQJhp+E7P1guJFCbJZwyMjVe6FPRrpDrUKMwDPmX9iiVCsy2YDCYsDHj/uf4kJmX7m0oxwa2WiJDCsJkQUXW/GoejA+OBnmIaawcgTLRgky9Hyki0eacuhjKj4ZVu3Myj/OrWQjLA+1mq5OSVFj8nT9uBgrx6yYIn4UPMj4579/v/tB4EPgMat5sMxSdu5jYZjWTRz4/sf+/PptlUrPgjuxrNXCEbAM2jaEj7E4Mer9D+9/1yDytX0LK1teLx6vPx+uPx80Q5OQkMqKFH1A6UeKP79+H35O/Mv4Y8pwIwsuWRPqNeY59A/cAAvBFQaIpPeoQTg0U6Iy2Tg862IsjiIilhBZL1LEQwVHTMKhCSh9wTBsklJClJXLrJpFU9C2/F5ZJzJM+ChhoXAIYopYNgxDyZQQEyAe8ZHlvG3NaPiO0HDEz3CIlb+Bu6SkHdDKIYsp+tkqGR9zxSMmLa0RVmJ2RceToeEDvKBtuVqhNQuHIKZkyYZYPMAjC5WDZg0HYKmSKxuRmUdYwRK0ngP/jJ4qbxeP3G8NGlYi1wLu1z1M+aOHIacdS885ThMA+MZGwhGUcEwZ+7l8AKYdVA4a4YgKKAwuw2rlcnsz/sTH/QufIcJBW5ydloM1RYJG5aCt5uYMy01Ip8+BIi9oYrVCIxwKk009TZGEubKB8P0f4YgILosNKNBwRH4d9XrxOIbg6B89DPm4kaBqBfBg76IiEbn44VzjSqh5ZYRvvAATDs2yLFYrtIJwCNKOXPEQyAb4+WZUDhoAHDEbcrLEIybbCF6KC60csoI2ng8ZGfhnZsrhACxYjo5ZG3eJL1WazTmy9soy5whNO8RTpcqTuyZqhjjVEMSU+L0/LVcrriczuZ4p1YJyxKQdmu9ZnPhQkhGTiuq3rEYrh6agFfNhGGL0B1fKepGyn7RGWNE/ZPojiAcHIKf3qE04ZOKh/xJ/fEr1X0EZf0x5PKEsoGRtQ9d+ZW9yAPtc/2oeu/EU2UQh0atF5G5pkzMyMlefz13eYfjWgf5In4DDoxKRyUbtsDKrZhErpMcKsf6rEQY/toKnSTVmeQzo7ZAa7RI8FvgnNBqSoZENfaBPq1b06VUVPvTtzFpbaQOHbDZMPOdR6H2tmrecyooUw+Paqk6fl+Cj0PtvfeEIFg98PpRkpMvGCmcjtWzXwiE5hVo4oxeMxPLVK6xoxKOZEGMYSnJlAyXn0C8v7fORhUj/1hoycM5sPdtsNrvdzvCKYn5NnJKVA1rdV+wEc9noug6uWlGG23gJsRIMnFTDUTnSxeNo/mEuJB7Xx5GNvXJgHftkuN96MMtu9XCP1cgKO8Dj4V2UQ8myh5uOhpiJ46r534AuO73Bous6Xzig+DApdz3yXD0ZxeDQEx0gsxNBcS18lN30e/GNLxwl+EAozQDJiIDDio/2ENH3y/tlWXHzHOK1SQffoc0BIJDhbe5w6NFujA9DLfRe1O0eVgw1sHqIsWp/zNsX48KKycbJ0hJSi4ygsGIbLPt8VEGk31QTMsIsKKwM+qYHv08GbJSxbaTffFdaKevaQ1hEzBsWTEYOHK58ICDi0Z54MtLg8OgtAiJObUghIxMOvz7HU+J6xywykuFw7fnRQsZw2Lyvn05GPhwB/T9R7s4aS6vrVCEDAo5ILxjOi3hHq3QyUODIcscsVsIyXAQs4OCA8gs9sELbmnDwyDLfHQ/4bAApx2IlBLO/iJualiYhyE8ConKMyWhSQsA7iJWQLgeREp0qAEdjiBTqSBk4GkCkXOOLwVHUy0WZLgnH0UIG0On4LWwWDuQBqI5FI3AcHYyUIUFoA+GYPUJ+gxR8O8LhPnLi8TO/IOEoAIrY2v7qB+7YJycbj6IAlwUuJFivFmmLXTIyy87pAhrhoBEOGuGgEQ4a4aARDny73N5cbm/oB8JBIxw0wkEjHDTCQSMcNGRb0wV9+7h/oROoHLRpytF1HR1BG9v/M2HdBoAnCzEAAAAASUVORK5CYII=">
+<link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAIAAACyr5FlAAAIbElEQVR42u2dP07kShDGBzQHeBd41oYTgETwsk24AwkpKQfgEBxgUlIS7kBCtgESHADNXmCP8IKRRpY9zNr196v2VyJAaLC7q3/+qqqnu3222WxWNNoxW69Wq91uR0fQBtZ13Tm9QPvOCAeNcPzNLrc3l9sb+oFw0AgHjXDQCAeNcNAIBw3f1nTB3j7uX+gEKgeNcNAIB41w0AgHjXDQWMri2vXnw9x/eb14JBxEYepFmsdlvUwgBOM6vmD/L02CcrbZbJpZQ/odEE4jF3y7YOu6rgU4jg5S8AghtIFwnBoSkMHAbNWC4MAfgOqIlISjXBpYNG8tBkfp6qBc48vA0UzRWKgjBeBoci6hRKeg4Wh+igm8g7hwHBzX/BQ1bE9BN1Ivh4x+H02+ALI1LOVYFBbgfcdSjiWTgSkhKMoRT8bV0+30D7/fPS/tCYFISMPcMYuGXFYQEMmHw9sLJ4CYNcBW1ynERzIcfv0/OpaGo+h9fQQ+MuFw6vlg2AJyBdc7JvKRBod5n+OZCGtDFh85cNj2FgEL7/ak8JEAhx8Z6Vi4Niyej2g4DHsIi4VfI4P5CIXDqm8lsHBqcCQfCdPnVmS83z2XIGPQVOVEXHBOGgTHHnlDMlbVzJaPmO9fIsKKnozSWHj0xeRhyw8resZbIsNQQgL0IyisiBlvjAwrPmKSD9+wolS/ve9awsK2g67BxbeUxSfjx/3PKR/72r4tkA9HOJQVuR8ZE4GIBEXTWb+ZD3c4cMg4ysTEkdb8bxgfZeDAIWM8rspBNb8gLB9d12Gd7GNIxmAUrYbwcJ3D9fe/6K//fvd89XR79XSLk4DbK4eYYquqtY+Fay5pfjuNB8zFA3FTkxUZX9u3ADIGN1Jmu2hFu7FyKGVD451gwfBrgNgVtuKBohyGZIQJhp+E7P1guJFCbJZwyMjVe6FPRrpDrUKMwDPmX9iiVCsy2YDCYsDHj/uf4kJmX7m0oxwa2WiJDCsJkQUXW/GoejA+OBnmIaawcgTLRgky9Hyki0eacuhjKj4ZVu3Myj/OrWQjLA+1mq5OSVFj8nT9uBgrx6yYIn4UPMj4579/v/tB4EPgMat5sMxSdu5jYZjWTRz4/sf+/PptlUrPgjuxrNXCEbAM2jaEj7E4Mer9D+9/1yDytX0LK1teLx6vPx+uPx80Q5OQkMqKFH1A6UeKP79+H35O/Mv4Y8pwIwsuWRPqNeY59A/cAAvBFQaIpPeoQTg0U6Iy2Tg862IsjiIilhBZL1LEQwVHTMKhCSh9wTBsklJClJXLrJpFU9C2/F5ZJzJM+ChhoXAIYopYNgxDyZQQEyAe8ZHlvG3NaPiO0HDEz3CIlb+Bu6SkHdDKIYsp+tkqGR9zxSMmLa0RVmJ2RceToeEDvKBtuVqhNQuHIKZkyYZYPMAjC5WDZg0HYKmSKxuRmUdYwRK0ngP/jJ4qbxeP3G8NGlYi1wLu1z1M+aOHIacdS885ThMA+MZGwhGUcEwZ+7l8AKYdVA4a4YgKKAwuw2rlcnsz/sTH/QufIcJBW5ydloM1RYJG5aCt5uYMy01Ip8+BIi9oYrVCIxwKk009TZGEubKB8P0f4YgILosNKNBwRH4d9XrxOIbg6B89DPm4kaBqBfBg76IiEbn44VzjSqh5ZYRvvAATDs2yLFYrtIJwCNKOXPEQyAb4+WZUDhoAHDEbcrLEIybbCF6KC60csoI2ng8ZGfhnZsrhACxYjo5ZG3eJL1WazTmy9soy5whNO8RTpcqTuyZqhjjVEMSU+L0/LVcrriczuZ4p1YJyxKQdmu9ZnPhQkhGTiuq3rEYrh6agFfNhGGL0B1fKepGyn7RGWNE/ZPojiAcHIKf3qE04ZOKh/xJ/fEr1X0EZf0x5PKEsoGRtQ9d+ZW9yAPtc/2oeu/EU2UQh0atF5G5pkzMyMlefz13eYfjWgf5In4DDoxKRyUbtsDKrZhErpMcKsf6rEQY/toKnSTVmeQzo7ZAa7RI8FvgnNBqSoZENfaBPq1b06VUVPvTtzFpbaQOHbDZMPOdR6H2tmrecyooUw+Paqk6fl+Cj0PtvfeEIFg98PpRkpMvGCmcjtWzXwiE5hVo4oxeMxPLVK6xoxKOZEGMYSnJlAyXn0C8v7fORhUj/1hoycM5sPdtsNrvdzvCKYn5NnJKVA1rdV+wEc9noug6uWlGG23gJsRIMnFTDUTnSxeNo/mEuJB7Xx5GNvXJgHftkuN96MMtu9XCP1cgKO8Dj4V2UQ8myh5uOhpiJ46r534AuO73Bous6Xzig+DApdz3yXD0ZxeDQEx0gsxNBcS18lN30e/GNLxwl+EAozQDJiIDDio/2ENH3y/tlWXHzHOK1SQffoc0BIJDhbe5w6NFujA9DLfRe1O0eVgw1sHqIsWp/zNsX48KKycbJ0hJSi4ygsGIbLPt8VEGk31QTMsIsKKwM+qYHv08GbJSxbaTffFdaKevaQ1hEzBsWTEYOHK58ICDi0Z54MtLg8OgtAiJObUghIxMOvz7HU+J6xywykuFw7fnRQsZw2Lyvn05GPhwB/T9R7s4aS6vrVCEDAo5ILxjOi3hHq3QyUODIcscsVsIyXAQs4OCA8gs9sELbmnDwyDLfHQ/4bAApx2IlBLO/iJualiYhyE8ConKMyWhSQsA7iJWQLgeREp0qAEdjiBTqSBk4GkCkXOOLwVHUy0WZLgnH0UIG0On4LWwWDuQBqI5FI3AcHYyUIUFoA+GYPUJ+gxR8O8LhPnLi8TO/IOEoAIrY2v7qB+7YJycbj6IAlwUuJFivFmmLXTIyy87pAhrhoBEOGuGgEQ4a4aARDny73N5cbm/oB8JBIxw0wkEjHDTCQSMcNGRb0wV9+7h/oROoHLRpytF1HR1BG9v/M2HdBoAnCzEAAAAASUVORK5CYII=">
+<title>tap.localizer</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #0a0a0a;
+    --panel: #141414;
+    --panel-2: #1c1c1c;
+    --line: #2a2a2a;
+    --line-2: #3a3a3a;
+    --text: #d4d4d4;
+    --text-dim: #6b6b6b;
+    --text-bright: #f0f0f0;
+    --trace-x: #4ade80;
+    --trace-y: #fbbf24;
+    --trace-z: #60a5fa;
+    --accent: #4ade80;
+    --warn: #f87171;
+    --grid: #1a2419;
+  }
+
+  * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+  html, body {
+    margin: 0; padding: 0; height: 100%;
+    background: var(--bg); color: var(--text);
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 13px; line-height: 1.4;
+    overscroll-behavior: none;
+    -webkit-user-select: none; user-select: none;
+    touch-action: manipulation;
+  }
+  body {
+    display: flex; flex-direction: column;
+    min-height: 100vh; min-height: 100dvh;
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
+
+  header {
+    border-bottom: 1px solid var(--line);
+    padding: 10px 14px;
+    display: flex; justify-content: space-between; align-items: center;
+    background: var(--panel);
+  }
+  .brand { font-weight: 700; letter-spacing: 0.04em; color: var(--text-bright); }
+  .brand .dim { color: var(--text-dim); font-weight: 400; }
+  .status { display: flex; gap: 10px; align-items: center; font-size: 11px; color: var(--text-dim); }
+  .led {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: #333; display: inline-block;
+    transition: background 0.15s, box-shadow 0.15s;
+  }
+  .led.on { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+  .led.warn { background: var(--warn); box-shadow: 0 0 8px var(--warn); }
+  .led.pulse { animation: pulse 1.2s ease-in-out infinite; }
+  @keyframes pulse {
+    0%, 100% { box-shadow: 0 0 4px currentColor; opacity: 0.6; }
+    50% { box-shadow: 0 0 10px currentColor; opacity: 1; }
+  }
+
+  main { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+
+  .phase { display: none; flex-direction: column; flex: 1; }
+  .phase.active { display: flex; }
+
+  /* === PERMISSION PHASE === */
+  #permission { justify-content: center; align-items: center; padding: 24px; text-align: center; gap: 18px; }
+  #permission h1 {
+    margin: 0; font-size: 18px; font-weight: 500; color: var(--text-bright);
+    letter-spacing: -0.01em;
+  }
+  #permission .blurb { color: var(--text-dim); max-width: 320px; font-size: 12px; }
+  .primary-btn {
+    background: transparent; color: var(--accent);
+    border: 1px solid var(--accent);
+    padding: 14px 24px; font: inherit; font-weight: 500;
+    letter-spacing: 0.05em; text-transform: uppercase; font-size: 12px;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .primary-btn:active { background: var(--accent); color: var(--bg); }
+  .err { color: var(--warn); font-size: 11px; margin-top: 8px; }
+
+  /* === SCOPE === */
+  .scope {
+    height: 140px; background: #050805;
+    border-bottom: 1px solid var(--line);
+    position: relative; overflow: hidden;
+  }
+  .scope canvas { width: 100%; height: 100%; display: block; }
+  .scope-overlay {
+    position: absolute; top: 6px; left: 8px; right: 8px;
+    display: flex; justify-content: space-between;
+    font-size: 10px; color: var(--text-dim); pointer-events: none;
+  }
+  .scope-legend { display: flex; gap: 10px; }
+  .scope-legend span { display: flex; align-items: center; gap: 4px; }
+  .scope-legend i { width: 8px; height: 1px; display: inline-block; }
+  .scope-readout { text-align: right; }
+  .scope-readout .val { color: var(--text); }
+
+  /* === COLLECT === */
+  .section-label {
+    padding: 10px 14px 6px; font-size: 10px; letter-spacing: 0.15em;
+    color: var(--text-dim); text-transform: uppercase;
+    display: flex; justify-content: space-between; align-items: baseline;
+  }
+  .section-label .meta { font-size: 10px; color: var(--text-dim); }
+
+  .zone-grid {
+    display: grid; grid-template-columns: 1fr 1fr 1fr;
+    gap: 1px; background: var(--line); padding: 0 0 1px 0;
+  }
+  .zone-btn {
+    background: var(--panel); border: none; color: var(--text);
+    padding: 14px 8px; font: inherit; font-size: 11px;
+    cursor: pointer; text-align: left;
+    display: flex; flex-direction: column; gap: 4px;
+    transition: background 0.1s;
+    letter-spacing: 0.04em;
+  }
+  .zone-btn:active { background: var(--panel-2); }
+  .zone-btn.armed {
+    background: var(--panel-2);
+    box-shadow: inset 3px 0 0 var(--accent);
+    color: var(--text-bright);
+  }
+  .zone-btn .zone-name { text-transform: uppercase; font-size: 10px; color: var(--text-dim); letter-spacing: 0.1em; }
+  .zone-btn.armed .zone-name { color: var(--accent); }
+  .zone-btn .zone-count { font-size: 16px; font-weight: 500; }
+
+  .controls {
+    display: flex; gap: 1px; background: var(--line); margin-top: 1px;
+  }
+  .ctrl-btn {
+    flex: 1; background: var(--panel); border: none; color: var(--text);
+    padding: 12px; font: inherit; font-size: 11px; cursor: pointer;
+    letter-spacing: 0.08em; text-transform: uppercase;
+  }
+  .ctrl-btn:active { background: var(--panel-2); }
+  .ctrl-btn.primary { color: var(--accent); }
+  .ctrl-btn.primary:disabled { color: var(--text-dim); }
+  .ctrl-btn.warn { color: var(--warn); }
+  .ctrl-btn:disabled { cursor: not-allowed; opacity: 0.5; }
+
+  .last-capture {
+    padding: 10px 14px; font-size: 11px; color: var(--text-dim);
+    border-top: 1px solid var(--line); background: var(--panel);
+    display: flex; justify-content: space-between; align-items: center;
+    min-height: 36px;
+  }
+  .last-capture .val { color: var(--text); }
+  .last-capture .flash { color: var(--accent); }
+
+  .settings-row {
+    display: flex; gap: 12px; padding: 10px 14px;
+    font-size: 11px; color: var(--text-dim);
+    border-top: 1px solid var(--line);
+    align-items: center; flex-wrap: wrap;
+  }
+  .settings-row label { display: flex; align-items: center; gap: 6px; }
+  .settings-row input[type=range] { width: 100px; }
+  .settings-row .val { color: var(--text); min-width: 30px; }
+
+  /* === INFER === */
+  #infer { padding: 0; }
+  .pred-panel {
+    flex: 1; display: flex; flex-direction: column;
+    justify-content: center; align-items: center;
+    padding: 24px; gap: 18px; text-align: center;
+    background:
+      radial-gradient(ellipse at center, #0d1410 0%, var(--bg) 70%);
+  }
+  .pred-label { font-size: 10px; letter-spacing: 0.2em; color: var(--text-dim); text-transform: uppercase; }
+  .pred-zone {
+    font-size: 48px; font-weight: 300; letter-spacing: -0.02em;
+    color: var(--text-bright); text-transform: uppercase;
+    min-height: 60px; line-height: 1;
+    transition: color 0.2s, text-shadow 0.2s;
+  }
+  .pred-zone.fresh {
+    color: var(--accent); text-shadow: 0 0 20px rgba(74, 222, 128, 0.4);
+  }
+  .pred-stats {
+    display: grid; grid-template-columns: 1fr 1fr;
+    gap: 1px; background: var(--line); width: 100%; max-width: 320px;
+  }
+  .stat { background: var(--panel); padding: 10px 14px; text-align: left; }
+  .stat .k { font-size: 10px; color: var(--text-dim); letter-spacing: 0.1em; text-transform: uppercase; }
+  .stat .v { font-size: 14px; color: var(--text); font-variant-numeric: tabular-nums; }
+  .pred-history {
+    display: flex; gap: 4px; flex-wrap: wrap; justify-content: center;
+    max-width: 340px; min-height: 18px;
+  }
+  .pred-history span {
+    font-size: 10px; padding: 2px 6px; background: var(--panel-2);
+    color: var(--text-dim); border: 1px solid var(--line);
+    text-transform: uppercase; letter-spacing: 0.05em;
+  }
+
+  /* utility */
+  .hidden { display: none !important; }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="brand">tap.localizer <span class="dim">/ v0.1</span></div>
+  <div class="status">
+    <span id="rate-display">— Hz</span>
+    <span id="status-led" class="led"></span>
+  </div>
+</header>
+
+<main>
+
+  <!-- PHASE 1: PERMISSION -->
+  <section id="permission" class="phase active">
+    <h1>tap localization via accelerometer</h1>
+    <p class="blurb">
+      Train a classifier to recognize where on the phone you're tapping —
+      screen, back, edges — purely from motion data. iOS requires explicit
+      permission for the DeviceMotion API.
+    </p>
+    <button id="grant-btn" class="primary-btn">grant motion access</button>
+    <div id="grant-err" class="err"></div>
+  </section>
+
+  <!-- PHASE 2: COLLECT/TRAIN -->
+  <section id="collect" class="phase">
+    <div class="scope">
+      <canvas id="scope-canvas"></canvas>
+      <div class="scope-overlay">
+        <div class="scope-legend">
+          <span><i style="background:var(--trace-x)"></i>x</span>
+          <span><i style="background:var(--trace-y)"></i>y</span>
+          <span><i style="background:var(--trace-z)"></i>z</span>
+        </div>
+        <div class="scope-readout">
+          <span class="val" id="scope-peak">0.00</span> m/s²
+        </div>
+      </div>
+    </div>
+
+    <div class="section-label">
+      <span>training zones / arm + tap</span>
+      <span class="meta" id="total-count">0 samples</span>
+    </div>
+
+    <div class="zone-grid" id="zone-grid">
+      <!-- buttons injected -->
+    </div>
+
+    <div class="controls">
+      <button class="ctrl-btn warn" id="clear-btn">clear all</button>
+      <button class="ctrl-btn primary" id="infer-btn" disabled>inference →</button>
+    </div>
+
+    <div class="last-capture" id="last-capture">
+      <span>last capture: <span class="val" id="last-zone">—</span></span>
+      <span>peak: <span class="val" id="last-peak">—</span> m/s²</span>
+    </div>
+
+    <div class="settings-row">
+      <label>threshold <input type="range" id="thr-input" min="1" max="6" step="0.1" value="2.5"><span class="val" id="thr-val">2.5</span></label>
+      <label>cooldown <input type="range" id="cd-input" min="100" max="800" step="50" value="350"><span class="val" id="cd-val">350</span>ms</label>
+    </div>
+  </section>
+
+  <!-- PHASE 3: INFER -->
+  <section id="infer" class="phase">
+    <div class="scope">
+      <canvas id="scope-canvas-2"></canvas>
+      <div class="scope-overlay">
+        <div class="scope-legend">
+          <span><i style="background:var(--trace-x)"></i>x</span>
+          <span><i style="background:var(--trace-y)"></i>y</span>
+          <span><i style="background:var(--trace-z)"></i>z</span>
+        </div>
+        <div class="scope-readout">
+          <span class="val" id="scope-peak-2">0.00</span> m/s²
+        </div>
+      </div>
+    </div>
+
+    <div class="pred-panel">
+      <div class="pred-label">predicted zone</div>
+      <div class="pred-zone" id="pred-zone">tap any surface</div>
+      <div class="pred-stats">
+        <div class="stat"><div class="k">confidence</div><div class="v" id="pred-conf">—</div></div>
+        <div class="stat"><div class="k">nn distance</div><div class="v" id="pred-dist">—</div></div>
+        <div class="stat"><div class="k">peak g</div><div class="v" id="pred-peak">—</div></div>
+        <div class="stat"><div class="k">samples</div><div class="v" id="pred-samples">—</div></div>
+      </div>
+      <div class="section-label" style="padding: 4px 0 0; justify-content: center;">recent</div>
+      <div class="pred-history" id="pred-history"></div>
+    </div>
+
+    <div class="controls">
+      <button class="ctrl-btn" id="back-to-train">← add training samples</button>
+    </div>
+  </section>
+
+</main>
+
+<script>
+// ============================================================================
+// CONFIG
+// ============================================================================
+const ZONES = [
+  { id: 'front',  label: 'screen' },
+  { id: 'back',   label: 'back' },
+  { id: 'top',    label: 'top edge' },
+  { id: 'bottom', label: 'bot edge' },
+  { id: 'left',   label: 'left edge' },
+  { id: 'right',  label: 'right edge' },
+];
+
+const BUF_SIZE = 96;
+const PRE_SAMPLES = 6;
+const POST_SAMPLES = 22;
+const WIN_SIZE = PRE_SAMPLES + POST_SAMPLES;  // 28 samples ≈ 466ms @ 60Hz
+const KNN_K = 5;
+
+let TAP_THRESHOLD = 2.5;
+let TAP_COOLDOWN = 350;
+
+// ============================================================================
+// STATE
+// ============================================================================
+const samples = Object.fromEntries(ZONES.map(z => [z.id, []]));
+let armedZone = null;
+let mode = 'collect';   // 'collect' | 'infer'
+let buffer = [];
+let lastTapTime = 0;
+let pendingTap = null;
+let rateEMA = 0;
+let lastEventT = 0;
+let predHistory = [];
+
+const $ = (id) => document.getElementById(id);
+
+// ============================================================================
+// DEVICEMOTION
+// ============================================================================
+async function grantMotion() {
+  const Cls = window.DeviceMotionEvent;
+  if (!Cls) {
+    $('grant-err').textContent = 'DeviceMotionEvent not supported on this browser.';
+    return;
+  }
+  try {
+    if (typeof Cls.requestPermission === 'function') {
+      const resp = await Cls.requestPermission();
+      if (resp !== 'granted') {
+        $('grant-err').textContent = 'Permission denied. Reload to try again.';
+        return;
+      }
+    }
+    window.addEventListener('devicemotion', onMotion);
+    enterCollect();
+  } catch (err) {
+    $('grant-err').textContent = 'Error requesting permission: ' + err.message;
+  }
+}
+
+function onMotion(e) {
+  const a = e.acceleration;
+  if (!a || a.x === null || a.x === undefined) {
+    // Fallback: gravity-only sensor (uncommon but exists)
+    $('grant-err').textContent = 'Sensor reports gravity only — tap detection will not work.';
+    return;
+  }
+  const t = e.timeStamp;
+  const x = a.x || 0, y = a.y || 0, z = a.z || 0;
+  const mag = Math.hypot(x, y, z);
+
+  buffer.push({ t, x, y, z, mag });
+  if (buffer.length > BUF_SIZE) buffer.shift();
+
+  // Rate estimate (EMA)
+  if (lastEventT > 0) {
+    const dt = t - lastEventT;
+    if (dt > 0) {
+      const inst = 1000 / dt;
+      rateEMA = rateEMA === 0 ? inst : (rateEMA * 0.9 + inst * 0.1);
+    }
+  }
+  lastEventT = t;
+
+  // Pending tap → wait until we have enough post-peak samples
+  if (pendingTap) {
+    if (t - pendingTap.t >= POST_SAMPLES * 16) {
+      extractAndHandle(pendingTap.t);
+      pendingTap = null;
+    }
+  } else if (mag > TAP_THRESHOLD && (t - lastTapTime) > TAP_COOLDOWN) {
+    pendingTap = { t, mag };
+    lastTapTime = t;
+  }
+}
+
+function extractAndHandle(peakT) {
+  // Find peak index in buffer
+  let peakIdx = -1;
+  for (let i = buffer.length - 1; i >= 0; i--) {
+    if (buffer[i].t === peakT) { peakIdx = i; break; }
+  }
+  if (peakIdx < 0) return;
+
+  const startIdx = peakIdx - PRE_SAMPLES;
+  const endIdx = peakIdx + POST_SAMPLES;
+  if (startIdx < 0 || endIdx >= buffer.length) return;
+
+  const window = buffer.slice(startIdx, endIdx);
+  const feat = featurize(window);
+  const peakMag = window.reduce((m, s) => Math.max(m, s.mag), 0);
+  handleTap(feat, peakMag);
+}
+
+// ============================================================================
+// FEATURES
+// ============================================================================
+function featurize(window) {
+  // Align by peak, peak-normalize, flatten 3 axes
+  const peakIdx = window.reduce((bi, s, i) => s.mag > window[bi].mag ? i : bi, 0);
+  const peakMag = window[peakIdx].mag || 1;
+  const feats = [];
+  for (const s of window) {
+    feats.push(s.x / peakMag, s.y / peakMag, s.z / peakMag);
+  }
+  // Append derived: time-to-peak, decay ratio
+  const ttp = peakIdx / window.length;
+  const earlyEnergy = window.slice(0, peakIdx + 1).reduce((s, p) => s + p.mag * p.mag, 0);
+  const lateEnergy = window.slice(peakIdx + 1).reduce((s, p) => s + p.mag * p.mag, 0) || 1;
+  const decay = Math.log(earlyEnergy / lateEnergy);
+  feats.push(ttp, decay);
+  return feats;
+}
+
+function euclidean(a, b) {
+  let s = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) s += (a[i] - b[i]) ** 2;
+  return Math.sqrt(s);
+}
+
+// ============================================================================
+// CLASSIFY
+// ============================================================================
+function classify(feat) {
+  const all = [];
+  for (const z of ZONES) {
+    for (const s of samples[z.id]) {
+      all.push({ zone: z.id, d: euclidean(feat, s) });
+    }
+  }
+  if (all.length === 0) return null;
+  all.sort((a, b) => a.d - b.d);
+  const k = Math.min(KNN_K, all.length);
+  const votes = {};
+  for (let i = 0; i < k; i++) {
+    const w = 1 / (1 + all[i].d);
+    votes[all[i].zone] = (votes[all[i].zone] || 0) + w;
+  }
+  const ranked = Object.entries(votes).sort((a, b) => b[1] - a[1]);
+  const total = ranked.reduce((s, [, v]) => s + v, 0);
+  return {
+    zone: ranked[0][0],
+    conf: ranked[0][1] / total,
+    nearest: all[0].d,
+  };
+}
+
+// ============================================================================
+// TAP HANDLING
+// ============================================================================
+function handleTap(feat, peakMag) {
+  if (mode === 'collect') {
+    if (!armedZone) return flashLastCapture('no zone armed — peak ' + peakMag.toFixed(2), false);
+    samples[armedZone].push(feat);
+    renderZones();
+    flashLastCapture(armedZone, true, peakMag);
+    $('infer-btn').disabled = !canInfer();
+  } else if (mode === 'infer') {
+    const pred = classify(feat);
+    if (pred) renderPrediction(pred, peakMag);
+  }
+}
+
+function canInfer() {
+  // Need at least 3 samples in at least 2 zones
+  const counts = ZONES.map(z => samples[z.id].length);
+  const nonEmpty = counts.filter(c => c >= 3).length;
+  return nonEmpty >= 2;
+}
+
+// ============================================================================
+// UI
+// ============================================================================
+function buildZoneButtons() {
+  const grid = $('zone-grid');
+  grid.innerHTML = '';
+  for (const z of ZONES) {
+    const btn = document.createElement('button');
+    btn.className = 'zone-btn';
+    btn.dataset.zone = z.id;
+    btn.innerHTML = `
+      <span class="zone-name">${z.label}</span>
+      <span class="zone-count" data-count="${z.id}">0</span>
+    `;
+    btn.addEventListener('click', () => armZone(z.id));
+    grid.appendChild(btn);
+  }
+}
+
+function armZone(zid) {
+  armedZone = (armedZone === zid) ? null : zid;
+  renderZones();
+}
+
+function renderZones() {
+  let total = 0;
+  for (const z of ZONES) {
+    const btn = document.querySelector(`.zone-btn[data-zone="${z.id}"]`);
+    const countEl = document.querySelector(`[data-count="${z.id}"]`);
+    if (btn) btn.classList.toggle('armed', armedZone === z.id);
+    if (countEl) countEl.textContent = samples[z.id].length;
+    total += samples[z.id].length;
+  }
+  $('total-count').textContent = total + ' samples';
+}
+
+function flashLastCapture(zoneOrMsg, ok, peakMag) {
+  const z = $('last-zone'), p = $('last-peak');
+  z.textContent = zoneOrMsg;
+  z.classList.toggle('flash', ok);
+  if (peakMag !== undefined) p.textContent = peakMag.toFixed(2);
+  setTimeout(() => z.classList.remove('flash'), 400);
+  setLed(true);
+  setTimeout(() => setLed(false), 100);
+}
+
+function setLed(active) {
+  const led = $('status-led');
+  led.classList.toggle('on', active);
+}
+
+function renderPrediction(pred, peakMag) {
+  const el = $('pred-zone');
+  const zLabel = ZONES.find(z => z.id === pred.zone)?.label || pred.zone;
+  el.textContent = zLabel;
+  el.classList.add('fresh');
+  setTimeout(() => el.classList.remove('fresh'), 500);
+
+  $('pred-conf').textContent = (pred.conf * 100).toFixed(0) + '%';
+  $('pred-dist').textContent = pred.nearest.toFixed(3);
+  $('pred-peak').textContent = peakMag.toFixed(2);
+  $('pred-samples').textContent = ZONES.reduce((s, z) => s + samples[z.id].length, 0);
+
+  predHistory.unshift(zLabel);
+  if (predHistory.length > 8) predHistory.pop();
+  $('pred-history').innerHTML = predHistory.map(z => `<span>${z}</span>`).join('');
+}
+
+// ============================================================================
+// PHASE TRANSITIONS
+// ============================================================================
+function showPhase(name) {
+  document.querySelectorAll('.phase').forEach(el => el.classList.remove('active'));
+  $(name).classList.add('active');
+}
+
+function enterCollect() {
+  mode = 'collect';
+  showPhase('collect');
+  startScope($('scope-canvas'), $('scope-peak'));
+}
+
+function enterInfer() {
+  if (!canInfer()) return;
+  mode = 'infer';
+  predHistory = [];
+  $('pred-zone').textContent = 'tap any surface';
+  $('pred-conf').textContent = '—';
+  $('pred-dist').textContent = '—';
+  $('pred-peak').textContent = '—';
+  $('pred-samples').textContent = ZONES.reduce((s, z) => s + samples[z.id].length, 0);
+  $('pred-history').innerHTML = '';
+  showPhase('infer');
+  startScope($('scope-canvas-2'), $('scope-peak-2'));
+}
+
+// ============================================================================
+// OSCILLOSCOPE
+// ============================================================================
+let scopeCanvas, scopeCtx, scopePeakEl, scopeRAF;
+function startScope(canvas, peakEl) {
+  if (scopeRAF) cancelAnimationFrame(scopeRAF);
+  scopeCanvas = canvas; scopePeakEl = peakEl;
+  resizeScope();
+  loopScope();
+}
+function resizeScope() {
+  if (!scopeCanvas) return;
+  const dpr = window.devicePixelRatio || 1;
+  const rect = scopeCanvas.getBoundingClientRect();
+  scopeCanvas.width = rect.width * dpr;
+  scopeCanvas.height = rect.height * dpr;
+  scopeCtx = scopeCanvas.getContext('2d');
+  scopeCtx.scale(dpr, dpr);
+}
+function loopScope() {
+  drawScope();
+  scopeRAF = requestAnimationFrame(loopScope);
+}
+function drawScope() {
+  if (!scopeCtx) return;
+  const w = scopeCanvas.clientWidth, h = scopeCanvas.clientHeight;
+  const ctx = scopeCtx;
+  ctx.clearRect(0, 0, w, h);
+
+  // Grid
+  ctx.strokeStyle = 'rgba(74, 222, 128, 0.08)';
+  ctx.lineWidth = 1;
+  for (let i = 1; i < 4; i++) {
+    ctx.beginPath();
+    ctx.moveTo(0, h * i / 4); ctx.lineTo(w, h * i / 4); ctx.stroke();
+  }
+  for (let i = 1; i < 8; i++) {
+    ctx.beginPath();
+    ctx.moveTo(w * i / 8, 0); ctx.lineTo(w * i / 8, h); ctx.stroke();
+  }
+  // Zero line
+  ctx.strokeStyle = 'rgba(74, 222, 128, 0.25)';
+  ctx.beginPath(); ctx.moveTo(0, h / 2); ctx.lineTo(w, h / 2); ctx.stroke();
+
+  if (buffer.length < 2) return;
+
+  const yScale = h / 2 / 8;  // ±8 m/s² fits
+  const stride = w / (BUF_SIZE - 1);
+
+  const start = Math.max(0, buffer.length - BUF_SIZE);
+  const data = buffer.slice(start);
+
+  function plot(getter, color) {
+    ctx.strokeStyle = color; ctx.lineWidth = 1.2;
+    ctx.beginPath();
+    for (let i = 0; i < data.length; i++) {
+      const x = i * stride;
+      const y = h / 2 - getter(data[i]) * yScale;
+      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }
+  plot(s => s.x, 'rgba(74, 222, 128, 0.9)');
+  plot(s => s.y, 'rgba(251, 191, 36, 0.85)');
+  plot(s => s.z, 'rgba(96, 165, 250, 0.85)');
+
+  // Threshold lines
+  ctx.strokeStyle = 'rgba(248, 113, 113, 0.4)';
+  ctx.setLineDash([2, 3]);
+  ctx.beginPath();
+  ctx.moveTo(0, h / 2 - TAP_THRESHOLD * yScale);
+  ctx.lineTo(w, h / 2 - TAP_THRESHOLD * yScale);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(0, h / 2 + TAP_THRESHOLD * yScale);
+  ctx.lineTo(w, h / 2 + TAP_THRESHOLD * yScale);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // Peak readout
+  const recent = buffer.slice(-12);
+  const peak = recent.reduce((m, s) => Math.max(m, s.mag), 0);
+  if (scopePeakEl) scopePeakEl.textContent = peak.toFixed(2);
+  $('rate-display').textContent = rateEMA.toFixed(0) + ' Hz';
+}
+
+window.addEventListener('resize', () => resizeScope());
+
+// ============================================================================
+// BIND
+// ============================================================================
+$('grant-btn').addEventListener('click', grantMotion);
+$('clear-btn').addEventListener('click', () => {
+  if (!confirm('Clear all training samples?')) return;
+  for (const z of ZONES) samples[z.id] = [];
+  armedZone = null;
+  renderZones();
+  $('infer-btn').disabled = true;
+});
+$('infer-btn').addEventListener('click', enterInfer);
+$('back-to-train').addEventListener('click', enterCollect);
+
+$('thr-input').addEventListener('input', (e) => {
+  TAP_THRESHOLD = parseFloat(e.target.value);
+  $('thr-val').textContent = TAP_THRESHOLD.toFixed(1);
+});
+$('cd-input').addEventListener('input', (e) => {
+  TAP_COOLDOWN = parseInt(e.target.value);
+  $('cd-val').textContent = TAP_COOLDOWN;
+});
+
+buildZoneButtons();
+renderZones();
+
+// Allow re-grant if user dismissed
+if (window.DeviceMotionEvent && typeof window.DeviceMotionEvent.requestPermission !== 'function') {
+  // Non-iOS: try to attach immediately
+  // (will only fire once user moves the device, which is fine)
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
Accelerometer-driven phone-surface tap zone classifier. Trains on six zones (screen, back, four edges) via DeviceMotion impulses, then classifies live taps with k-NN over peak-normalized acceleration windows + decay features.

**iOS homescreen install**: `apple-mobile-web-app-capable`, status-bar styling, inline base64 `apple-touch-icon` (phosphor-green oscilloscope target), short homescreen title (`tap.loc`).

**Expected limits**: iOS Safari caps DeviceMotion at ~60Hz, so zone resolution is coarse. Edge zones should separate cleanly (dominant axis differs); front/back may collapse — that's the experiment.

No build step, no external libs (one Google Fonts request, fails open).

🤖 Generated with [Claude](https://claude.com)