### PR TITLE
kb-packer: sync polysemy caveat (parity with creating-kb#715)

### DIFF
--- a/ai-tools/kb-packer.html
+++ b/ai-tools/kb-packer.html
@@ -855,7 +855,12 @@ retrieval competitive with embeddings. Do not skip it.
    synonym can lift a result but can never drop a doc the literal question would
    have matched. Defaults: core 1.0, expand 0.4, query-floor 0.25, top-k 5.
    Keep expansion targeted — terms too generic ("system", "process") leak into
-   unrelated chunks and blur the ranking.
+   unrelated chunks and blur the ranking. A precise word can mislead too if it
+   is polysemous: prefer the disambiguating phrase as one `--core` term (e.g.
+   `--core "centered simhash"`) over a bare ambiguous word (`--core "centered"`,
+   which also matches "centered around …" in unrelated chunks). The passage
+   extractor is lexical too, so it will highlight the wrong sense rather than
+   correct it.
 
 4. **Read the returned chunks. Answer from them, and cite chunk ids inline.**
    The chunks are the source of truth the user installed. When a chunk


### PR DESCRIPTION
Adds a polysemy caveat to the query-expansion protocol, kept byte-identical with the `creating-kb` template so browser-built and CLI-built `.skill` bundles stay identical.

**Why.** The existing caveat warns against *generic* terms ("system", "process") that leak by frequency. A precise but *polysemous* `--core` term passes that check and still poisons the query: testing the spring-reading KB, `--core "centered"` (intended: centered simhash) top-ranked a System Card chunk via "centered around feature steering", and the lexical passage extractor highlighted that wrong sense. New text tells the agent to prefer the disambiguating phrase as one `--core` term.

**Scope.** Edits only the embedded `<script type=text/plain id=rt-bundle-skill>` template text in `kb-packer.html`; no build-logic change. Paired with oaustegard/claude-skills#715 (same prose in `bundle_SKILL.md`).