### PR TITLE
Tangled string embed demo page

### DIFF
--- a/bsky/tangled-string-embed-demo.html
+++ b/bsky/tangled-string-embed-demo.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tangled String Embed — Demo</title>
+<style>
+  body {
+    max-width: 70ch;
+    margin: 2em auto;
+    padding: 0 1em;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    line-height: 1.5;
+    color: #1f2328;
+    background: #ffffff;
+  }
+  h1 { font-size: 1.4em; }
+  code.inline {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: #f6f8fa;
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+  pre.usage {
+    background: #f6f8fa;
+    padding: 0.75em 1em;
+    border-radius: 8px;
+    overflow-x: auto;
+    font-size: 0.8em;
+  }
+  a { color: #0969da; }
+  @media (prefers-color-scheme: dark) {
+    body { color: #e6edf3; background: #0d1117; }
+    code.inline, pre.usage { background: #161b22; }
+    a { color: #58a6ff; }
+  }
+</style>
+</head>
+<body>
+<h1>Tangled String Embed</h1>
+<p>
+  <a href="https://tangled.org">Tangled</a>'s "strings" are its gist/pastebin —
+  <code class="inline">sh.tangled.string</code> records living in the author's
+  own ATProto repo.
+  <a href="https://github.com/oaustegard/oaustegard.github.io/blob/main/bsky/tangled-string-embed.js">tangled-string-embed.js</a>
+  renders any of them inline on any page, gist-style: resolve the handle, find
+  the PDS, fetch the record, highlight. No backend.
+</p>
+<pre class="usage">&lt;script src="https://austegard.com/bsky/tangled-string-embed.js"
+        data-string="at://austegard.com/sh.tangled.string/3mps32mnq6h2h"&gt;&lt;/script&gt;</pre>
+<p>
+  Below, the widget embeds a string containing <em>its own source code</em> —
+  fetched live from <a href="https://tangled.org/strings/austegard.com/3mps32mnq6h2h">this
+  string</a> in austegard.com's repo:
+</p>
+
+<script src="/bsky/tangled-string-embed.js"
+        data-string="at://austegard.com/sh.tangled.string/3mps32mnq6h2h"></script>
+
+<p>
+  Container mode also works — one shared script tag, any number of
+  <code class="inline">&lt;div data-tangled-string="handle/rkey"&gt;</code>
+  elements. Here's someone else's string (a PDS migration doc by cuducos.me):
+</p>
+
+<div data-tangled-string="cuducos.me/3mpr2zx3szt22"></div>
+
+</body>
+</html>


### PR DESCRIPTION
Demo at `/bsky/tangled-string-embed-demo.html` — the widget embedding **its own source code**, published as a live string in austegard.com's repo: https://tangled.org/strings/austegard.com/3mps32mnq6h2h (`at://.../sh.tangled.string/3mps32mnq6h2h`, created this session).

Shows both modes: gist-style self-replacing `<script data-string=...>` and container mode via `[data-tangled-string]` (embedding a third-party string from cuducos.me).

Record verified readable unauthenticated; tangled.org page returns 200. Browser render still needs the post-merge eyeball.