### PR TITLE
bsky: render richtext facet links in thread-reader & constellation graph

### DIFF
--- a/bsky/post-constellation-graph.html
+++ b/bsky/post-constellation-graph.html
@@ -398,7 +398,7 @@
         const qUrl = 'https://bsky.app/profile/' + rec.author.did + '/post/' + rec.uri.split('/').pop();
         return `<a href="${escHtml(qUrl)}" target="_blank" rel="noopener" class="embed-quote block" onclick="event.stopPropagation()" style="text-decoration:none;color:inherit">
           <div style="font-weight:600;font-size:10px;margin-bottom:2px">${escHtml(rec.author.displayName || rec.author.handle)}</div>
-          <div style="color:#4b5563" class="line-clamp-2">${escHtml(rec.value?.text || '')}</div>
+          <div style="color:#4b5563" class="line-clamp-2">${renderRichText(rec.value?.text || '', rec.value?.facets)}</div>
         </a>`;
       }
       if (t === 'app.bsky.embed.recordWithMedia#view') {
@@ -410,6 +410,66 @@
     function escHtml(s) {
       if (!s) return '';
       return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+
+    // ── Rich-text rendering (facets + fallback linkify) ───────────────────────
+    // Bluesky links are AT-Protocol richtext facets (byte-range → URI), not
+    // inline markup. A post can show a link as plain shortened text whose real
+    // target lives in record.facets, often with NO external embed card — without
+    // applying facets that link is dead text. Resolve facets and also linkify
+    // bare URLs / markdown [t](u) as a fallback. stopPropagation keeps a link tap
+    // from triggering node selection.
+
+    function byteToCharOffset(str, byteOffset) {
+      let b = 0;
+      for (let i = 0; i < str.length; i++) {
+        if (b >= byteOffset) return i;
+        const code = str.codePointAt(i);
+        if (code > 0xFFFF) { b += 4; i++; }       // surrogate pair (2 UTF-16 units)
+        else if (code >= 0x800) b += 3;
+        else if (code >= 0x80) b += 2;
+        else b += 1;
+      }
+      return str.length;
+    }
+
+    function anchorHtml(href, label) {
+      return `<a href="${escHtml(href)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="color:#2563eb;text-decoration:underline">${escHtml(label)}</a>`;
+    }
+
+    function linkifyHtml(str) {
+      const re = /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)|(https?:\/\/[^\s<]+[^\s<.,;:!?)\]'"]|www\.[^\s<]+[^\s<.,;:!?)\]'"])/g;
+      let out = '', last = 0, m;
+      while ((m = re.exec(str))) {
+        if (m.index > last) out += escHtml(str.slice(last, m.index));
+        if (m[1] !== undefined) out += anchorHtml(m[2], m[1]);             // markdown [label](url)
+        else { const raw = m[3]; out += anchorHtml(raw.startsWith('www.') ? 'https://' + raw : raw, raw); }
+        last = re.lastIndex;
+      }
+      if (last < str.length) out += escHtml(str.slice(last));
+      return out;
+    }
+
+    // Returns safe HTML: facet links resolved, remaining text linkified + escaped.
+    function renderRichText(text, facets) {
+      text = text || '';
+      const linkFacets = (facets || [])
+        .map(f => {
+          const lf = (f.features || []).find(ft => ft['$type'] === 'app.bsky.richtext.facet#link');
+          return lf ? { start: byteToCharOffset(text, f.index.byteStart), end: byteToCharOffset(text, f.index.byteEnd), uri: lf.uri } : null;
+        })
+        .filter(f => f && f.start < f.end)
+        .sort((a, b) => a.start - b.start);
+      if (linkFacets.length === 0) return linkifyHtml(text);
+      let out = '', cursor = 0;
+      for (const f of linkFacets) {
+        if (f.start < cursor) continue;           // skip overlapping facets
+        if (f.start > cursor) out += linkifyHtml(text.slice(cursor, f.start));
+        out += anchorHtml(f.uri, text.slice(f.start, f.end));
+        cursor = f.end;
+      }
+      if (cursor < text.length) out += linkifyHtml(text.slice(cursor));
+      return out;
     }
 
     // ── URL param helpers ────────────────────────────────────────────────────────
@@ -1277,7 +1337,7 @@
             ${badge}
             <span style="margin-left:auto;font-size:9px;color:#9ca3af;flex-shrink:0">${time}</span>
           </div>
-          <p class="line-clamp-6 post-text" style="color:#4b5563;font-size:10px;margin:0">${escHtml(text)}</p>
+          <p class="line-clamp-6 post-text" style="color:#4b5563;font-size:10px;margin:0">${renderRichText(text, p.record?.facets)}</p>
           <div style="display:flex;align-items:center;gap:6px;margin-top:4px;font-size:9px;color:#9ca3af">
             <span>&#10084;&#65039;${p.likeCount || 0}</span>
             <span>&#128172;${p.replyCount || 0}</span>
@@ -1301,7 +1361,7 @@
           </div>
           ${badge}
         </div>
-        <p class="post-text" style="color:#374151;font-size:11px;margin:0;line-height:1.45">${escHtml(text)}</p>
+        <p class="post-text" style="color:#374151;font-size:11px;margin:0;line-height:1.45">${renderRichText(text, p.record?.facets)}</p>
         ${embedHtml}
         <div style="display:flex;align-items:center;gap:8px;margin-top:8px;font-size:10px;color:#9ca3af">
           <span>&#128172;${p.replyCount || 0}</span>

--- a/bsky/thread-reader.html
+++ b/bsky/thread-reader.html
@@ -308,6 +308,77 @@
       `;
     }
 
+    // ── Rich-text rendering (facets + fallback linkify) ───────────────────────
+    // Bluesky carries links as AT-Protocol richtext facets (byte-range → URI),
+    // not inline markup. A post can show a link as plain shortened text
+    // ("anthropic.com/…") whose real target lives in record.facets, often with
+    // NO external embed card. Without applying facets that link is dead text, so
+    // we resolve facets here and also linkify bare URLs / markdown [t](u) as a
+    // belt-and-suspenders fallback.
+
+    // UTF-8 byte offset → JS (UTF-16) string index, matching TextEncoder.
+    function byteToCharOffset(str, byteOffset) {
+      let b = 0;
+      for (let i = 0; i < str.length; i++) {
+        if (b >= byteOffset) return i;
+        const code = str.codePointAt(i);
+        if (code > 0xFFFF) { b += 4; i++; }       // surrogate pair (2 UTF-16 units)
+        else if (code >= 0x800) b += 3;
+        else if (code >= 0x80) b += 2;
+        else b += 1;
+      }
+      return str.length;
+    }
+
+    const LINKIFY_RE = /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)|(https?:\/\/[^\s<]+[^\s<.,;:!?)\]'"]|www\.[^\s<]+[^\s<.,;:!?)\]'"])/g;
+
+    // Turn a plain-text segment into an array of strings / <a> vnodes.
+    function linkifySegment(str) {
+      const out = [];
+      let last = 0, m;
+      LINKIFY_RE.lastIndex = 0;
+      while ((m = LINKIFY_RE.exec(str))) {
+        if (m.index > last) out.push(str.slice(last, m.index));
+        if (m[1] !== undefined) {                 // markdown [label](url)
+          out.push(html`<a href=${m[2]} target="_blank" rel="noopener" class="text-sky-600 hover:underline break-words">${m[1]}</a>`);
+        } else {                                  // bare url / www.
+          const raw = m[3];
+          const href = raw.startsWith('www.') ? 'https://' + raw : raw;
+          out.push(html`<a href=${href} target="_blank" rel="noopener" class="text-sky-600 hover:underline break-words">${raw}</a>`);
+        }
+        last = LINKIFY_RE.lastIndex;
+      }
+      if (last < str.length) out.push(str.slice(last));
+      return out;
+    }
+
+    function PostText({ text, facets, cls }) {
+      text = text || '';
+      const linkFacets = (facets || [])
+        .map(f => {
+          const lf = (f.features || []).find(ft => ft['$type'] === 'app.bsky.richtext.facet#link');
+          return lf ? { start: byteToCharOffset(text, f.index.byteStart), end: byteToCharOffset(text, f.index.byteEnd), uri: lf.uri } : null;
+        })
+        .filter(f => f && f.start < f.end)
+        .sort((a, b) => a.start - b.start);
+
+      let children;
+      if (linkFacets.length === 0) {
+        children = linkifySegment(text);
+      } else {
+        children = [];
+        let cursor = 0;
+        for (const f of linkFacets) {
+          if (f.start < cursor) continue;         // skip overlapping facets
+          if (f.start > cursor) children.push(...linkifySegment(text.slice(cursor, f.start)));
+          children.push(html`<a href=${f.uri} target="_blank" rel="noopener" class="text-sky-600 hover:underline break-words">${text.slice(f.start, f.end)}</a>`);
+          cursor = f.end;
+        }
+        if (cursor < text.length) children.push(...linkifySegment(text.slice(cursor)));
+      }
+      return html`<p class=${cls}>${children}</p>`;
+    }
+
     // ── Embed components ──────────────────────────────────────────────────────
 
     function ImageGrid({ images }) {
@@ -383,7 +454,7 @@
               <span class="text-xs text-gray-400 truncate">@${record.author.handle}</span>
               <span class="text-xs text-gray-400 ml-auto flex-shrink-0">${timeAgo(record.indexedAt||record.value?.createdAt||'')}</span>
             </div>
-            <p class="text-xs text-gray-700 post-text leading-relaxed">${record.value?.text||''}</p>
+            <${PostText} cls="text-xs text-gray-700 post-text leading-relaxed" text=${record.value?.text||''} facets=${record.value?.facets} />
           </a>
           <${QuotedPostMedia} embeds=${record.embeds} />
         </div>
@@ -467,7 +538,7 @@
                     ${timeAgo(post.record?.createdAt || post.indexedAt || '')}
                   </a>
                 </div>
-                <p class="text-gray-800 text-sm post-text leading-relaxed">${post.record?.text||''}</p>
+                <${PostText} cls="text-gray-800 text-sm post-text leading-relaxed" text=${post.record?.text||''} facets=${post.record?.facets} />
                 <${StackPostEmbed} embed=${post.embed} />
                 <div class="flex items-center gap-3 mt-2 text-gray-400 text-xs">
                   <span title="Replies">💬 ${post.replyCount||0}</span>
@@ -610,7 +681,7 @@
                     ${timeAgo(p.record.createdAt)}
                   </a>
                 </div>
-                <p class="text-gray-800 text-sm post-text leading-relaxed">${p.record.text}</p>
+                <${PostText} cls="text-gray-800 text-sm post-text leading-relaxed" text=${p.record.text} facets=${p.record?.facets} />
                 ${p.embed && html`<${PostEmbed} embed=${p.embed} />`}
                 <div class="flex items-center gap-3 mt-2 text-gray-400 text-xs">
                   <span>💬 ${p.replyCount||0}</span>


### PR DESCRIPTION
Reported breakage: posts like [this Strix thread](https://bsky.app/profile/strix.timkellogg.me/post/3mnkvub3rc22q) show their link as plain, unclickable text in **thread-reader** and **post-constellation-graph**, even though the link is clickable in the official Bluesky app.

## Root cause

Nothing is malformed in those posts. The link is a valid AT-Protocol **richtext facet** (`app.bsky.richtext.facet#link`): a byte range over shortened display text (`anthropic.com/research/...`) whose real target (`https://www.anthropic.com/research/...`) lives in `record.facets`. Crucially these posts attach **no** `app.bsky.embed.external` preview card (19 of Strix's last 22 link posts follow this pattern).

Both tools rendered post text **raw** — htm-escaped in thread-reader, `escHtml` in the graph — with no facet processing and no URL linkification. They only ever produced clickable links from embed cards. So a faceted inline link with no card became dead text. (Not markdown — the posts use standard facets.)

## Fix

A small rich-text renderer added to each tool:

- Walks link facets by **UTF-8 byte offset**, converted to JS string index via a `codePointAt`-based mapping (correct across emoji / surrogate pairs — the prior `bsky-core` counter drifts on 4-byte code points).
- Emits anchors for facet links; falls back to linkifying bare `http(s)://` / `www.` URLs and markdown `[text](url)` in the remaining text.
- Output stays HTML-escaped (verified against `<script>`/quote injection); constellation anchors `stopPropagation()` so a link tap does not select the node.

thread-reader uses preact vnodes; the graph builds HTML strings — same algorithm, target-appropriate output. Three text sites updated in each (main post, thread/collapsed post, quoted post).

Verified the exact functions in Node against the real post + synthetic markdown / bare-URL / emoji-offset / XSS cases — all pass.

Preview build: [Branch Preview workflow runs](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml) (URL in the run's job summary).

https://claude.ai/code/session_0174tT1YaRYFzCTomDAAVTP4