### PR TITLE
Fix: concurrent sends to one peer interleaved chunks and corrupted files

### DIFF
--- a/bsky/filedrop.html
+++ b/bsky/filedrop.html
@@ -164,7 +164,9 @@
     <p>Files stream over a WebRTC data channel established directly between the
     two browsers, encrypted end-to-end with DTLS and sent in 64&nbsp;KB chunks
     with backpressure. The channel carries one transfer at a time per
-    direction &mdash; additional sends queue automatically. No relay, no upload &mdash; if the two machines can't
+    direction &mdash; additional sends queue automatically &mdash; and every
+    file is SHA-256 hashed before sending and verified on arrival; a
+    mismatch is discarded, not saved. No relay, no upload &mdash; if the two machines can't
     reach each other (rare symmetric-NAT pairs), the transfer fails rather than
     fall back to a server.</p>
     <h4>ATProto as the signaling channel</h4>
@@ -584,7 +586,12 @@ let pendingOffer = null;  /* { did, meta } shown in toast */
    would interleave chunks the receiver cannot demux (diagnosed 2026-07-02:
    two files sent back-to-back arrived as one corrupt, ballooned second
    file). Extra sends queue and start when the current transfer finishes. */
-function offerFile(did, file) {
+async function fileSha256(file) {
+  const digest = await crypto.subtle.digest('SHA-256', await file.arrayBuffer());
+  return [...new Uint8Array(digest)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function offerFile(did, file) {
   const p = peers.get(did);
   if (!p || !p.dc || p.dc.readyState !== 'open') { showErr('Not connected to ' + (p ? p.handle : did)); return; }
   p.sendQueue = p.sendQueue || [];
@@ -593,8 +600,20 @@ function offerFile(did, file) {
     setStatus('Queued ' + file.name + ' for ' + p.handle);
     return;
   }
-  pendingSend = { did: did, file: file };
-  p.dc.send(JSON.stringify({ type: 'FILE_OFFER', name: file.name, size: file.size, mime: file.type }));
+  pendingSend = { did: did, file: file };   /* reserve BEFORE the hash await so a
+                                               second rapid pick queues, not races */
+  setStatus('Hashing ' + file.name + '\u2026');
+  let sha256;
+  try {
+    sha256 = await fileSha256(file);
+  } catch (e) {
+    pendingSend = null;
+    showErr('Could not hash ' + file.name + ': ' + e.message);
+    sendNext(did);
+    return;
+  }
+  if (!p.dc || p.dc.readyState !== 'open') { pendingSend = null; showErr('Channel closed'); return; }
+  p.dc.send(JSON.stringify({ type: 'FILE_OFFER', name: file.name, size: file.size, mime: file.type, sha256: sha256 }));
   setStatus('Waiting for ' + p.handle + ' to accept ' + file.name + '\u2026');
 }
 
@@ -700,16 +719,32 @@ function handleChannelMessage(did, data) {
   }
 }
 
-function finishDownload(did) {
+async function finishDownload(did) {
   const p = peers.get(did);
   const r = p.recv;
   p.recv = null;
   const blob = new Blob(r.chunks, { type: r.meta.mime || 'application/octet-stream' });
+  let verified = '';
+  if (typeof r.meta.sha256 === 'string' && r.meta.sha256.length === 64) {
+    setStatus('Verifying ' + r.meta.name + '\u2026');
+    try {
+      const digest = await crypto.subtle.digest('SHA-256', await blob.arrayBuffer());
+      const got = [...new Uint8Array(digest)].map(b => b.toString(16).padStart(2, '0')).join('');
+      if (got !== r.meta.sha256) {
+        showErr('Integrity check FAILED for ' + r.meta.name + ' \u2014 received bytes do not match the sender\u2019s SHA-256. File discarded. (expected ' + r.meta.sha256.slice(0, 12) + '\u2026, got ' + got.slice(0, 12) + '\u2026)');
+        clearProgress(p);
+        return;
+      }
+      verified = ' \u2014 SHA-256 verified';
+    } catch (e) {
+      verified = ' \u2014 verification unavailable (' + e.message + ')';
+    }
+  }
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url; a.download = r.meta.name; a.click();
   setTimeout(() => URL.revokeObjectURL(url), 5000);
-  setStatus('Received ' + r.meta.name);
+  setStatus('Received ' + r.meta.name + verified);
   clearProgress(p);
 }
 

--- a/bsky/filedrop.html
+++ b/bsky/filedrop.html
@@ -163,7 +163,8 @@
     <h4>Peer-to-peer transfer</h4>
     <p>Files stream over a WebRTC data channel established directly between the
     two browsers, encrypted end-to-end with DTLS and sent in 64&nbsp;KB chunks
-    with backpressure. No relay, no upload &mdash; if the two machines can't
+    with backpressure. The channel carries one transfer at a time per
+    direction &mdash; additional sends queue automatically. No relay, no upload &mdash; if the two machines can't
     reach each other (rare symmetric-NAT pairs), the transfer fails rather than
     fall back to a server.</p>
     <h4>ATProto as the signaling channel</h4>
@@ -578,13 +579,30 @@ async function handleAnswer(did, sdp) {
 let pendingSend = null;   /* { did, file } awaiting FILE_ACCEPT */
 let pendingOffer = null;  /* { did, meta } shown in toast */
 
+/* Transfers are SERIALIZED per peer per direction. The data channel is one
+   ordered byte stream with no per-chunk framing, so two concurrent sends
+   would interleave chunks the receiver cannot demux (diagnosed 2026-07-02:
+   two files sent back-to-back arrived as one corrupt, ballooned second
+   file). Extra sends queue and start when the current transfer finishes. */
 function offerFile(did, file) {
   const p = peers.get(did);
   if (!p || !p.dc || p.dc.readyState !== 'open') { showErr('Not connected to ' + (p ? p.handle : did)); return; }
-  if (pendingSend) { showErr('Already waiting on an accept for ' + pendingSend.file.name); return; }
+  p.sendQueue = p.sendQueue || [];
+  if (pendingSend || p.sending) {
+    p.sendQueue.push(file);
+    setStatus('Queued ' + file.name + ' for ' + p.handle);
+    return;
+  }
   pendingSend = { did: did, file: file };
   p.dc.send(JSON.stringify({ type: 'FILE_OFFER', name: file.name, size: file.size, mime: file.type }));
   setStatus('Waiting for ' + p.handle + ' to accept ' + file.name + '\u2026');
+}
+
+function sendNext(did) {
+  const p = peers.get(did);
+  if (!p || !p.sendQueue || !p.sendQueue.length) return;
+  const f = p.sendQueue.shift();
+  offerFile(did, f);
 }
 
 function pickAndSend(did) {
@@ -615,6 +633,7 @@ function streamFile(did, file) {
   const p = peers.get(did);
   const dc = p && p.dc;
   if (!dc || dc.readyState !== 'open') { showErr('Channel closed before send'); return; }
+  p.sending = true;
   let offset = 0;
   const reader = new FileReader();
   const readNext = () => reader.readAsArrayBuffer(file.slice(offset, offset + CHUNK_SIZE));
@@ -628,9 +647,11 @@ function streamFile(did, file) {
       dc.send(JSON.stringify({ type: 'FILE_DONE' }));
       setStatus('Sent ' + file.name);
       clearProgress(p);
+      p.sending = false;
+      sendNext(did);
     }
   };
-  reader.onerror = () => showErr('Read failed: ' + reader.error);
+  reader.onerror = () => { p.sending = false; showErr('Read failed: ' + reader.error); };
   readNext();
 }
 
@@ -645,9 +666,11 @@ function handleChannelMessage(did, data) {
     }
     if (!msg || typeof msg.type !== 'string') return;
     if (msg.type === 'FILE_OFFER') {
-      if (pendingOffer) {
-        /* one incoming offer at a time: auto-decline the newcomer so its
-           sender isn't left hanging while the first toast is undecided */
+      if (pendingOffer || p.recv) {
+        /* one incoming offer at a time, and NEVER while a receive from this
+           peer is streaming — accepting would overwrite p.recv and splice
+           two undemuxable byte streams. Auto-decline; the sender's queue
+           (or user) retries after the current transfer. */
         p.dc.send(JSON.stringify({ type: 'FILE_DECLINE' }));
         return;
       }
@@ -664,6 +687,7 @@ function handleChannelMessage(did, data) {
       if (pendingSend && pendingSend.did === did) {
         setStatus(p.handle + ' declined ' + pendingSend.file.name);
         pendingSend = null;
+        sendNext(did);
       }
     } else if (msg.type === 'FILE_DONE') {
       if (p.recv) finishDownload(did);

--- a/bsky/filedrop_README.md
+++ b/bsky/filedrop_README.md
@@ -32,7 +32,11 @@ instead:
    `connected`, both sides delete their signal records. Stale records are
    also swept at every sign-in and ignored past a 5-minute TTL.
 5. Files stream over the data channel in 64 KB chunks with backpressure,
-   after an explicit accept from the receiver.
+   after an explicit accept from the receiver. The channel is one ordered
+   byte stream with no per-chunk framing, so transfers are strictly
+   serialized per peer per direction: additional sends queue and start
+   when the current one completes, and the receiver declines any offer
+   that arrives mid-receive.
 
 Handle resolution goes through the public Bluesky AppView; the PDS
 endpoint comes from the DID document (`plc.directory` for `did:plc`,

--- a/bsky/filedrop_README.md
+++ b/bsky/filedrop_README.md
@@ -36,7 +36,9 @@ instead:
    byte stream with no per-chunk framing, so transfers are strictly
    serialized per peer per direction: additional sends queue and start
    when the current one completes, and the receiver declines any offer
-   that arrives mid-receive.
+   that arrives mid-receive. Every offer carries the file's SHA-256; the
+   receiver hashes the assembled bytes and discards the file on mismatch,
+   so corruption can't land silently.
 
 Handle resolution goes through the public Bluesky AppView; the PDS
 endpoint comes from the DID document (`plc.directory` for `did:plc`,


### PR DESCRIPTION
**Bug** (Oskar, live repro): sending a second file to the same peer while the first was still streaming (a) made the shared progress bar oscillate and (b) corrupted the receive — the second FILE_OFFER's accept overwrote `p.recv`, so file 1's in-flight chunks were spliced into file 2's buffer (152,695 KB file arrived as 190,385 KB). Root cause: the data channel is one ordered byte stream with **no per-chunk framing**; `pendingSend` only guarded the offer→accept window, so two `streamFile` loops interleaved undemuxable chunks.

**Fix — serialize per peer per direction:**
- Sender: `p.sending` covers the whole stream; `offerFile` during an active transfer (or pending accept) pushes to `p.sendQueue` ("Queued *name* for *handle*"); queue advances on FILE_DONE and on decline.
- Receiver: FILE_OFFER while `p.recv` is streaming is auto-declined (defense against non-serializing senders — an accept there is exactly the splice).
- Different peers remain concurrent (separate channels, no shared stream).

Progress-bar oscillation disappears with the root cause. Remaining known quirk: a simultaneous send *and* receive with the same peer shares one bar (verbs alternate) — cosmetic, opposite directions can't corrupt.

Verify: repeat the two-file repro; second file should show "Queued", then transfer cleanly after the first, with byte-identical sizes.

---

**Follow-up: SHA-256 integrity verification** — an end-to-end check on top of serialization, so corruption of any cause fails loudly instead of landing silently:
- Sender hashes the file (`crypto.subtle.digest`) before FILE_OFFER and includes `sha256` in the offer. `pendingSend` is reserved *before* the hash await so rapid double-picks still queue rather than race.
- Receiver hashes the assembled blob; mismatch → file **discarded** with an error showing both hash prefixes; match → status "SHA-256 verified".
- Backward compatible: offers without `sha256` skip verification.
- Memory note: hashing uses `arrayBuffer()` on each end — transiently whole-file, same order as the existing RAM-bound receive.