### PR TITLE
Tangled string viewer page

### DIFF
--- a/bsky/tangled-string.html
+++ b/bsky/tangled-string.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tangled Strings</title>
+<style>
+  body {
+    max-width: 90ch;
+    margin: 2em auto;
+    padding: 0 1em;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    line-height: 1.5;
+    color: #1f2328;
+    background: #ffffff;
+  }
+  h1 { font-size: 1.3em; }
+  code.inline {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: #f6f8fa;
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.9em;
+  }
+  form.picker { display: flex; gap: 0.5em; margin: 1em 0; }
+  form.picker input {
+    flex: 1;
+    padding: 0.5em 0.7em;
+    font: inherit;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 0.85em;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    background: inherit;
+    color: inherit;
+  }
+  form.picker button {
+    padding: 0.5em 1em;
+    font: inherit;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    background: #f6f8fa;
+    color: inherit;
+    cursor: pointer;
+  }
+  .hint { color: #57606a; font-size: 0.85em; }
+  a { color: #0969da; }
+  @media (prefers-color-scheme: dark) {
+    body { color: #e6edf3; background: #0d1117; }
+    code.inline, form.picker button { background: #161b22; }
+    form.picker input, form.picker button { border-color: #30363d; }
+    .hint { color: #8b949e; }
+    a { color: #58a6ff; }
+  }
+</style>
+</head>
+<body>
+<h1>Tangled Strings</h1>
+<p class="hint">
+  Viewer for <a href="https://tangled.org">Tangled</a> strings
+  (<code class="inline">sh.tangled.string</code> records), fetched live from the
+  author's PDS. Pass one or more via
+  <code class="inline">?s=handle/rkey&amp;s=…</code> — also accepts
+  <code class="inline">at://</code> URIs and tangled.org/strings URLs.
+</p>
+
+<form class="picker" id="picker">
+  <input id="ref" placeholder="handle/rkey, at://…, or tangled.org/strings/… URL" autofocus>
+  <button type="submit">View</button>
+</form>
+
+<div id="strings"></div>
+
+<script>
+  const params = new URLSearchParams(location.search);
+  // ?s= repeatable; also accept comma-separated within one value
+  const refs = params.getAll('s').flatMap(v => v.split(',')).map(v => v.trim()).filter(Boolean);
+
+  const container = document.getElementById('strings');
+  for (const ref of refs) {
+    const div = document.createElement('div');
+    div.setAttribute('data-tangled-string', ref);
+    container.appendChild(div);
+  }
+
+  document.getElementById('picker').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const v = document.getElementById('ref').value.trim();
+    if (!v) return;
+    const p = new URLSearchParams(location.search);
+    p.append('s', v);
+    location.search = p.toString();
+  });
+
+  if (refs.length) document.getElementById('ref').placeholder = 'add another…';
+</script>
+<script src="/bsky/tangled-string-embed.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
`/bsky/tangled-string.html?s=handle/rkey&s=…` — standalone viewer rendering one or more strings via the existing widget's container mode. `s` is repeatable and comma-splittable; accepts `handle/rkey`, `at://` URIs, and tangled.org/strings URLs (whatever `parseRef` takes). Includes an input box to add strings interactively (appends to the URL, so results are shareable).

Try after merge:
`https://austegard.com/bsky/tangled-string.html?s=austegard.com/3mps32mnq6h2h&s=cuducos.me/3mpr2zx3szt22`

Inline script creates the `[data-tangled-string]` divs before the deferred widget loads, so its DOMContentLoaded scan picks them up. No new fetch/render logic — all reuse.