### PR TITLE
deploy(kb-packer): regenerate SPA after creating-kb df-drop + snippet-sort

### DIFF
--- a/ai-tools/kb-packer.html
+++ b/ai-tools/kb-packer.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="ai-disclosure" content="ai-assisted">
+<meta name="kb-packer-runtime-hash" content="326345cc2f470bc49103057d432d828b0cf2320ff552ea617f4127bed59b5ecb">
 <title>KB Packer — build a portable knowledgebase skill</title>
 <style>
   * { box-sizing: border-box; }
@@ -130,7 +131,6 @@ class Index {
     this.N = Number(idx.N);
     this.avgdl = Number(idx.avgdl);
     this.doclen = idx.doclen;
-    this.df = idx.df;
     this.postings = idx.postings;
     this._idf = new Map();
     this._chunks = null;
@@ -147,7 +147,7 @@ class Index {
   idf(term) {
     let v = this._idf.get(term);
     if (v === undefined) {
-      const df = this.df[term] || 0;
+      const df = (this.postings[term] || []).length;
       v = Math.log(1.0 + (this.N - df + 0.5) / (df + 0.5));
       this._idf.set(term, v);
     }
@@ -295,13 +295,19 @@ function makeSnippet(index, text, query, budget, context = 1) {
   const sents = text.split(SENT_SPLIT).map((s) => s.trim()).filter(Boolean);
   if (!sents.length) return [text.slice(0, budget) + "…", true];
   const n = sents.length;
-  const scored = sents.map((s, i) => {
+  // Only query-bearing sentences can seed; score them, drop zero-score
+  // sentences before sorting (filter the rounded value to match the prior
+  // round-then-filter exactly), so the sort is over the few matches, not all
+  // sentences of a whole-document chunk.
+  const scored = [];
+  for (let i = 0; i < n; i++) {
     let sc = 0;
-    for (const t of new Set(tokenize(s))) if (query.has(t)) sc += query.get(t) * index.idf(t);
-    return [Math.round(sc * 1e6) / 1e6, i];
-  });
+    for (const t of new Set(tokenize(sents[i]))) if (query.has(t)) sc += query.get(t) * index.idf(t);
+    const r = Math.round(sc * 1e6) / 1e6;
+    if (r > 0) scored.push([r, i]);
+  }
   scored.sort((a, b) => (b[0] - a[0]) || (a[1] - b[1]));
-  const seeds = scored.filter(([sc]) => sc > 0).map(([, i]) => i);
+  const seeds = scored.map(([, i]) => i);
   if (!seeds.length) return [text.slice(0, budget) + "…", true];
 
   let selected = new Set();
@@ -470,7 +476,6 @@ class Index:
         self.N = int(idx["N"])
         self.avgdl = float(idx["avgdl"])
         self.doclen = idx["doclen"]
-        self.df = idx["df"]
         self.postings = idx["postings"]
         self._idf_cache: dict[str, float] = {}
         # chunks.jsonl loaded lazily on demand
@@ -490,7 +495,7 @@ class Index:
     def idf(self, term: str) -> float:
         """Robust BM25 idf (always positive — Lucene/bm25+ variant)."""
         if term not in self._idf_cache:
-            df = self.df.get(term, 0)
+            df = len(self.postings.get(term, ()))
             self._idf_cache[term] = math.log(1.0 + (self.N - df + 0.5) / (df + 0.5))
         return self._idf_cache[term]
 
@@ -678,12 +683,16 @@ def make_snippet(index: Index, text: str, query: dict[str, float], budget: int,
     if not sents:
         return text[:budget] + "…", True
     n = len(sents)
+    # Only query-bearing sentences can seed; score them and drop zero-score
+    # sentences (the rounded value, matching the prior round-then-filter)
+    # before sorting, so the sort is over the few matches, not every sentence.
     scored = []
     for i, s in enumerate(sents):
         toks = set(tokenize(s))
         sc = round(sum(query[t] * index.idf(t) for t in toks if t in query), 6)
-        scored.append((sc, i))
-    seeds = [i for sc, i in sorted(scored, key=lambda x: (-x[0], x[1])) if sc > 0]
+        if sc > 0:
+            scored.append((sc, i))
+    seeds = [i for sc, i in sorted(scored, key=lambda x: (-x[0], x[1]))]
     if not seeds:
         return text[:budget] + "…", True
 
@@ -1036,10 +1045,11 @@ function buildIndex(chunks, k1, b) {
   });
   const N = chunks.length;
   const avgdl = N ? doclen.reduce((s, x) => s + x, 0) / N : 0;
-  const df = {};
+  // df is derivable from postings[t].length, so it is not emitted; idf()
+  // computes it on demand. Drops a vocab-sized map from every .skill index.
   const postingsObj = {};
-  for (const [t, pl] of postings) { df[t] = pl.length; postingsObj[t] = pl; }
-  return { params: { k1, b }, N, avgdl, doclen, df, postings: postingsObj };
+  for (const [t, pl] of postings) postingsObj[t] = pl;
+  return { params: { k1, b }, N, avgdl, doclen, postings: postingsObj };
 }
 
 // --- bundle assembly -------------------------------------------------------- //


### PR DESCRIPTION
Deploys the regenerated `kb-packer.html` after [claude-skills#717](https://github.com/oaustegard/claude-skills/pull/717) (merged) changed the canonical `creating-kb` runtime: the index no longer ships the derivable `df` map, and the snippet path sorts only query-bearing sentences.

Generated by `build_packer.py` in `oaustegard/claude-workspace` `experiments/kb-packer-web/` from the re-vendored runtime ([workspace PR #144](https://github.com/oaustegard/claude-workspace/pull/144)). `check_sync.py` is clean on **both** edges — HTML matches vendor, vendor matches canonical `creating-kb` on main. Builds remain byte-identical between the CLI and this browser SPA (`test_parity.py` green).

---
_Generated by [Claude Code](https://claude.ai/code)_