### PR TITLE
FileDrop fix: peer.did was undefined in poll loop

### DIFF
--- a/bsky/filedrop.html
+++ b/bsky/filedrop.html
@@ -295,7 +295,7 @@ const seenUris = new Set();
 function upsertPeerRow(did, handle, pds) {
   let p = peers.get(did);
   if (p) return p;
-  p = { handle, pds, pc: null, dc: null, el: null, recv: null, offerRkey: null, answerRkey: null };
+  p = { did, handle, pds, pc: null, dc: null, el: null, recv: null, offerRkey: null, answerRkey: null };
   peers.set(did, p);
   const el = document.createElement('div');
   el.className = 'peer';


### PR DESCRIPTION
`upsertPeerRow(did, handle, pds)` stored `{ handle, pds, ... }` without `did`, so `listPeerRecords(peer)` built `?repo=undefined` and every poll 400'd — regardless of whether the peer had signed in. One line: include `did` in the peer object.

Verify after merge: add a peer and confirm the poll URL carries their `did:plc:...`.