### PR TITLE
tap-localizer v0.2

### DIFF
--- a/fun-and-games/tap-localizer.html
+++ b/fun-and-games/tap-localizer.html
@@ -19,21 +19,20 @@
     --panel: #141414;
     --panel-2: #1c1c1c;
     --line: #2a2a2a;
-    --line-2: #3a3a3a;
     --text: #d4d4d4;
     --text-dim: #6b6b6b;
     --text-bright: #f0f0f0;
     --trace-x: #4ade80;
     --trace-y: #fbbf24;
     --trace-z: #60a5fa;
+    --trace-r: #c084fc;
     --accent: #4ade80;
+    --accent-2: #fbbf24;
     --warn: #f87171;
-    --grid: #1a2419;
   }
-
   * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
   html, body {
-    margin: 0; padding: 0; height: 100%;
+    margin: 0; padding: 0; height: 100%; min-height: 100dvh;
     background: var(--bg); color: var(--text);
     font-family: 'JetBrains Mono', ui-monospace, monospace;
     font-size: 13px; line-height: 1.4;
@@ -46,10 +45,7 @@
     min-height: 100vh; min-height: 100dvh;
     padding-top: env(safe-area-inset-top);
     padding-bottom: env(safe-area-inset-bottom);
-    padding-left: env(safe-area-inset-left);
-    padding-right: env(safe-area-inset-right);
   }
-
   header {
     border-bottom: 1px solid var(--line);
     padding: 10px 14px;
@@ -60,29 +56,19 @@
   .brand .dim { color: var(--text-dim); font-weight: 400; }
   .status { display: flex; gap: 10px; align-items: center; font-size: 11px; color: var(--text-dim); }
   .led {
-    width: 8px; height: 8px; border-radius: 50%;
-    background: #333; display: inline-block;
-    transition: background 0.15s, box-shadow 0.15s;
+    width: 8px; height: 8px; border-radius: 50%; background: #333;
+    display: inline-block; transition: background 0.15s, box-shadow 0.15s;
   }
   .led.on { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
   .led.warn { background: var(--warn); box-shadow: 0 0 8px var(--warn); }
-  .led.pulse { animation: pulse 1.2s ease-in-out infinite; }
-  @keyframes pulse {
-    0%, 100% { box-shadow: 0 0 4px currentColor; opacity: 0.6; }
-    50% { box-shadow: 0 0 10px currentColor; opacity: 1; }
-  }
 
-  main { flex: 1; display: flex; flex-direction: column; min-height: 0; }
-
-  .phase { display: none; flex-direction: column; flex: 1; }
+  main { flex: 1; display: flex; flex-direction: column; min-height: 0; position: relative; }
+  .phase { display: none; flex-direction: column; flex: 1; min-height: 0; }
   .phase.active { display: flex; }
 
-  /* === PERMISSION PHASE === */
+  /* ===== PERMISSION ===== */
   #permission { justify-content: center; align-items: center; padding: 24px; text-align: center; gap: 18px; }
-  #permission h1 {
-    margin: 0; font-size: 18px; font-weight: 500; color: var(--text-bright);
-    letter-spacing: -0.01em;
-  }
+  #permission h1 { margin: 0; font-size: 18px; font-weight: 500; color: var(--text-bright); letter-spacing: -0.01em; }
   #permission .blurb { color: var(--text-dim); max-width: 320px; font-size: 12px; }
   .primary-btn {
     background: transparent; color: var(--accent);
@@ -94,9 +80,32 @@
   .primary-btn:active { background: var(--accent); color: var(--bg); }
   .err { color: var(--warn); font-size: 11px; margin-top: 8px; }
 
-  /* === SCOPE === */
+  /* ===== INTRO CARD ===== */
+  .intro-card {
+    margin: 12px 14px; padding: 14px;
+    background: var(--panel); border: 1px solid var(--line);
+    border-left: 2px solid var(--accent);
+    font-size: 12px; line-height: 1.55;
+    position: relative;
+  }
+  .intro-card h2 {
+    margin: 0 0 8px; font-size: 10px; letter-spacing: 0.15em;
+    color: var(--accent); text-transform: uppercase; font-weight: 500;
+  }
+  .intro-card p { margin: 0 0 6px; color: var(--text-dim); }
+  .intro-card p strong { color: var(--text); font-weight: 500; }
+  .intro-card .close-x {
+    position: absolute; top: 8px; right: 10px;
+    background: none; border: none; color: var(--text-dim);
+    font: inherit; cursor: pointer; padding: 4px;
+  }
+  .intro-card ol { margin: 6px 0 0; padding-left: 20px; color: var(--text-dim); }
+  .intro-card ol li { margin-bottom: 4px; }
+  .intro-card ol li strong { color: var(--text); }
+
+  /* ===== SCOPE ===== */
   .scope {
-    height: 140px; background: #050805;
+    height: 110px; background: #050805;
     border-bottom: 1px solid var(--line);
     position: relative; overflow: hidden;
   }
@@ -109,38 +118,30 @@
   .scope-legend { display: flex; gap: 10px; }
   .scope-legend span { display: flex; align-items: center; gap: 4px; }
   .scope-legend i { width: 8px; height: 1px; display: inline-block; }
-  .scope-readout { text-align: right; }
   .scope-readout .val { color: var(--text); }
 
-  /* === COLLECT === */
+  /* ===== COLLECT ===== */
   .section-label {
     padding: 10px 14px 6px; font-size: 10px; letter-spacing: 0.15em;
     color: var(--text-dim); text-transform: uppercase;
     display: flex; justify-content: space-between; align-items: baseline;
   }
-  .section-label .meta { font-size: 10px; color: var(--text-dim); }
-
   .zone-grid {
     display: grid; grid-template-columns: 1fr 1fr 1fr;
     gap: 1px; background: var(--line); padding: 0 0 1px 0;
   }
   .zone-btn {
     background: var(--panel); border: none; color: var(--text);
-    padding: 14px 8px; font: inherit; font-size: 11px;
+    padding: 16px 8px; font: inherit; font-size: 11px;
     cursor: pointer; text-align: left;
     display: flex; flex-direction: column; gap: 4px;
-    transition: background 0.1s;
     letter-spacing: 0.04em;
   }
   .zone-btn:active { background: var(--panel-2); }
-  .zone-btn.armed {
-    background: var(--panel-2);
-    box-shadow: inset 3px 0 0 var(--accent);
-    color: var(--text-bright);
-  }
   .zone-btn .zone-name { text-transform: uppercase; font-size: 10px; color: var(--text-dim); letter-spacing: 0.1em; }
-  .zone-btn.armed .zone-name { color: var(--accent); }
-  .zone-btn .zone-count { font-size: 16px; font-weight: 500; }
+  .zone-btn .zone-count { font-size: 18px; font-weight: 500; }
+  .zone-btn.has-samples { box-shadow: inset 2px 0 0 var(--accent); }
+  .zone-btn.has-samples .zone-count { color: var(--accent); }
 
   .controls {
     display: flex; gap: 1px; background: var(--line); margin-top: 1px;
@@ -156,15 +157,6 @@
   .ctrl-btn.warn { color: var(--warn); }
   .ctrl-btn:disabled { cursor: not-allowed; opacity: 0.5; }
 
-  .last-capture {
-    padding: 10px 14px; font-size: 11px; color: var(--text-dim);
-    border-top: 1px solid var(--line); background: var(--panel);
-    display: flex; justify-content: space-between; align-items: center;
-    min-height: 36px;
-  }
-  .last-capture .val { color: var(--text); }
-  .last-capture .flash { color: var(--accent); }
-
   .settings-row {
     display: flex; gap: 12px; padding: 10px 14px;
     font-size: 11px; color: var(--text-dim);
@@ -172,35 +164,129 @@
     align-items: center; flex-wrap: wrap;
   }
   .settings-row label { display: flex; align-items: center; gap: 6px; }
-  .settings-row input[type=range] { width: 100px; }
+  .settings-row input[type=range] { width: 90px; }
   .settings-row .val { color: var(--text); min-width: 30px; }
 
-  /* === INFER === */
+  /* ===== CAPTURE OVERLAY ===== */
+  #capture-overlay {
+    position: fixed; inset: 0; z-index: 100;
+    background: var(--bg);
+    display: none; flex-direction: column;
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  #capture-overlay.active { display: flex; }
+  .capture-header {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 10px 14px; border-bottom: 1px solid var(--line); background: var(--panel);
+  }
+  .capture-title {
+    font-size: 11px; letter-spacing: 0.1em;
+    text-transform: uppercase; color: var(--text);
+  }
+  .capture-title strong { color: var(--accent); font-weight: 500; }
+  .done-btn {
+    background: transparent; color: var(--text);
+    border: 1px solid var(--line);
+    padding: 8px 16px; font: inherit; font-size: 11px;
+    letter-spacing: 0.08em; text-transform: uppercase;
+    cursor: pointer;
+  }
+  .done-btn:active { background: var(--panel-2); }
+  .capture-area {
+    flex: 1; display: flex; flex-direction: column;
+    justify-content: center; align-items: center;
+    padding: 32px 24px; gap: 18px; text-align: center;
+    position: relative;
+    background:
+      radial-gradient(ellipse at center, #0d1410 0%, var(--bg) 70%);
+    touch-action: none;
+  }
+  .capture-instr {
+    color: var(--text-dim); font-size: 13px;
+    max-width: 280px; line-height: 1.5;
+  }
+  .capture-instr strong { color: var(--text-bright); }
+  .capture-zone-label {
+    font-size: 32px; font-weight: 300; letter-spacing: -0.01em;
+    color: var(--text-bright); text-transform: uppercase;
+    line-height: 1;
+  }
+  .capture-flash {
+    width: 60px; height: 60px; border-radius: 50%;
+    border: 2px solid var(--accent); opacity: 0;
+    transition: opacity 0.4s, transform 0.4s;
+    transform: scale(0.5);
+  }
+  .capture-flash.fire { opacity: 1; transform: scale(1.4); }
+  .capture-stats {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 1px;
+    background: var(--line); width: 100%; max-width: 320px;
+  }
+  .stat { background: var(--panel); padding: 10px 14px; text-align: left; }
+  .stat .k { font-size: 9px; color: var(--text-dim); letter-spacing: 0.1em; text-transform: uppercase; }
+  .stat .v { font-size: 16px; color: var(--text); font-variant-numeric: tabular-nums; }
+  .capture-mini-scope {
+    height: 80px; background: #050805; border-top: 1px solid var(--line);
+  }
+  .capture-mini-scope canvas { width: 100%; height: 100%; display: block; }
+
+  /* ===== INFER ===== */
   #infer { padding: 0; }
   .pred-panel {
     flex: 1; display: flex; flex-direction: column;
-    justify-content: center; align-items: center;
-    padding: 24px; gap: 18px; text-align: center;
+    align-items: center; padding: 18px 14px; gap: 14px; text-align: center;
     background:
       radial-gradient(ellipse at center, #0d1410 0%, var(--bg) 70%);
   }
+  .pred-zone-display {
+    display: flex; flex-direction: column; align-items: center; gap: 4px;
+  }
   .pred-label { font-size: 10px; letter-spacing: 0.2em; color: var(--text-dim); text-transform: uppercase; }
   .pred-zone {
-    font-size: 48px; font-weight: 300; letter-spacing: -0.02em;
+    font-size: 36px; font-weight: 300; letter-spacing: -0.02em;
     color: var(--text-bright); text-transform: uppercase;
-    min-height: 60px; line-height: 1;
+    min-height: 44px; line-height: 1;
     transition: color 0.2s, text-shadow 0.2s;
   }
-  .pred-zone.fresh {
-    color: var(--accent); text-shadow: 0 0 20px rgba(74, 222, 128, 0.4);
+  .pred-zone.fresh { color: var(--accent); text-shadow: 0 0 20px rgba(74, 222, 128, 0.5); }
+  .pred-zone.touch-override { color: var(--accent-2); text-shadow: 0 0 20px rgba(251, 191, 36, 0.5); }
+
+  .phone-frame {
+    width: 140px; aspect-ratio: 1 / 2.05;
+    border: 1.5px solid var(--line);
+    border-radius: 18px;
+    position: relative; background: #050805;
+    flex-shrink: 0;
   }
+  .phone-frame::before {
+    content: ''; position: absolute;
+    top: 6px; left: 50%; transform: translateX(-50%);
+    width: 40px; height: 4px; background: var(--line); border-radius: 2px;
+  }
+  .phone-frame .actual, .phone-frame .predicted {
+    position: absolute; width: 10px; height: 10px; border-radius: 50%;
+    transform: translate(-50%, -50%); transition: top 0.15s, left 0.15s, opacity 0.3s;
+    opacity: 0;
+  }
+  .phone-frame .actual { background: var(--accent-2); box-shadow: 0 0 10px var(--accent-2); }
+  .phone-frame .predicted {
+    width: 14px; height: 14px;
+    border: 1.5px solid var(--accent); background: transparent;
+  }
+  .phone-frame .actual.show, .phone-frame .predicted.show { opacity: 1; }
+  .phone-frame-row { display: flex; gap: 18px; align-items: center; }
+  .phone-frame-legend { display: flex; flex-direction: column; gap: 8px; font-size: 10px; text-align: left; }
+  .phone-frame-legend > div { display: flex; align-items: center; gap: 6px; color: var(--text-dim); }
+  .phone-frame-legend i { width: 10px; height: 10px; border-radius: 50%; }
+  .phone-frame-legend .li-actual i { background: var(--accent-2); }
+  .phone-frame-legend .li-pred i { border: 1.5px solid var(--accent); background: transparent; }
+  .phone-frame-legend .err-val { color: var(--text); font-variant-numeric: tabular-nums; }
+
   .pred-stats {
     display: grid; grid-template-columns: 1fr 1fr;
     gap: 1px; background: var(--line); width: 100%; max-width: 320px;
   }
-  .stat { background: var(--panel); padding: 10px 14px; text-align: left; }
-  .stat .k { font-size: 10px; color: var(--text-dim); letter-spacing: 0.1em; text-transform: uppercase; }
-  .stat .v { font-size: 14px; color: var(--text); font-variant-numeric: tabular-nums; }
   .pred-history {
     display: flex; gap: 4px; flex-wrap: wrap; justify-content: center;
     max-width: 340px; min-height: 18px;
@@ -210,15 +296,15 @@
     color: var(--text-dim); border: 1px solid var(--line);
     text-transform: uppercase; letter-spacing: 0.05em;
   }
-
-  /* utility */
+  .pred-history span.touch { color: var(--accent-2); border-color: var(--accent-2); }
+  .pred-history span.acc { color: var(--accent); border-color: var(--accent); }
   .hidden { display: none !important; }
 </style>
 </head>
 <body>
 
 <header>
-  <div class="brand">tap.localizer <span class="dim">/ v0.1</span></div>
+  <div class="brand">tap.localizer <span class="dim">/ v0.2</span></div>
   <div class="status">
     <span id="rate-display">— Hz</span>
     <span id="status-led" class="led"></span>
@@ -227,7 +313,6 @@
 
 <main>
 
-  <!-- PHASE 1: PERMISSION -->
   <section id="permission" class="phase active">
     <h1>tap localization via accelerometer</h1>
     <p class="blurb">
@@ -239,8 +324,17 @@
     <div id="grant-err" class="err"></div>
   </section>
 
-  <!-- PHASE 2: COLLECT/TRAIN -->
   <section id="collect" class="phase">
+    <div class="intro-card" id="intro-card">
+      <button class="close-x" id="intro-close" aria-label="dismiss">×</button>
+      <h2>how it works</h2>
+      <p>Pick a zone, tap that part of the phone repeatedly to collect samples, then switch to inference.</p>
+      <ol>
+        <li><strong>Screen</strong> uses your touchscreen taps as labels — tap anywhere on the capture surface.</li>
+        <li><strong>Back & edges</strong> use accelerometer impulses — physically tap that part of the phone. Hold the phone firmly elsewhere.</li>
+        <li><strong>5–10 samples per zone</strong> is enough to start. Inference unlocks at 3+ samples in 2+ zones.</li>
+      </ol>
+    </div>
     <div class="scope">
       <canvas id="scope-canvas"></canvas>
       <div class="scope-overlay">
@@ -248,39 +342,26 @@
           <span><i style="background:var(--trace-x)"></i>x</span>
           <span><i style="background:var(--trace-y)"></i>y</span>
           <span><i style="background:var(--trace-z)"></i>z</span>
+          <span><i style="background:var(--trace-r)"></i>ω</span>
         </div>
-        <div class="scope-readout">
-          <span class="val" id="scope-peak">0.00</span> m/s²
-        </div>
+        <div class="scope-readout"><span class="val" id="scope-peak">0.00</span> m/s²</div>
       </div>
     </div>
-
     <div class="section-label">
-      <span>training zones / arm + tap</span>
+      <span>training zones / tap to start</span>
       <span class="meta" id="total-count">0 samples</span>
     </div>
-
-    <div class="zone-grid" id="zone-grid">
-      <!-- buttons injected -->
-    </div>
-
+    <div class="zone-grid" id="zone-grid"></div>
     <div class="controls">
       <button class="ctrl-btn warn" id="clear-btn">clear all</button>
       <button class="ctrl-btn primary" id="infer-btn" disabled>inference →</button>
     </div>
-
-    <div class="last-capture" id="last-capture">
-      <span>last capture: <span class="val" id="last-zone">—</span></span>
-      <span>peak: <span class="val" id="last-peak">—</span> m/s²</span>
-    </div>
-
     <div class="settings-row">
       <label>threshold <input type="range" id="thr-input" min="1" max="6" step="0.1" value="2.5"><span class="val" id="thr-val">2.5</span></label>
       <label>cooldown <input type="range" id="cd-input" min="100" max="800" step="50" value="350"><span class="val" id="cd-val">350</span>ms</label>
     </div>
   </section>
 
-  <!-- PHASE 3: INFER -->
   <section id="infer" class="phase">
     <div class="scope">
       <canvas id="scope-canvas-2"></canvas>
@@ -289,26 +370,35 @@
           <span><i style="background:var(--trace-x)"></i>x</span>
           <span><i style="background:var(--trace-y)"></i>y</span>
           <span><i style="background:var(--trace-z)"></i>z</span>
+          <span><i style="background:var(--trace-r)"></i>ω</span>
         </div>
-        <div class="scope-readout">
-          <span class="val" id="scope-peak-2">0.00</span> m/s²
-        </div>
+        <div class="scope-readout"><span class="val" id="scope-peak-2">0.00</span> m/s²</div>
       </div>
     </div>
-
     <div class="pred-panel">
-      <div class="pred-label">predicted zone</div>
-      <div class="pred-zone" id="pred-zone">tap any surface</div>
-      <div class="pred-stats">
-        <div class="stat"><div class="k">confidence</div><div class="v" id="pred-conf">—</div></div>
-        <div class="stat"><div class="k">nn distance</div><div class="v" id="pred-dist">—</div></div>
-        <div class="stat"><div class="k">peak g</div><div class="v" id="pred-peak">—</div></div>
-        <div class="stat"><div class="k">samples</div><div class="v" id="pred-samples">—</div></div>
+      <div class="pred-zone-display">
+        <div class="pred-label">predicted zone</div>
+        <div class="pred-zone" id="pred-zone">tap any surface</div>
       </div>
-      <div class="section-label" style="padding: 4px 0 0; justify-content: center;">recent</div>
+      <div class="phone-frame-row">
+        <div class="phone-frame" id="phone-frame">
+          <div class="actual" id="actual-dot"></div>
+          <div class="predicted" id="predicted-dot"></div>
+        </div>
+        <div class="phone-frame-legend">
+          <div class="li-actual"><i></i> actual touch</div>
+          <div class="li-pred"><i></i> predicted (accel)</div>
+          <div>error: <span class="err-val" id="pos-err">—</span></div>
+        </div>
+      </div>
+      <div class="pred-stats">
+        <div class="stat"><div class="k">trigger</div><div class="v" id="pred-trig">—</div></div>
+        <div class="stat"><div class="k">confidence</div><div class="v" id="pred-conf">—</div></div>
+        <div class="stat"><div class="k">peak g</div><div class="v" id="pred-peak">—</div></div>
+        <div class="stat"><div class="k">nn dist</div><div class="v" id="pred-dist">—</div></div>
+      </div>
       <div class="pred-history" id="pred-history"></div>
     </div>
-
     <div class="controls">
       <button class="ctrl-btn" id="back-to-train">← add training samples</button>
     </div>
@@ -316,82 +406,100 @@
 
 </main>
 
+<div id="capture-overlay">
+  <div class="capture-header">
+    <div class="capture-title">capturing <strong id="capture-zone-name">—</strong></div>
+    <button class="done-btn" id="done-btn">done</button>
+  </div>
+  <div class="capture-area" id="capture-area">
+    <div class="capture-zone-label" id="capture-zone-big">SCREEN</div>
+    <div class="capture-instr" id="capture-instr">Tap anywhere on this area. Each tap is recorded as a screen sample with its <strong>x, y</strong> position.</div>
+    <div class="capture-flash" id="capture-flash"></div>
+    <div class="capture-stats">
+      <div class="stat"><div class="k">this session</div><div class="v" id="capture-count">0</div></div>
+      <div class="stat"><div class="k">last peak</div><div class="v" id="capture-peak">—</div></div>
+    </div>
+  </div>
+  <div class="capture-mini-scope">
+    <canvas id="capture-mini-canvas"></canvas>
+  </div>
+</div>
+
 <script>
 // ============================================================================
 // CONFIG
 // ============================================================================
 const ZONES = [
-  { id: 'front',  label: 'screen' },
-  { id: 'back',   label: 'back' },
-  { id: 'top',    label: 'top edge' },
-  { id: 'bottom', label: 'bot edge' },
-  { id: 'left',   label: 'left edge' },
-  { id: 'right',  label: 'right edge' },
+  { id: 'front',  label: 'screen',   instr: 'Tap anywhere on this area. Each tap is recorded with its <strong>x, y</strong> position.' },
+  { id: 'back',   label: 'back',     instr: 'Tap the <strong>back</strong> of the phone. Hold by the edges. Screen contact will be ignored.' },
+  { id: 'top',    label: 'top edge', instr: 'Tap the <strong>top edge</strong> (near the camera bump area).' },
+  { id: 'bottom', label: 'bot edge', instr: 'Tap the <strong>bottom edge</strong> (lightning/USB-C side).' },
+  { id: 'left',   label: 'left edge',instr: 'Tap the <strong>left edge</strong> (volume buttons side).' },
+  { id: 'right',  label: 'right edge',instr: 'Tap the <strong>right edge</strong> (power button side).' },
 ];
 
 const BUF_SIZE = 96;
 const PRE_SAMPLES = 6;
 const POST_SAMPLES = 22;
-const WIN_SIZE = PRE_SAMPLES + POST_SAMPLES;  // 28 samples ≈ 466ms @ 60Hz
+const WIN_SIZE = PRE_SAMPLES + POST_SAMPLES;
 const KNN_K = 5;
-
+const TOUCH_CORRELATION_MS = 150;
 let TAP_THRESHOLD = 2.5;
 let TAP_COOLDOWN = 350;
 
 // ============================================================================
 // STATE
 // ============================================================================
+// Each zone holds an array of {feat:[], x?:number, y?:number}
 const samples = Object.fromEntries(ZONES.map(z => [z.id, []]));
-let armedZone = null;
-let mode = 'collect';   // 'collect' | 'infer'
+let captureZone = null;   // when overlay is active
+let mode = 'idle';        // 'idle' | 'capturing' | 'inferring'
 let buffer = [];
 let lastTapTime = 0;
 let pendingTap = null;
+let lastTouchT = 0;
+let lastTouchXY = null;   // {x: 0-1, y: 0-1, clientX, clientY}
 let rateEMA = 0;
 let lastEventT = 0;
+let sessionCount = 0;
 let predHistory = [];
 
 const $ = (id) => document.getElementById(id);
 
 // ============================================================================
-// DEVICEMOTION
+// DEVICE MOTION
 // ============================================================================
 async function grantMotion() {
   const Cls = window.DeviceMotionEvent;
-  if (!Cls) {
-    $('grant-err').textContent = 'DeviceMotionEvent not supported on this browser.';
-    return;
-  }
+  if (!Cls) { $('grant-err').textContent = 'DeviceMotionEvent not supported.'; return; }
   try {
     if (typeof Cls.requestPermission === 'function') {
       const resp = await Cls.requestPermission();
-      if (resp !== 'granted') {
-        $('grant-err').textContent = 'Permission denied. Reload to try again.';
-        return;
-      }
+      if (resp !== 'granted') { $('grant-err').textContent = 'Permission denied.'; return; }
     }
     window.addEventListener('devicemotion', onMotion);
     enterCollect();
   } catch (err) {
-    $('grant-err').textContent = 'Error requesting permission: ' + err.message;
+    $('grant-err').textContent = 'Error: ' + err.message;
   }
 }
 
 function onMotion(e) {
   const a = e.acceleration;
   if (!a || a.x === null || a.x === undefined) {
-    // Fallback: gravity-only sensor (uncommon but exists)
     $('grant-err').textContent = 'Sensor reports gravity only — tap detection will not work.';
     return;
   }
+  const r = e.rotationRate || { alpha: 0, beta: 0, gamma: 0 };
   const t = e.timeStamp;
   const x = a.x || 0, y = a.y || 0, z = a.z || 0;
+  const ra = r.alpha || 0, rb = r.beta || 0, rg = r.gamma || 0;
   const mag = Math.hypot(x, y, z);
+  const rmag = Math.hypot(ra, rb, rg);
 
-  buffer.push({ t, x, y, z, mag });
+  buffer.push({ t, x, y, z, mag, ra, rb, rg, rmag });
   if (buffer.length > BUF_SIZE) buffer.shift();
 
-  // Rate estimate (EMA)
   if (lastEventT > 0) {
     const dt = t - lastEventT;
     if (dt > 0) {
@@ -401,10 +509,11 @@ function onMotion(e) {
   }
   lastEventT = t;
 
-  // Pending tap → wait until we have enough post-peak samples
+  // Tap impulse detection
   if (pendingTap) {
     if (t - pendingTap.t >= POST_SAMPLES * 16) {
-      extractAndHandle(pendingTap.t);
+      const feat = extractFeatures(pendingTap.t);
+      if (feat) handleAccelTap(feat.feat, feat.peakMag);
       pendingTap = null;
     }
   } else if (mag > TAP_THRESHOLD && (t - lastTapTime) > TAP_COOLDOWN) {
@@ -413,59 +522,50 @@ function onMotion(e) {
   }
 }
 
-function extractAndHandle(peakT) {
-  // Find peak index in buffer
+function extractFeatures(peakT) {
   let peakIdx = -1;
   for (let i = buffer.length - 1; i >= 0; i--) {
     if (buffer[i].t === peakT) { peakIdx = i; break; }
   }
-  if (peakIdx < 0) return;
-
+  if (peakIdx < 0) return null;
   const startIdx = peakIdx - PRE_SAMPLES;
   const endIdx = peakIdx + POST_SAMPLES;
-  if (startIdx < 0 || endIdx >= buffer.length) return;
-
-  const window = buffer.slice(startIdx, endIdx);
-  const feat = featurize(window);
-  const peakMag = window.reduce((m, s) => Math.max(m, s.mag), 0);
-  handleTap(feat, peakMag);
+  if (startIdx < 0 || endIdx >= buffer.length) return null;
+  const win = buffer.slice(startIdx, endIdx);
+  return { feat: featurize(win), peakMag: win.reduce((m, s) => Math.max(m, s.mag), 0) };
 }
 
-// ============================================================================
-// FEATURES
-// ============================================================================
-function featurize(window) {
-  // Align by peak, peak-normalize, flatten 3 axes
-  const peakIdx = window.reduce((bi, s, i) => s.mag > window[bi].mag ? i : bi, 0);
-  const peakMag = window[peakIdx].mag || 1;
-  const feats = [];
-  for (const s of window) {
-    feats.push(s.x / peakMag, s.y / peakMag, s.z / peakMag);
+function featurize(win) {
+  // Peak-normalize acceleration, separately normalize rotation
+  const peakIdx = win.reduce((bi, s, i) => s.mag > win[bi].mag ? i : bi, 0);
+  const peakMag = win[peakIdx].mag || 1;
+  const peakRot = win.reduce((m, s) => Math.max(m, s.rmag), 0) || 1;
+  const f = [];
+  for (const s of win) {
+    f.push(s.x / peakMag, s.y / peakMag, s.z / peakMag, s.rmag / peakRot);
   }
-  // Append derived: time-to-peak, decay ratio
-  const ttp = peakIdx / window.length;
-  const earlyEnergy = window.slice(0, peakIdx + 1).reduce((s, p) => s + p.mag * p.mag, 0);
-  const lateEnergy = window.slice(peakIdx + 1).reduce((s, p) => s + p.mag * p.mag, 0) || 1;
-  const decay = Math.log(earlyEnergy / lateEnergy);
-  feats.push(ttp, decay);
-  return feats;
+  const ttp = peakIdx / win.length;
+  const e1 = win.slice(0, peakIdx + 1).reduce((s, p) => s + p.mag * p.mag, 0);
+  const e2 = win.slice(peakIdx + 1).reduce((s, p) => s + p.mag * p.mag, 0) || 1;
+  const decay = Math.log(e1 / e2);
+  f.push(ttp, decay);
+  return f;
 }
-
 function euclidean(a, b) {
-  let s = 0;
-  const n = Math.min(a.length, b.length);
+  let s = 0; const n = Math.min(a.length, b.length);
   for (let i = 0; i < n; i++) s += (a[i] - b[i]) ** 2;
   return Math.sqrt(s);
 }
 
 // ============================================================================
-// CLASSIFY
+// CLASSIFY / REGRESS
 // ============================================================================
-function classify(feat) {
+function classifyZones(feat, excludeFront) {
   const all = [];
   for (const z of ZONES) {
+    if (excludeFront && z.id === 'front') continue;
     for (const s of samples[z.id]) {
-      all.push({ zone: z.id, d: euclidean(feat, s) });
+      all.push({ zone: z.id, d: euclidean(feat, s.feat) });
     }
   }
   if (all.length === 0) return null;
@@ -478,34 +578,99 @@ function classify(feat) {
   }
   const ranked = Object.entries(votes).sort((a, b) => b[1] - a[1]);
   const total = ranked.reduce((s, [, v]) => s + v, 0);
-  return {
-    zone: ranked[0][0],
-    conf: ranked[0][1] / total,
-    nearest: all[0].d,
-  };
+  return { zone: ranked[0][0], conf: ranked[0][1] / total, nearest: all[0].d };
+}
+
+function regressFrontXY(feat) {
+  // k-NN regression on front samples only
+  const all = samples.front
+    .filter(s => s.x !== undefined)
+    .map(s => ({ s, d: euclidean(feat, s.feat) }));
+  if (all.length === 0) return null;
+  all.sort((a, b) => a.d - b.d);
+  const k = Math.min(KNN_K, all.length);
+  let wsum = 0, xsum = 0, ysum = 0;
+  for (let i = 0; i < k; i++) {
+    const w = 1 / (1 + all[i].d);
+    wsum += w;
+    xsum += w * all[i].s.x;
+    ysum += w * all[i].s.y;
+  }
+  return { x: xsum / wsum, y: ysum / wsum, nearest: all[0].d, n: all.length };
 }
 
 // ============================================================================
-// TAP HANDLING
+// TAP HANDLERS (training & inference)
 // ============================================================================
-function handleTap(feat, peakMag) {
-  if (mode === 'collect') {
-    if (!armedZone) return flashLastCapture('no zone armed — peak ' + peakMag.toFixed(2), false);
-    samples[armedZone].push(feat);
-    renderZones();
-    flashLastCapture(armedZone, true, peakMag);
-    $('infer-btn').disabled = !canInfer();
-  } else if (mode === 'infer') {
-    const pred = classify(feat);
-    if (pred) renderPrediction(pred, peakMag);
+function handleAccelTap(feat, peakMag) {
+  // Was this an accidental screen touch? (touchstart in last 150ms)
+  const wasTouch = (performance.now() - lastTouchT) < TOUCH_CORRELATION_MS;
+
+  if (mode === 'capturing') {
+    if (captureZone === 'front') return;   // front uses touch trigger, ignore accel-only
+    if (wasTouch) {
+      // User touched the screen accidentally — reject
+      flashCapture(false);
+      return;
+    }
+    addSample(captureZone, feat);
+    flashCapture(true, peakMag);
+  } else if (mode === 'inferring') {
+    if (wasTouch && lastTouchXY) {
+      // Forced front prediction + position regression eval
+      const pred = regressFrontXY(feat);
+      showPrediction({
+        zone: 'front', conf: 1.0, trig: 'touch+accel',
+        peakMag, predXY: pred,
+        actualXY: lastTouchXY,
+      });
+    } else {
+      const pred = classifyZones(feat, true);
+      if (pred) showPrediction({
+        zone: pred.zone, conf: pred.conf, trig: 'accel',
+        peakMag, nearest: pred.nearest,
+      });
+    }
   }
 }
 
+function handleScreenTap(clientX, clientY) {
+  // Normalize to 0-1
+  const w = window.innerWidth, h = window.innerHeight;
+  const xy = { x: clientX / w, y: clientY / h, clientX, clientY };
+  lastTouchT = performance.now();
+  lastTouchXY = xy;
+
+  if (mode === 'capturing' && captureZone === 'front') {
+    // Wait briefly for impulse to land in buffer, then capture window
+    setTimeout(() => {
+      // Build window ending at the most recent sample
+      if (buffer.length < WIN_SIZE) { flashCapture(false); return; }
+      const win = buffer.slice(-WIN_SIZE);
+      const feat = featurize(win);
+      const peakMag = win.reduce((m, s) => Math.max(m, s.mag), 0);
+      addSample('front', feat, xy);
+      flashCapture(true, peakMag);
+    }, 180);   // ~10-11 samples post-touch
+  }
+  // For inference, the touchstart is just a marker — actual prediction happens
+  // when the accel impulse fires (handleAccelTap). If no impulse fires (very
+  // light tap), we miss the prediction, which is acceptable for v0.2.
+}
+
+function addSample(zoneId, feat, xy) {
+  const s = { feat };
+  if (xy) { s.x = xy.x; s.y = xy.y; }
+  samples[zoneId].push(s);
+  sessionCount++;
+  $('capture-count').textContent = sessionCount;
+  renderZones();
+  $('infer-btn').disabled = !canInfer();
+}
+
 function canInfer() {
-  // Need at least 3 samples in at least 2 zones
   const counts = ZONES.map(z => samples[z.id].length);
-  const nonEmpty = counts.filter(c => c >= 3).length;
-  return nonEmpty >= 2;
+  return counts.filter(c => c >= 3).length >= 2;
 }
 
 // ============================================================================
@@ -518,18 +683,10 @@ function buildZoneButtons() {
     const btn = document.createElement('button');
     btn.className = 'zone-btn';
     btn.dataset.zone = z.id;
-    btn.innerHTML = `
-      <span class="zone-name">${z.label}</span>
-      <span class="zone-count" data-count="${z.id}">0</span>
-    `;
-    btn.addEventListener('click', () => armZone(z.id));
+    btn.innerHTML = `<span class="zone-name">${z.label}</span><span class="zone-count" data-count="${z.id}">0</span>`;
+    btn.addEventListener('click', () => openCapture(z.id));
     grid.appendChild(btn);
   }
-}
-
-function armZone(zid) {
-  armedZone = (armedZone === zid) ? null : zid;
-  renderZones();
 }
 
 function renderZones() {
@@ -537,43 +694,90 @@ function renderZones() {
   for (const z of ZONES) {
     const btn = document.querySelector(`.zone-btn[data-zone="${z.id}"]`);
     const countEl = document.querySelector(`[data-count="${z.id}"]`);
-    if (btn) btn.classList.toggle('armed', armedZone === z.id);
-    if (countEl) countEl.textContent = samples[z.id].length;
-    total += samples[z.id].length;
+    const c = samples[z.id].length;
+    if (btn) btn.classList.toggle('has-samples', c > 0);
+    if (countEl) countEl.textContent = c;
+    total += c;
   }
   $('total-count').textContent = total + ' samples';
 }
 
-function flashLastCapture(zoneOrMsg, ok, peakMag) {
-  const z = $('last-zone'), p = $('last-peak');
-  z.textContent = zoneOrMsg;
-  z.classList.toggle('flash', ok);
-  if (peakMag !== undefined) p.textContent = peakMag.toFixed(2);
-  setTimeout(() => z.classList.remove('flash'), 400);
-  setLed(true);
-  setTimeout(() => setLed(false), 100);
+function openCapture(zoneId) {
+  captureZone = zoneId;
+  mode = 'capturing';
+  sessionCount = 0;
+  const z = ZONES.find(zz => zz.id === zoneId);
+  $('capture-zone-name').textContent = z.label;
+  $('capture-zone-big').textContent = z.label.toUpperCase();
+  $('capture-instr').innerHTML = z.instr;
+  $('capture-count').textContent = 0;
+  $('capture-peak').textContent = '—';
+  $('capture-overlay').classList.add('active');
+  startMiniScope();
 }
 
-function setLed(active) {
-  const led = $('status-led');
-  led.classList.toggle('on', active);
+function closeCapture() {
+  $('capture-overlay').classList.remove('active');
+  captureZone = null;
+  mode = 'idle';
+  stopMiniScope();
+  // hide intro card on first successful collection
+  if (Object.values(samples).some(arr => arr.length > 0)) {
+    $('intro-card').classList.add('hidden');
+  }
 }
 
-function renderPrediction(pred, peakMag) {
+function flashCapture(ok, peakMag) {
+  const el = $('capture-flash');
+  el.classList.add('fire');
+  setTimeout(() => el.classList.remove('fire'), 400);
+  if (peakMag !== undefined) $('capture-peak').textContent = peakMag.toFixed(2);
+  setLed(true); setTimeout(() => setLed(false), 100);
+}
+function setLed(on) { $('status-led').classList.toggle('on', on); }
+
+function showPrediction(pred) {
   const el = $('pred-zone');
   const zLabel = ZONES.find(z => z.id === pred.zone)?.label || pred.zone;
   el.textContent = zLabel;
-  el.classList.add('fresh');
-  setTimeout(() => el.classList.remove('fresh'), 500);
+  el.classList.remove('fresh', 'touch-override');
+  el.classList.add(pred.trig === 'touch+accel' ? 'touch-override' : 'fresh');
+  setTimeout(() => el.classList.remove('fresh', 'touch-override'), 600);
 
-  $('pred-conf').textContent = (pred.conf * 100).toFixed(0) + '%';
-  $('pred-dist').textContent = pred.nearest.toFixed(3);
-  $('pred-peak').textContent = peakMag.toFixed(2);
-  $('pred-samples').textContent = ZONES.reduce((s, z) => s + samples[z.id].length, 0);
+  $('pred-trig').textContent = pred.trig;
+  $('pred-conf').textContent = pred.conf ? (pred.conf * 100).toFixed(0) + '%' : '—';
+  $('pred-peak').textContent = pred.peakMag ? pred.peakMag.toFixed(2) : '—';
+  $('pred-dist').textContent = pred.nearest !== undefined ? pred.nearest.toFixed(3) : (pred.predXY ? pred.predXY.nearest.toFixed(3) : '—');
 
-  predHistory.unshift(zLabel);
+  predHistory.unshift({ label: zLabel, trig: pred.trig });
   if (predHistory.length > 8) predHistory.pop();
-  $('pred-history').innerHTML = predHistory.map(z => `<span>${z}</span>`).join('');
+  $('pred-history').innerHTML = predHistory.map(h => {
+    const cls = h.trig.includes('touch') ? 'touch' : 'acc';
+    return `<span class="${cls}">${h.label}</span>`;
+  }).join('');
+
+  // Phone-frame visualization
+  const frame = $('phone-frame');
+  const fw = frame.clientWidth, fh = frame.clientHeight;
+  const actual = $('actual-dot'), predicted = $('predicted-dot');
+  if (pred.actualXY) {
+    actual.style.left = (pred.actualXY.x * fw) + 'px';
+    actual.style.top = (pred.actualXY.y * fh) + 'px';
+    actual.classList.add('show');
+    setTimeout(() => actual.classList.remove('show'), 2500);
+  }
+  if (pred.predXY) {
+    predicted.style.left = (pred.predXY.x * fw) + 'px';
+    predicted.style.top = (pred.predXY.y * fh) + 'px';
+    predicted.classList.add('show');
+    setTimeout(() => predicted.classList.remove('show'), 2500);
+    if (pred.actualXY) {
+      const dx = (pred.predXY.x - pred.actualXY.x);
+      const dy = (pred.predXY.y - pred.actualXY.y);
+      const errPct = Math.hypot(dx, dy) * 100;
+      $('pos-err').textContent = errPct.toFixed(0) + '%';
+    }
+  }
 }
 
 // ============================================================================
@@ -583,85 +787,76 @@ function showPhase(name) {
   document.querySelectorAll('.phase').forEach(el => el.classList.remove('active'));
   $(name).classList.add('active');
 }
-
 function enterCollect() {
-  mode = 'collect';
+  mode = 'idle';
   showPhase('collect');
   startScope($('scope-canvas'), $('scope-peak'));
 }
-
 function enterInfer() {
   if (!canInfer()) return;
-  mode = 'infer';
+  mode = 'inferring';
   predHistory = [];
   $('pred-zone').textContent = 'tap any surface';
+  $('pred-trig').textContent = '—';
   $('pred-conf').textContent = '—';
-  $('pred-dist').textContent = '—';
   $('pred-peak').textContent = '—';
-  $('pred-samples').textContent = ZONES.reduce((s, z) => s + samples[z.id].length, 0);
+  $('pred-dist').textContent = '—';
   $('pred-history').innerHTML = '';
+  $('pos-err').textContent = '—';
   showPhase('infer');
   startScope($('scope-canvas-2'), $('scope-peak-2'));
 }
 
 // ============================================================================
-// OSCILLOSCOPE
+// OSCILLOSCOPE (main + mini)
 // ============================================================================
 let scopeCanvas, scopeCtx, scopePeakEl, scopeRAF;
 function startScope(canvas, peakEl) {
   if (scopeRAF) cancelAnimationFrame(scopeRAF);
   scopeCanvas = canvas; scopePeakEl = peakEl;
-  resizeScope();
+  resizeCanvas(scopeCanvas, (ctx) => { scopeCtx = ctx; });
   loopScope();
 }
-function resizeScope() {
-  if (!scopeCanvas) return;
+function resizeCanvas(canvas, cb) {
   const dpr = window.devicePixelRatio || 1;
-  const rect = scopeCanvas.getBoundingClientRect();
-  scopeCanvas.width = rect.width * dpr;
-  scopeCanvas.height = rect.height * dpr;
-  scopeCtx = scopeCanvas.getContext('2d');
-  scopeCtx.scale(dpr, dpr);
+  const rect = canvas.getBoundingClientRect();
+  canvas.width = rect.width * dpr; canvas.height = rect.height * dpr;
+  const ctx = canvas.getContext('2d'); ctx.scale(dpr, dpr);
+  if (cb) cb(ctx);
 }
-function loopScope() {
-  drawScope();
-  scopeRAF = requestAnimationFrame(loopScope);
-}
-function drawScope() {
-  if (!scopeCtx) return;
-  const w = scopeCanvas.clientWidth, h = scopeCanvas.clientHeight;
-  const ctx = scopeCtx;
-  ctx.clearRect(0, 0, w, h);
+function loopScope() { drawScope(scopeCanvas, scopeCtx, scopePeakEl); scopeRAF = requestAnimationFrame(loopScope); }
 
-  // Grid
-  ctx.strokeStyle = 'rgba(74, 222, 128, 0.08)';
-  ctx.lineWidth = 1;
-  for (let i = 1; i < 4; i++) {
-    ctx.beginPath();
-    ctx.moveTo(0, h * i / 4); ctx.lineTo(w, h * i / 4); ctx.stroke();
-  }
-  for (let i = 1; i < 8; i++) {
-    ctx.beginPath();
-    ctx.moveTo(w * i / 8, 0); ctx.lineTo(w * i / 8, h); ctx.stroke();
-  }
-  // Zero line
+let miniCanvas, miniCtx, miniRAF;
+function startMiniScope() {
+  miniCanvas = $('capture-mini-canvas');
+  resizeCanvas(miniCanvas, (ctx) => { miniCtx = ctx; });
+  if (miniRAF) cancelAnimationFrame(miniRAF);
+  const loop = () => { drawScope(miniCanvas, miniCtx, null); miniRAF = requestAnimationFrame(loop); };
+  loop();
+}
+function stopMiniScope() { if (miniRAF) cancelAnimationFrame(miniRAF); miniRAF = null; }
+
+function drawScope(canvas, ctx, peakEl) {
+  if (!ctx || !canvas) return;
+  const w = canvas.clientWidth, h = canvas.clientHeight;
+  ctx.clearRect(0, 0, w, h);
+  ctx.strokeStyle = 'rgba(74, 222, 128, 0.08)'; ctx.lineWidth = 1;
+  for (let i = 1; i < 4; i++) { ctx.beginPath(); ctx.moveTo(0, h * i / 4); ctx.lineTo(w, h * i / 4); ctx.stroke(); }
+  for (let i = 1; i < 8; i++) { ctx.beginPath(); ctx.moveTo(w * i / 8, 0); ctx.lineTo(w * i / 8, h); ctx.stroke(); }
   ctx.strokeStyle = 'rgba(74, 222, 128, 0.25)';
   ctx.beginPath(); ctx.moveTo(0, h / 2); ctx.lineTo(w, h / 2); ctx.stroke();
 
   if (buffer.length < 2) return;
-
-  const yScale = h / 2 / 8;  // ±8 m/s² fits
+  const yScale = h / 2 / 8;
   const stride = w / (BUF_SIZE - 1);
-
   const start = Math.max(0, buffer.length - BUF_SIZE);
   const data = buffer.slice(start);
-
-  function plot(getter, color) {
+  function plot(getter, color, scale) {
     ctx.strokeStyle = color; ctx.lineWidth = 1.2;
     ctx.beginPath();
     for (let i = 0; i < data.length; i++) {
       const x = i * stride;
-      const y = h / 2 - getter(data[i]) * yScale;
+      const y = h / 2 - getter(data[i]) * (scale || yScale);
       if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
     }
     ctx.stroke();
@@ -669,28 +864,51 @@ function drawScope() {
   plot(s => s.x, 'rgba(74, 222, 128, 0.9)');
   plot(s => s.y, 'rgba(251, 191, 36, 0.85)');
   plot(s => s.z, 'rgba(96, 165, 250, 0.85)');
+  // Rotation magnitude (scaled smaller)
+  plot(s => s.rmag, 'rgba(192, 132, 252, 0.7)', h / 2 / 600);
 
   // Threshold lines
   ctx.strokeStyle = 'rgba(248, 113, 113, 0.4)';
   ctx.setLineDash([2, 3]);
-  ctx.beginPath();
-  ctx.moveTo(0, h / 2 - TAP_THRESHOLD * yScale);
-  ctx.lineTo(w, h / 2 - TAP_THRESHOLD * yScale);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.moveTo(0, h / 2 + TAP_THRESHOLD * yScale);
-  ctx.lineTo(w, h / 2 + TAP_THRESHOLD * yScale);
-  ctx.stroke();
+  ctx.beginPath(); ctx.moveTo(0, h / 2 - TAP_THRESHOLD * yScale); ctx.lineTo(w, h / 2 - TAP_THRESHOLD * yScale); ctx.stroke();
+  ctx.beginPath(); ctx.moveTo(0, h / 2 + TAP_THRESHOLD * yScale); ctx.lineTo(w, h / 2 + TAP_THRESHOLD * yScale); ctx.stroke();
   ctx.setLineDash([]);
 
-  // Peak readout
   const recent = buffer.slice(-12);
   const peak = recent.reduce((m, s) => Math.max(m, s.mag), 0);
-  if (scopePeakEl) scopePeakEl.textContent = peak.toFixed(2);
+  if (peakEl) peakEl.textContent = peak.toFixed(2);
   $('rate-display').textContent = rateEMA.toFixed(0) + ' Hz';
 }
+window.addEventListener('resize', () => {
+  if (scopeCanvas) resizeCanvas(scopeCanvas, (c) => scopeCtx = c);
+  if (miniCanvas) resizeCanvas(miniCanvas, (c) => miniCtx = c);
+});
 
-window.addEventListener('resize', () => resizeScope());
+// ============================================================================
+// TOUCH HANDLING
+// ============================================================================
+// Capture area: front-mode captures here; other-mode swallows touches.
+$('capture-area').addEventListener('touchstart', (e) => {
+  if (e.touches.length !== 1) return;
+  e.preventDefault();   // prevent zoom/scroll
+  if (captureZone === 'front') {
+    const t = e.touches[0];
+    handleScreenTap(t.clientX, t.clientY);
+  }
+  // For non-front zones, deliberately swallow — finger contact shouldn't add samples
+}, { passive: false });
+
+// In inference, listen on the whole infer phase
+$('infer').addEventListener('touchstart', (e) => {
+  if (mode !== 'inferring') return;
+  if (e.touches.length !== 1) return;
+  // Don't preventDefault — back button still needs to be tappable.
+  // We just record the timestamp + position; handleAccelTap will use it.
+  const t = e.touches[0];
+  const tag = e.target.tagName;
+  if (tag === 'BUTTON') return;   // ignore taps on controls
+  handleScreenTap(t.clientX, t.clientY);
+}, { passive: true });
 
 // ============================================================================
 // BIND
@@ -699,12 +917,14 @@ $('grant-btn').addEventListener('click', grantMotion);
 $('clear-btn').addEventListener('click', () => {
   if (!confirm('Clear all training samples?')) return;
   for (const z of ZONES) samples[z.id] = [];
-  armedZone = null;
   renderZones();
   $('infer-btn').disabled = true;
+  $('intro-card').classList.remove('hidden');
 });
 $('infer-btn').addEventListener('click', enterInfer);
 $('back-to-train').addEventListener('click', enterCollect);
+$('done-btn').addEventListener('click', closeCapture);
+$('intro-close').addEventListener('click', () => $('intro-card').classList.add('hidden'));
 
 $('thr-input').addEventListener('input', (e) => {
   TAP_THRESHOLD = parseFloat(e.target.value);
@@ -717,12 +937,6 @@ $('cd-input').addEventListener('input', (e) => {
 
 buildZoneButtons();
 renderZones();
-
-// Allow re-grant if user dismissed
-if (window.DeviceMotionEvent && typeof window.DeviceMotionEvent.requestPermission !== 'function') {
-  // Non-iOS: try to attach immediately
-  // (will only fire once user moves the device, which is fine)
-}
 </script>
 </body>
 </html>

--- a/fun-and-games/tap-localizer.html
+++ b/fun-and-games/tap-localizer.html
@@ -1,0 +1,728 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black">
+<meta name="apple-mobile-web-app-title" content="tap.loc">
+<meta name="ai-disclosure" content="ai-assisted">
+<link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAIAAACyr5FlAAAIbElEQVR42u2dP07kShDGBzQHeBd41oYTgETwsk24AwkpKQfgEBxgUlIS7kBCtgESHADNXmCP8IKRRpY9zNr196v2VyJAaLC7q3/+qqqnu3222WxWNNoxW69Wq91uR0fQBtZ13Tm9QPvOCAeNcPzNLrc3l9sb+oFw0AgHjXDQCAeNcNAIBw3f1nTB3j7uX+gEKgeNcNAIB41w0AgHjXDQWMri2vXnw9x/eb14JBxEYepFmsdlvUwgBOM6vmD/L02CcrbZbJpZQ/odEE4jF3y7YOu6rgU4jg5S8AghtIFwnBoSkMHAbNWC4MAfgOqIlISjXBpYNG8tBkfp6qBc48vA0UzRWKgjBeBoci6hRKeg4Wh+igm8g7hwHBzX/BQ1bE9BN1Ivh4x+H02+ALI1LOVYFBbgfcdSjiWTgSkhKMoRT8bV0+30D7/fPS/tCYFISMPcMYuGXFYQEMmHw9sLJ4CYNcBW1ynERzIcfv0/OpaGo+h9fQQ+MuFw6vlg2AJyBdc7JvKRBod5n+OZCGtDFh85cNj2FgEL7/ak8JEAhx8Z6Vi4Niyej2g4DHsIi4VfI4P5CIXDqm8lsHBqcCQfCdPnVmS83z2XIGPQVOVEXHBOGgTHHnlDMlbVzJaPmO9fIsKKnozSWHj0xeRhyw8resZbIsNQQgL0IyisiBlvjAwrPmKSD9+wolS/ve9awsK2g67BxbeUxSfjx/3PKR/72r4tkA9HOJQVuR8ZE4GIBEXTWb+ZD3c4cMg4ysTEkdb8bxgfZeDAIWM8rspBNb8gLB9d12Gd7GNIxmAUrYbwcJ3D9fe/6K//fvd89XR79XSLk4DbK4eYYquqtY+Fay5pfjuNB8zFA3FTkxUZX9u3ADIGN1Jmu2hFu7FyKGVD451gwfBrgNgVtuKBohyGZIQJhp+E7P1guJFCbJZwyMjVe6FPRrpDrUKMwDPmX9iiVCsy2YDCYsDHj/uf4kJmX7m0oxwa2WiJDCsJkQUXW/GoejA+OBnmIaawcgTLRgky9Hyki0eacuhjKj4ZVu3Myj/OrWQjLA+1mq5OSVFj8nT9uBgrx6yYIn4UPMj4579/v/tB4EPgMat5sMxSdu5jYZjWTRz4/sf+/PptlUrPgjuxrNXCEbAM2jaEj7E4Mer9D+9/1yDytX0LK1teLx6vPx+uPx80Q5OQkMqKFH1A6UeKP79+H35O/Mv4Y8pwIwsuWRPqNeY59A/cAAvBFQaIpPeoQTg0U6Iy2Tg862IsjiIilhBZL1LEQwVHTMKhCSh9wTBsklJClJXLrJpFU9C2/F5ZJzJM+ChhoXAIYopYNgxDyZQQEyAe8ZHlvG3NaPiO0HDEz3CIlb+Bu6SkHdDKIYsp+tkqGR9zxSMmLa0RVmJ2RceToeEDvKBtuVqhNQuHIKZkyYZYPMAjC5WDZg0HYKmSKxuRmUdYwRK0ngP/jJ4qbxeP3G8NGlYi1wLu1z1M+aOHIacdS885ThMA+MZGwhGUcEwZ+7l8AKYdVA4a4YgKKAwuw2rlcnsz/sTH/QufIcJBW5ydloM1RYJG5aCt5uYMy01Ip8+BIi9oYrVCIxwKk009TZGEubKB8P0f4YgILosNKNBwRH4d9XrxOIbg6B89DPm4kaBqBfBg76IiEbn44VzjSqh5ZYRvvAATDs2yLFYrtIJwCNKOXPEQyAb4+WZUDhoAHDEbcrLEIybbCF6KC60csoI2ng8ZGfhnZsrhACxYjo5ZG3eJL1WazTmy9soy5whNO8RTpcqTuyZqhjjVEMSU+L0/LVcrriczuZ4p1YJyxKQdmu9ZnPhQkhGTiuq3rEYrh6agFfNhGGL0B1fKepGyn7RGWNE/ZPojiAcHIKf3qE04ZOKh/xJ/fEr1X0EZf0x5PKEsoGRtQ9d+ZW9yAPtc/2oeu/EU2UQh0atF5G5pkzMyMlefz13eYfjWgf5In4DDoxKRyUbtsDKrZhErpMcKsf6rEQY/toKnSTVmeQzo7ZAa7RI8FvgnNBqSoZENfaBPq1b06VUVPvTtzFpbaQOHbDZMPOdR6H2tmrecyooUw+Paqk6fl+Cj0PtvfeEIFg98PpRkpMvGCmcjtWzXwiE5hVo4oxeMxPLVK6xoxKOZEGMYSnJlAyXn0C8v7fORhUj/1hoycM5sPdtsNrvdzvCKYn5NnJKVA1rdV+wEc9noug6uWlGG23gJsRIMnFTDUTnSxeNo/mEuJB7Xx5GNvXJgHftkuN96MMtu9XCP1cgKO8Dj4V2UQ8myh5uOhpiJ46r534AuO73Bous6Xzig+DApdz3yXD0ZxeDQEx0gsxNBcS18lN30e/GNLxwl+EAozQDJiIDDio/2ENH3y/tlWXHzHOK1SQffoc0BIJDhbe5w6NFujA9DLfRe1O0eVgw1sHqIsWp/zNsX48KKycbJ0hJSi4ygsGIbLPt8VEGk31QTMsIsKKwM+qYHv08GbJSxbaTffFdaKevaQ1hEzBsWTEYOHK58ICDi0Z54MtLg8OgtAiJObUghIxMOvz7HU+J6xywykuFw7fnRQsZw2Lyvn05GPhwB/T9R7s4aS6vrVCEDAo5ILxjOi3hHq3QyUODIcscsVsIyXAQs4OCA8gs9sELbmnDwyDLfHQ/4bAApx2IlBLO/iJualiYhyE8ConKMyWhSQsA7iJWQLgeREp0qAEdjiBTqSBk4GkCkXOOLwVHUy0WZLgnH0UIG0On4LWwWDuQBqI5FI3AcHYyUIUFoA+GYPUJ+gxR8O8LhPnLi8TO/IOEoAIrY2v7qB+7YJycbj6IAlwUuJFivFmmLXTIyy87pAhrhoBEOGuGgEQ4a4aARDny73N5cbm/oB8JBIxw0wkEjHDTCQSMcNGRb0wV9+7h/oROoHLRpytF1HR1BG9v/M2HdBoAnCzEAAAAASUVORK5CYII=">
+<link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAIAAACyr5FlAAAIbElEQVR42u2dP07kShDGBzQHeBd41oYTgETwsk24AwkpKQfgEBxgUlIS7kBCtgESHADNXmCP8IKRRpY9zNr196v2VyJAaLC7q3/+qqqnu3222WxWNNoxW69Wq91uR0fQBtZ13Tm9QPvOCAeNcPzNLrc3l9sb+oFw0AgHjXDQCAeNcNAIBw3f1nTB3j7uX+gEKgeNcNAIB41w0AgHjXDQWMri2vXnw9x/eb14JBxEYepFmsdlvUwgBOM6vmD/L02CcrbZbJpZQ/odEE4jF3y7YOu6rgU4jg5S8AghtIFwnBoSkMHAbNWC4MAfgOqIlISjXBpYNG8tBkfp6qBc48vA0UzRWKgjBeBoci6hRKeg4Wh+igm8g7hwHBzX/BQ1bE9BN1Ivh4x+H02+ALI1LOVYFBbgfcdSjiWTgSkhKMoRT8bV0+30D7/fPS/tCYFISMPcMYuGXFYQEMmHw9sLJ4CYNcBW1ynERzIcfv0/OpaGo+h9fQQ+MuFw6vlg2AJyBdc7JvKRBod5n+OZCGtDFh85cNj2FgEL7/ak8JEAhx8Z6Vi4Niyej2g4DHsIi4VfI4P5CIXDqm8lsHBqcCQfCdPnVmS83z2XIGPQVOVEXHBOGgTHHnlDMlbVzJaPmO9fIsKKnozSWHj0xeRhyw8resZbIsNQQgL0IyisiBlvjAwrPmKSD9+wolS/ve9awsK2g67BxbeUxSfjx/3PKR/72r4tkA9HOJQVuR8ZE4GIBEXTWb+ZD3c4cMg4ysTEkdb8bxgfZeDAIWM8rspBNb8gLB9d12Gd7GNIxmAUrYbwcJ3D9fe/6K//fvd89XR79XSLk4DbK4eYYquqtY+Fay5pfjuNB8zFA3FTkxUZX9u3ADIGN1Jmu2hFu7FyKGVD451gwfBrgNgVtuKBohyGZIQJhp+E7P1guJFCbJZwyMjVe6FPRrpDrUKMwDPmX9iiVCsy2YDCYsDHj/uf4kJmX7m0oxwa2WiJDCsJkQUXW/GoejA+OBnmIaawcgTLRgky9Hyki0eacuhjKj4ZVu3Myj/OrWQjLA+1mq5OSVFj8nT9uBgrx6yYIn4UPMj4579/v/tB4EPgMat5sMxSdu5jYZjWTRz4/sf+/PptlUrPgjuxrNXCEbAM2jaEj7E4Mer9D+9/1yDytX0LK1teLx6vPx+uPx80Q5OQkMqKFH1A6UeKP79+H35O/Mv4Y8pwIwsuWRPqNeY59A/cAAvBFQaIpPeoQTg0U6Iy2Tg862IsjiIilhBZL1LEQwVHTMKhCSh9wTBsklJClJXLrJpFU9C2/F5ZJzJM+ChhoXAIYopYNgxDyZQQEyAe8ZHlvG3NaPiO0HDEz3CIlb+Bu6SkHdDKIYsp+tkqGR9zxSMmLa0RVmJ2RceToeEDvKBtuVqhNQuHIKZkyYZYPMAjC5WDZg0HYKmSKxuRmUdYwRK0ngP/jJ4qbxeP3G8NGlYi1wLu1z1M+aOHIacdS885ThMA+MZGwhGUcEwZ+7l8AKYdVA4a4YgKKAwuw2rlcnsz/sTH/QufIcJBW5ydloM1RYJG5aCt5uYMy01Ip8+BIi9oYrVCIxwKk009TZGEubKB8P0f4YgILosNKNBwRH4d9XrxOIbg6B89DPm4kaBqBfBg76IiEbn44VzjSqh5ZYRvvAATDs2yLFYrtIJwCNKOXPEQyAb4+WZUDhoAHDEbcrLEIybbCF6KC60csoI2ng8ZGfhnZsrhACxYjo5ZG3eJL1WazTmy9soy5whNO8RTpcqTuyZqhjjVEMSU+L0/LVcrriczuZ4p1YJyxKQdmu9ZnPhQkhGTiuq3rEYrh6agFfNhGGL0B1fKepGyn7RGWNE/ZPojiAcHIKf3qE04ZOKh/xJ/fEr1X0EZf0x5PKEsoGRtQ9d+ZW9yAPtc/2oeu/EU2UQh0atF5G5pkzMyMlefz13eYfjWgf5In4DDoxKRyUbtsDKrZhErpMcKsf6rEQY/toKnSTVmeQzo7ZAa7RI8FvgnNBqSoZENfaBPq1b06VUVPvTtzFpbaQOHbDZMPOdR6H2tmrecyooUw+Paqk6fl+Cj0PtvfeEIFg98PpRkpMvGCmcjtWzXwiE5hVo4oxeMxPLVK6xoxKOZEGMYSnJlAyXn0C8v7fORhUj/1hoycM5sPdtsNrvdzvCKYn5NnJKVA1rdV+wEc9noug6uWlGG23gJsRIMnFTDUTnSxeNo/mEuJB7Xx5GNvXJgHftkuN96MMtu9XCP1cgKO8Dj4V2UQ8myh5uOhpiJ46r534AuO73Bous6Xzig+DApdz3yXD0ZxeDQEx0gsxNBcS18lN30e/GNLxwl+EAozQDJiIDDio/2ENH3y/tlWXHzHOK1SQffoc0BIJDhbe5w6NFujA9DLfRe1O0eVgw1sHqIsWp/zNsX48KKycbJ0hJSi4ygsGIbLPt8VEGk31QTMsIsKKwM+qYHv08GbJSxbaTffFdaKevaQ1hEzBsWTEYOHK58ICDi0Z54MtLg8OgtAiJObUghIxMOvz7HU+J6xywykuFw7fnRQsZw2Lyvn05GPhwB/T9R7s4aS6vrVCEDAo5ILxjOi3hHq3QyUODIcscsVsIyXAQs4OCA8gs9sELbmnDwyDLfHQ/4bAApx2IlBLO/iJualiYhyE8ConKMyWhSQsA7iJWQLgeREp0qAEdjiBTqSBk4GkCkXOOLwVHUy0WZLgnH0UIG0On4LWwWDuQBqI5FI3AcHYyUIUFoA+GYPUJ+gxR8O8LhPnLi8TO/IOEoAIrY2v7qB+7YJycbj6IAlwUuJFivFmmLXTIyy87pAhrhoBEOGuGgEQ4a4aARDny73N5cbm/oB8JBIxw0wkEjHDTCQSMcNGRb0wV9+7h/oROoHLRpytF1HR1BG9v/M2HdBoAnCzEAAAAASUVORK5CYII=">
+<title>tap.localizer</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #0a0a0a;
+    --panel: #141414;
+    --panel-2: #1c1c1c;
+    --line: #2a2a2a;
+    --line-2: #3a3a3a;
+    --text: #d4d4d4;
+    --text-dim: #6b6b6b;
+    --text-bright: #f0f0f0;
+    --trace-x: #4ade80;
+    --trace-y: #fbbf24;
+    --trace-z: #60a5fa;
+    --accent: #4ade80;
+    --warn: #f87171;
+    --grid: #1a2419;
+  }
+
+  * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+  html, body {
+    margin: 0; padding: 0; height: 100%;
+    background: var(--bg); color: var(--text);
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 13px; line-height: 1.4;
+    overscroll-behavior: none;
+    -webkit-user-select: none; user-select: none;
+    touch-action: manipulation;
+  }
+  body {
+    display: flex; flex-direction: column;
+    min-height: 100vh; min-height: 100dvh;
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
+
+  header {
+    border-bottom: 1px solid var(--line);
+    padding: 10px 14px;
+    display: flex; justify-content: space-between; align-items: center;
+    background: var(--panel);
+  }
+  .brand { font-weight: 700; letter-spacing: 0.04em; color: var(--text-bright); }
+  .brand .dim { color: var(--text-dim); font-weight: 400; }
+  .status { display: flex; gap: 10px; align-items: center; font-size: 11px; color: var(--text-dim); }
+  .led {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: #333; display: inline-block;
+    transition: background 0.15s, box-shadow 0.15s;
+  }
+  .led.on { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+  .led.warn { background: var(--warn); box-shadow: 0 0 8px var(--warn); }
+  .led.pulse { animation: pulse 1.2s ease-in-out infinite; }
+  @keyframes pulse {
+    0%, 100% { box-shadow: 0 0 4px currentColor; opacity: 0.6; }
+    50% { box-shadow: 0 0 10px currentColor; opacity: 1; }
+  }
+
+  main { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+
+  .phase { display: none; flex-direction: column; flex: 1; }
+  .phase.active { display: flex; }
+
+  /* === PERMISSION PHASE === */
+  #permission { justify-content: center; align-items: center; padding: 24px; text-align: center; gap: 18px; }
+  #permission h1 {
+    margin: 0; font-size: 18px; font-weight: 500; color: var(--text-bright);
+    letter-spacing: -0.01em;
+  }
+  #permission .blurb { color: var(--text-dim); max-width: 320px; font-size: 12px; }
+  .primary-btn {
+    background: transparent; color: var(--accent);
+    border: 1px solid var(--accent);
+    padding: 14px 24px; font: inherit; font-weight: 500;
+    letter-spacing: 0.05em; text-transform: uppercase; font-size: 12px;
+    cursor: pointer; transition: all 0.15s;
+  }
+  .primary-btn:active { background: var(--accent); color: var(--bg); }
+  .err { color: var(--warn); font-size: 11px; margin-top: 8px; }
+
+  /* === SCOPE === */
+  .scope {
+    height: 140px; background: #050805;
+    border-bottom: 1px solid var(--line);
+    position: relative; overflow: hidden;
+  }
+  .scope canvas { width: 100%; height: 100%; display: block; }
+  .scope-overlay {
+    position: absolute; top: 6px; left: 8px; right: 8px;
+    display: flex; justify-content: space-between;
+    font-size: 10px; color: var(--text-dim); pointer-events: none;
+  }
+  .scope-legend { display: flex; gap: 10px; }
+  .scope-legend span { display: flex; align-items: center; gap: 4px; }
+  .scope-legend i { width: 8px; height: 1px; display: inline-block; }
+  .scope-readout { text-align: right; }
+  .scope-readout .val { color: var(--text); }
+
+  /* === COLLECT === */
+  .section-label {
+    padding: 10px 14px 6px; font-size: 10px; letter-spacing: 0.15em;
+    color: var(--text-dim); text-transform: uppercase;
+    display: flex; justify-content: space-between; align-items: baseline;
+  }
+  .section-label .meta { font-size: 10px; color: var(--text-dim); }
+
+  .zone-grid {
+    display: grid; grid-template-columns: 1fr 1fr 1fr;
+    gap: 1px; background: var(--line); padding: 0 0 1px 0;
+  }
+  .zone-btn {
+    background: var(--panel); border: none; color: var(--text);
+    padding: 14px 8px; font: inherit; font-size: 11px;
+    cursor: pointer; text-align: left;
+    display: flex; flex-direction: column; gap: 4px;
+    transition: background 0.1s;
+    letter-spacing: 0.04em;
+  }
+  .zone-btn:active { background: var(--panel-2); }
+  .zone-btn.armed {
+    background: var(--panel-2);
+    box-shadow: inset 3px 0 0 var(--accent);
+    color: var(--text-bright);
+  }
+  .zone-btn .zone-name { text-transform: uppercase; font-size: 10px; color: var(--text-dim); letter-spacing: 0.1em; }
+  .zone-btn.armed .zone-name { color: var(--accent); }
+  .zone-btn .zone-count { font-size: 16px; font-weight: 500; }
+
+  .controls {
+    display: flex; gap: 1px; background: var(--line); margin-top: 1px;
+  }
+  .ctrl-btn {
+    flex: 1; background: var(--panel); border: none; color: var(--text);
+    padding: 12px; font: inherit; font-size: 11px; cursor: pointer;
+    letter-spacing: 0.08em; text-transform: uppercase;
+  }
+  .ctrl-btn:active { background: var(--panel-2); }
+  .ctrl-btn.primary { color: var(--accent); }
+  .ctrl-btn.primary:disabled { color: var(--text-dim); }
+  .ctrl-btn.warn { color: var(--warn); }
+  .ctrl-btn:disabled { cursor: not-allowed; opacity: 0.5; }
+
+  .last-capture {
+    padding: 10px 14px; font-size: 11px; color: var(--text-dim);
+    border-top: 1px solid var(--line); background: var(--panel);
+    display: flex; justify-content: space-between; align-items: center;
+    min-height: 36px;
+  }
+  .last-capture .val { color: var(--text); }
+  .last-capture .flash { color: var(--accent); }
+
+  .settings-row {
+    display: flex; gap: 12px; padding: 10px 14px;
+    font-size: 11px; color: var(--text-dim);
+    border-top: 1px solid var(--line);
+    align-items: center; flex-wrap: wrap;
+  }
+  .settings-row label { display: flex; align-items: center; gap: 6px; }
+  .settings-row input[type=range] { width: 100px; }
+  .settings-row .val { color: var(--text); min-width: 30px; }
+
+  /* === INFER === */
+  #infer { padding: 0; }
+  .pred-panel {
+    flex: 1; display: flex; flex-direction: column;
+    justify-content: center; align-items: center;
+    padding: 24px; gap: 18px; text-align: center;
+    background:
+      radial-gradient(ellipse at center, #0d1410 0%, var(--bg) 70%);
+  }
+  .pred-label { font-size: 10px; letter-spacing: 0.2em; color: var(--text-dim); text-transform: uppercase; }
+  .pred-zone {
+    font-size: 48px; font-weight: 300; letter-spacing: -0.02em;
+    color: var(--text-bright); text-transform: uppercase;
+    min-height: 60px; line-height: 1;
+    transition: color 0.2s, text-shadow 0.2s;
+  }
+  .pred-zone.fresh {
+    color: var(--accent); text-shadow: 0 0 20px rgba(74, 222, 128, 0.4);
+  }
+  .pred-stats {
+    display: grid; grid-template-columns: 1fr 1fr;
+    gap: 1px; background: var(--line); width: 100%; max-width: 320px;
+  }
+  .stat { background: var(--panel); padding: 10px 14px; text-align: left; }
+  .stat .k { font-size: 10px; color: var(--text-dim); letter-spacing: 0.1em; text-transform: uppercase; }
+  .stat .v { font-size: 14px; color: var(--text); font-variant-numeric: tabular-nums; }
+  .pred-history {
+    display: flex; gap: 4px; flex-wrap: wrap; justify-content: center;
+    max-width: 340px; min-height: 18px;
+  }
+  .pred-history span {
+    font-size: 10px; padding: 2px 6px; background: var(--panel-2);
+    color: var(--text-dim); border: 1px solid var(--line);
+    text-transform: uppercase; letter-spacing: 0.05em;
+  }
+
+  /* utility */
+  .hidden { display: none !important; }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="brand">tap.localizer <span class="dim">/ v0.1</span></div>
+  <div class="status">
+    <span id="rate-display">— Hz</span>
+    <span id="status-led" class="led"></span>
+  </div>
+</header>
+
+<main>
+
+  <!-- PHASE 1: PERMISSION -->
+  <section id="permission" class="phase active">
+    <h1>tap localization via accelerometer</h1>
+    <p class="blurb">
+      Train a classifier to recognize where on the phone you're tapping —
+      screen, back, edges — purely from motion data. iOS requires explicit
+      permission for the DeviceMotion API.
+    </p>
+    <button id="grant-btn" class="primary-btn">grant motion access</button>
+    <div id="grant-err" class="err"></div>
+  </section>
+
+  <!-- PHASE 2: COLLECT/TRAIN -->
+  <section id="collect" class="phase">
+    <div class="scope">
+      <canvas id="scope-canvas"></canvas>
+      <div class="scope-overlay">
+        <div class="scope-legend">
+          <span><i style="background:var(--trace-x)"></i>x</span>
+          <span><i style="background:var(--trace-y)"></i>y</span>
+          <span><i style="background:var(--trace-z)"></i>z</span>
+        </div>
+        <div class="scope-readout">
+          <span class="val" id="scope-peak">0.00</span> m/s²
+        </div>
+      </div>
+    </div>
+
+    <div class="section-label">
+      <span>training zones / arm + tap</span>
+      <span class="meta" id="total-count">0 samples</span>
+    </div>
+
+    <div class="zone-grid" id="zone-grid">
+      <!-- buttons injected -->
+    </div>
+
+    <div class="controls">
+      <button class="ctrl-btn warn" id="clear-btn">clear all</button>
+      <button class="ctrl-btn primary" id="infer-btn" disabled>inference →</button>
+    </div>
+
+    <div class="last-capture" id="last-capture">
+      <span>last capture: <span class="val" id="last-zone">—</span></span>
+      <span>peak: <span class="val" id="last-peak">—</span> m/s²</span>
+    </div>
+
+    <div class="settings-row">
+      <label>threshold <input type="range" id="thr-input" min="1" max="6" step="0.1" value="2.5"><span class="val" id="thr-val">2.5</span></label>
+      <label>cooldown <input type="range" id="cd-input" min="100" max="800" step="50" value="350"><span class="val" id="cd-val">350</span>ms</label>
+    </div>
+  </section>
+
+  <!-- PHASE 3: INFER -->
+  <section id="infer" class="phase">
+    <div class="scope">
+      <canvas id="scope-canvas-2"></canvas>
+      <div class="scope-overlay">
+        <div class="scope-legend">
+          <span><i style="background:var(--trace-x)"></i>x</span>
+          <span><i style="background:var(--trace-y)"></i>y</span>
+          <span><i style="background:var(--trace-z)"></i>z</span>
+        </div>
+        <div class="scope-readout">
+          <span class="val" id="scope-peak-2">0.00</span> m/s²
+        </div>
+      </div>
+    </div>
+
+    <div class="pred-panel">
+      <div class="pred-label">predicted zone</div>
+      <div class="pred-zone" id="pred-zone">tap any surface</div>
+      <div class="pred-stats">
+        <div class="stat"><div class="k">confidence</div><div class="v" id="pred-conf">—</div></div>
+        <div class="stat"><div class="k">nn distance</div><div class="v" id="pred-dist">—</div></div>
+        <div class="stat"><div class="k">peak g</div><div class="v" id="pred-peak">—</div></div>
+        <div class="stat"><div class="k">samples</div><div class="v" id="pred-samples">—</div></div>
+      </div>
+      <div class="section-label" style="padding: 4px 0 0; justify-content: center;">recent</div>
+      <div class="pred-history" id="pred-history"></div>
+    </div>
+
+    <div class="controls">
+      <button class="ctrl-btn" id="back-to-train">← add training samples</button>
+    </div>
+  </section>
+
+</main>
+
+<script>
+// ============================================================================
+// CONFIG
+// ============================================================================
+const ZONES = [
+  { id: 'front',  label: 'screen' },
+  { id: 'back',   label: 'back' },
+  { id: 'top',    label: 'top edge' },
+  { id: 'bottom', label: 'bot edge' },
+  { id: 'left',   label: 'left edge' },
+  { id: 'right',  label: 'right edge' },
+];
+
+const BUF_SIZE = 96;
+const PRE_SAMPLES = 6;
+const POST_SAMPLES = 22;
+const WIN_SIZE = PRE_SAMPLES + POST_SAMPLES;  // 28 samples ≈ 466ms @ 60Hz
+const KNN_K = 5;
+
+let TAP_THRESHOLD = 2.5;
+let TAP_COOLDOWN = 350;
+
+// ============================================================================
+// STATE
+// ============================================================================
+const samples = Object.fromEntries(ZONES.map(z => [z.id, []]));
+let armedZone = null;
+let mode = 'collect';   // 'collect' | 'infer'
+let buffer = [];
+let lastTapTime = 0;
+let pendingTap = null;
+let rateEMA = 0;
+let lastEventT = 0;
+let predHistory = [];
+
+const $ = (id) => document.getElementById(id);
+
+// ============================================================================
+// DEVICEMOTION
+// ============================================================================
+async function grantMotion() {
+  const Cls = window.DeviceMotionEvent;
+  if (!Cls) {
+    $('grant-err').textContent = 'DeviceMotionEvent not supported on this browser.';
+    return;
+  }
+  try {
+    if (typeof Cls.requestPermission === 'function') {
+      const resp = await Cls.requestPermission();
+      if (resp !== 'granted') {
+        $('grant-err').textContent = 'Permission denied. Reload to try again.';
+        return;
+      }
+    }
+    window.addEventListener('devicemotion', onMotion);
+    enterCollect();
+  } catch (err) {
+    $('grant-err').textContent = 'Error requesting permission: ' + err.message;
+  }
+}
+
+function onMotion(e) {
+  const a = e.acceleration;
+  if (!a || a.x === null || a.x === undefined) {
+    // Fallback: gravity-only sensor (uncommon but exists)
+    $('grant-err').textContent = 'Sensor reports gravity only — tap detection will not work.';
+    return;
+  }
+  const t = e.timeStamp;
+  const x = a.x || 0, y = a.y || 0, z = a.z || 0;
+  const mag = Math.hypot(x, y, z);
+
+  buffer.push({ t, x, y, z, mag });
+  if (buffer.length > BUF_SIZE) buffer.shift();
+
+  // Rate estimate (EMA)
+  if (lastEventT > 0) {
+    const dt = t - lastEventT;
+    if (dt > 0) {
+      const inst = 1000 / dt;
+      rateEMA = rateEMA === 0 ? inst : (rateEMA * 0.9 + inst * 0.1);
+    }
+  }
+  lastEventT = t;
+
+  // Pending tap → wait until we have enough post-peak samples
+  if (pendingTap) {
+    if (t - pendingTap.t >= POST_SAMPLES * 16) {
+      extractAndHandle(pendingTap.t);
+      pendingTap = null;
+    }
+  } else if (mag > TAP_THRESHOLD && (t - lastTapTime) > TAP_COOLDOWN) {
+    pendingTap = { t, mag };
+    lastTapTime = t;
+  }
+}
+
+function extractAndHandle(peakT) {
+  // Find peak index in buffer
+  let peakIdx = -1;
+  for (let i = buffer.length - 1; i >= 0; i--) {
+    if (buffer[i].t === peakT) { peakIdx = i; break; }
+  }
+  if (peakIdx < 0) return;
+
+  const startIdx = peakIdx - PRE_SAMPLES;
+  const endIdx = peakIdx + POST_SAMPLES;
+  if (startIdx < 0 || endIdx >= buffer.length) return;
+
+  const window = buffer.slice(startIdx, endIdx);
+  const feat = featurize(window);
+  const peakMag = window.reduce((m, s) => Math.max(m, s.mag), 0);
+  handleTap(feat, peakMag);
+}
+
+// ============================================================================
+// FEATURES
+// ============================================================================
+function featurize(window) {
+  // Align by peak, peak-normalize, flatten 3 axes
+  const peakIdx = window.reduce((bi, s, i) => s.mag > window[bi].mag ? i : bi, 0);
+  const peakMag = window[peakIdx].mag || 1;
+  const feats = [];
+  for (const s of window) {
+    feats.push(s.x / peakMag, s.y / peakMag, s.z / peakMag);
+  }
+  // Append derived: time-to-peak, decay ratio
+  const ttp = peakIdx / window.length;
+  const earlyEnergy = window.slice(0, peakIdx + 1).reduce((s, p) => s + p.mag * p.mag, 0);
+  const lateEnergy = window.slice(peakIdx + 1).reduce((s, p) => s + p.mag * p.mag, 0) || 1;
+  const decay = Math.log(earlyEnergy / lateEnergy);
+  feats.push(ttp, decay);
+  return feats;
+}
+
+function euclidean(a, b) {
+  let s = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) s += (a[i] - b[i]) ** 2;
+  return Math.sqrt(s);
+}
+
+// ============================================================================
+// CLASSIFY
+// ============================================================================
+function classify(feat) {
+  const all = [];
+  for (const z of ZONES) {
+    for (const s of samples[z.id]) {
+      all.push({ zone: z.id, d: euclidean(feat, s) });
+    }
+  }
+  if (all.length === 0) return null;
+  all.sort((a, b) => a.d - b.d);
+  const k = Math.min(KNN_K, all.length);
+  const votes = {};
+  for (let i = 0; i < k; i++) {
+    const w = 1 / (1 + all[i].d);
+    votes[all[i].zone] = (votes[all[i].zone] || 0) + w;
+  }
+  const ranked = Object.entries(votes).sort((a, b) => b[1] - a[1]);
+  const total = ranked.reduce((s, [, v]) => s + v, 0);
+  return {
+    zone: ranked[0][0],
+    conf: ranked[0][1] / total,
+    nearest: all[0].d,
+  };
+}
+
+// ============================================================================
+// TAP HANDLING
+// ============================================================================
+function handleTap(feat, peakMag) {
+  if (mode === 'collect') {
+    if (!armedZone) return flashLastCapture('no zone armed — peak ' + peakMag.toFixed(2), false);
+    samples[armedZone].push(feat);
+    renderZones();
+    flashLastCapture(armedZone, true, peakMag);
+    $('infer-btn').disabled = !canInfer();
+  } else if (mode === 'infer') {
+    const pred = classify(feat);
+    if (pred) renderPrediction(pred, peakMag);
+  }
+}
+
+function canInfer() {
+  // Need at least 3 samples in at least 2 zones
+  const counts = ZONES.map(z => samples[z.id].length);
+  const nonEmpty = counts.filter(c => c >= 3).length;
+  return nonEmpty >= 2;
+}
+
+// ============================================================================
+// UI
+// ============================================================================
+function buildZoneButtons() {
+  const grid = $('zone-grid');
+  grid.innerHTML = '';
+  for (const z of ZONES) {
+    const btn = document.createElement('button');
+    btn.className = 'zone-btn';
+    btn.dataset.zone = z.id;
+    btn.innerHTML = `
+      <span class="zone-name">${z.label}</span>
+      <span class="zone-count" data-count="${z.id}">0</span>
+    `;
+    btn.addEventListener('click', () => armZone(z.id));
+    grid.appendChild(btn);
+  }
+}
+
+function armZone(zid) {
+  armedZone = (armedZone === zid) ? null : zid;
+  renderZones();
+}
+
+function renderZones() {
+  let total = 0;
+  for (const z of ZONES) {
+    const btn = document.querySelector(`.zone-btn[data-zone="${z.id}"]`);
+    const countEl = document.querySelector(`[data-count="${z.id}"]`);
+    if (btn) btn.classList.toggle('armed', armedZone === z.id);
+    if (countEl) countEl.textContent = samples[z.id].length;
+    total += samples[z.id].length;
+  }
+  $('total-count').textContent = total + ' samples';
+}
+
+function flashLastCapture(zoneOrMsg, ok, peakMag) {
+  const z = $('last-zone'), p = $('last-peak');
+  z.textContent = zoneOrMsg;
+  z.classList.toggle('flash', ok);
+  if (peakMag !== undefined) p.textContent = peakMag.toFixed(2);
+  setTimeout(() => z.classList.remove('flash'), 400);
+  setLed(true);
+  setTimeout(() => setLed(false), 100);
+}
+
+function setLed(active) {
+  const led = $('status-led');
+  led.classList.toggle('on', active);
+}
+
+function renderPrediction(pred, peakMag) {
+  const el = $('pred-zone');
+  const zLabel = ZONES.find(z => z.id === pred.zone)?.label || pred.zone;
+  el.textContent = zLabel;
+  el.classList.add('fresh');
+  setTimeout(() => el.classList.remove('fresh'), 500);
+
+  $('pred-conf').textContent = (pred.conf * 100).toFixed(0) + '%';
+  $('pred-dist').textContent = pred.nearest.toFixed(3);
+  $('pred-peak').textContent = peakMag.toFixed(2);
+  $('pred-samples').textContent = ZONES.reduce((s, z) => s + samples[z.id].length, 0);
+
+  predHistory.unshift(zLabel);
+  if (predHistory.length > 8) predHistory.pop();
+  $('pred-history').innerHTML = predHistory.map(z => `<span>${z}</span>`).join('');
+}
+
+// ============================================================================
+// PHASE TRANSITIONS
+// ============================================================================
+function showPhase(name) {
+  document.querySelectorAll('.phase').forEach(el => el.classList.remove('active'));
+  $(name).classList.add('active');
+}
+
+function enterCollect() {
+  mode = 'collect';
+  showPhase('collect');
+  startScope($('scope-canvas'), $('scope-peak'));
+}
+
+function enterInfer() {
+  if (!canInfer()) return;
+  mode = 'infer';
+  predHistory = [];
+  $('pred-zone').textContent = 'tap any surface';
+  $('pred-conf').textContent = '—';
+  $('pred-dist').textContent = '—';
+  $('pred-peak').textContent = '—';
+  $('pred-samples').textContent = ZONES.reduce((s, z) => s + samples[z.id].length, 0);
+  $('pred-history').innerHTML = '';
+  showPhase('infer');
+  startScope($('scope-canvas-2'), $('scope-peak-2'));
+}
+
+// ============================================================================
+// OSCILLOSCOPE
+// ============================================================================
+let scopeCanvas, scopeCtx, scopePeakEl, scopeRAF;
+function startScope(canvas, peakEl) {
+  if (scopeRAF) cancelAnimationFrame(scopeRAF);
+  scopeCanvas = canvas; scopePeakEl = peakEl;
+  resizeScope();
+  loopScope();
+}
+function resizeScope() {
+  if (!scopeCanvas) return;
+  const dpr = window.devicePixelRatio || 1;
+  const rect = scopeCanvas.getBoundingClientRect();
+  scopeCanvas.width = rect.width * dpr;
+  scopeCanvas.height = rect.height * dpr;
+  scopeCtx = scopeCanvas.getContext('2d');
+  scopeCtx.scale(dpr, dpr);
+}
+function loopScope() {
+  drawScope();
+  scopeRAF = requestAnimationFrame(loopScope);
+}
+function drawScope() {
+  if (!scopeCtx) return;
+  const w = scopeCanvas.clientWidth, h = scopeCanvas.clientHeight;
+  const ctx = scopeCtx;
+  ctx.clearRect(0, 0, w, h);
+
+  // Grid
+  ctx.strokeStyle = 'rgba(74, 222, 128, 0.08)';
+  ctx.lineWidth = 1;
+  for (let i = 1; i < 4; i++) {
+    ctx.beginPath();
+    ctx.moveTo(0, h * i / 4); ctx.lineTo(w, h * i / 4); ctx.stroke();
+  }
+  for (let i = 1; i < 8; i++) {
+    ctx.beginPath();
+    ctx.moveTo(w * i / 8, 0); ctx.lineTo(w * i / 8, h); ctx.stroke();
+  }
+  // Zero line
+  ctx.strokeStyle = 'rgba(74, 222, 128, 0.25)';
+  ctx.beginPath(); ctx.moveTo(0, h / 2); ctx.lineTo(w, h / 2); ctx.stroke();
+
+  if (buffer.length < 2) return;
+
+  const yScale = h / 2 / 8;  // ±8 m/s² fits
+  const stride = w / (BUF_SIZE - 1);
+
+  const start = Math.max(0, buffer.length - BUF_SIZE);
+  const data = buffer.slice(start);
+
+  function plot(getter, color) {
+    ctx.strokeStyle = color; ctx.lineWidth = 1.2;
+    ctx.beginPath();
+    for (let i = 0; i < data.length; i++) {
+      const x = i * stride;
+      const y = h / 2 - getter(data[i]) * yScale;
+      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }
+  plot(s => s.x, 'rgba(74, 222, 128, 0.9)');
+  plot(s => s.y, 'rgba(251, 191, 36, 0.85)');
+  plot(s => s.z, 'rgba(96, 165, 250, 0.85)');
+
+  // Threshold lines
+  ctx.strokeStyle = 'rgba(248, 113, 113, 0.4)';
+  ctx.setLineDash([2, 3]);
+  ctx.beginPath();
+  ctx.moveTo(0, h / 2 - TAP_THRESHOLD * yScale);
+  ctx.lineTo(w, h / 2 - TAP_THRESHOLD * yScale);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(0, h / 2 + TAP_THRESHOLD * yScale);
+  ctx.lineTo(w, h / 2 + TAP_THRESHOLD * yScale);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // Peak readout
+  const recent = buffer.slice(-12);
+  const peak = recent.reduce((m, s) => Math.max(m, s.mag), 0);
+  if (scopePeakEl) scopePeakEl.textContent = peak.toFixed(2);
+  $('rate-display').textContent = rateEMA.toFixed(0) + ' Hz';
+}
+
+window.addEventListener('resize', () => resizeScope());
+
+// ============================================================================
+// BIND
+// ============================================================================
+$('grant-btn').addEventListener('click', grantMotion);
+$('clear-btn').addEventListener('click', () => {
+  if (!confirm('Clear all training samples?')) return;
+  for (const z of ZONES) samples[z.id] = [];
+  armedZone = null;
+  renderZones();
+  $('infer-btn').disabled = true;
+});
+$('infer-btn').addEventListener('click', enterInfer);
+$('back-to-train').addEventListener('click', enterCollect);
+
+$('thr-input').addEventListener('input', (e) => {
+  TAP_THRESHOLD = parseFloat(e.target.value);
+  $('thr-val').textContent = TAP_THRESHOLD.toFixed(1);
+});
+$('cd-input').addEventListener('input', (e) => {
+  TAP_COOLDOWN = parseInt(e.target.value);
+  $('cd-val').textContent = TAP_COOLDOWN;
+});
+
+buildZoneButtons();
+renderZones();
+
+// Allow re-grant if user dismissed
+if (window.DeviceMotionEvent && typeof window.DeviceMotionEvent.requestPermission !== 'function') {
+  // Non-iOS: try to attach immediately
+  // (will only fire once user moves the device, which is fine)
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
Follow-up to #242 with the behavioral fixes you flagged:

- Intro card on first visit explaining the flow
- Full-screen capture overlay per zone — screen taps no longer trigger UI elements
- Screen training is now `touchstart`-driven, storing `(x, y)` alongside the impulse
- Other zones reject impulses within 150ms of a `touchstart` (filters accidental finger contact)
- Inference: touchstart-coincident impulses force "screen" prediction (closes the right-edge-classified-as-screen gap)
- For screen taps: k-NN regression on `(x, y)` and visual comparison vs ground truth on a phone outline
- Added `rotationRate` magnitude as 4th feature channel
- History badges color-coded by trigger source (yellow=touch, green=accel)

🤖 Generated with [Claude](https://claude.com)