### PR TITLE
Demo: drop random third-party string

### DIFF
--- a/bsky/tangled-string-embed-demo.html
+++ b/bsky/tangled-string-embed-demo.html
@@ -61,10 +61,10 @@
 <p>
   Container mode also works — one shared script tag, any number of
   <code class="inline">&lt;div data-tangled-string="handle/rkey"&gt;</code>
-  elements. Here's someone else's string (a PDS migration doc by cuducos.me):
+  elements. Same string, container-mode syntax:
 </p>
 
-<div data-tangled-string="cuducos.me/3mpr2zx3szt22"></div>
+<div data-tangled-string="austegard.com/3mps32mnq6h2h"></div>
 
 </body>
 </html>


### PR DESCRIPTION
The cuducos.me embed was a test fixture that leaked into the demo. Container-mode example now uses the same austegard.com string — self-contained page, both modes, one record. Cross-PDS fetch stays verified per #269 notes, just not performed on the demo page.