### PR TITLE
Extract atproto-rtc.js; FileDrop becomes its first consumer

### DIFF
--- a/bsky/atproto-rtc.js
+++ b/bsky/atproto-rtc.js
@@ -1,0 +1,662 @@
+/**
+ * atproto-rtc.js
+ *
+ * ATProto-signaled WebRTC data channels — peer-to-peer connections
+ * established between two browsers using short-lived ATProto records
+ * as the signaling channel, instead of a dedicated signaling server.
+ *
+ * SECURITY MODEL (preserved from the source this was extracted from):
+ *  - Signal records ($type = collection option) are written ONLY to the
+ *    caller's OWN repo, addressed (`to`) at the peer's DID.
+ *  - A peer's repo is only ever READ (unauthenticated listRecords against
+ *    their PDS) — never written to.
+ *  - A record's authorship is cryptographically bound to its author's
+ *    account by the PDS/repo signature chain, so an offer or answer
+ *    attributed to `did:plc:xyz` cannot be forged by anyone but that
+ *    account's PDS. The DTLS fingerprint embedded in the SDP means the
+ *    resulting encrypted channel is authenticated to that same identity.
+ *  - Records are deleted the moment a connection completes, swept for
+ *    staleness at every login, and ignored outright past a TTL
+ *    (`signalTtlS`) regardless of deletion.
+ *  - Untrusted peers (anyone who signals you without you having added
+ *    them first) are NOT polled, offered to, or knocked at until your
+ *    `onIncoming` consent gate returns true. This is a hard gate, not
+ *    a UI nicety: no network activity toward an unaccepted peer occurs.
+ *
+ * This library only carries session-setup text (SDP, a few KB) over
+ * ATProto. Application payloads belong on the resulting RTCDataChannel;
+ * this library does not interpret or transport them.
+ *
+ * @license MIT
+ * @version 1.0.0
+ *
+ * @example
+ *   import { AtprotoRTC } from '/bsky/atproto-rtc.js';
+ *
+ *   const rtc = new AtprotoRTC(); // defaults: com.austegard.rtc.signal, google STUN
+ *   rtc.onIncoming = async (did) => confirm(did + ' wants to connect. Accept?');
+ *
+ *   await rtc.login('alice.bsky.social', appPassword);
+ *   rtc.start(); // begin poll loop + discovery
+ *
+ *   const conn = await rtc.connect('bob.bsky.social');
+ *   conn.on('open', () => conn.channel.send('hello'));
+ *   conn.on('close', () => console.log('closed'));
+ *
+ *   const requests = await rtc.discoverPeers(); // who has signaled me
+ */
+
+/* ---------- minimal event emitter ---------- */
+class Emitter {
+  constructor() { this._l = new Map(); }
+  on(evt, fn) {
+    if (!this._l.has(evt)) this._l.set(evt, new Set());
+    this._l.get(evt).add(fn);
+    return () => this._l.get(evt) && this._l.get(evt).delete(fn);
+  }
+  off(evt, fn) { const s = this._l.get(evt); if (s) s.delete(fn); }
+  emit(evt, ...args) {
+    const s = this._l.get(evt);
+    if (!s) return;
+    for (const fn of s) {
+      try { fn(...args); } catch (e) { console.debug('[atproto-rtc] listener error:', e); }
+    }
+  }
+}
+
+/**
+ * A single peer-to-peer connection, wrapping the RTCPeerConnection and
+ * (once open) its RTCDataChannel.
+ *
+ * Events: 'open', 'close', 'error', 'statechange'
+ */
+export class AtprotoRTCConnection extends Emitter {
+  constructor(did) {
+    super();
+    this.did = did;
+    this.pc = null;
+    this.channel = null;
+  }
+
+  close() {
+    if (this.channel) { try { this.channel.close(); } catch (e) {} }
+    if (this.pc) { try { this.pc.close(); } catch (e) {} }
+    this.pc = null;
+    this.channel = null;
+    this.emit('close');
+  }
+}
+
+/**
+ * AtprotoRTC — signaling + connection manager.
+ */
+export class AtprotoRTC extends Emitter {
+  /**
+   * @param {Object} [opts]
+   * @param {string} [opts.collection='com.austegard.rtc.signal']
+   * @param {Array}  [opts.iceServers] default: [{urls:'stun:stun.l.google.com:19302'}]
+   * @param {number} [opts.pollMs=2000]
+   * @param {number} [opts.signalTtlS=300]
+   */
+  constructor(opts = {}) {
+    super();
+    this.collection  = opts.collection  || 'com.austegard.rtc.signal';
+    this.iceServers  = opts.iceServers !== undefined
+      ? opts.iceServers
+      : [{ urls: 'stun:stun.l.google.com:19302' }];
+    this.pollMs      = opts.pollMs      || 2000;
+    this.signalTtlS  = opts.signalTtlS  || 300;
+    this.discoverMs  = opts.discoverMs  || 6000;
+
+    /** @type {{did:?string, handle:?string, pds:?string, accessJwt:?string, password:?string}} */
+    this.me = { handle: null, did: null, pds: null, accessJwt: null, password: null };
+
+    /** consent gate: (did) => boolean|Promise<boolean>. Default: reject all. */
+    this.onIncoming = () => false;
+
+    /* peers: did -> { did, handle, pds, trusted, pc, dc, conn, offerRkey, answerRkey, knockRkey, sending } */
+    this.peers = new Map();
+    this._seenUris = new Map();       /* uri -> first-seen ms */
+    this._ignoredDids = new Set();
+    this._discoverChecked = new Set();
+
+    this._pollTimer = null;
+    this._discoverTimer = null;
+    this._running = false;
+
+    console.debug('[atproto-rtc] iceServers:', JSON.stringify(this.iceServers));
+  }
+
+  /* ================= identity + auth ================= */
+
+  /** Handle -> DID via the public AppView. */
+  static async resolveHandle(handle) {
+    const r = await fetch('https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=' + encodeURIComponent(handle));
+    if (!r.ok) throw new Error('Could not resolve handle ' + handle + ' (' + r.status + ')');
+    return (await r.json()).did;
+  }
+
+  /** DID -> PDS service endpoint via DID document (plc.directory or did:web). */
+  static async resolvePds(did) {
+    let doc;
+    if (did.startsWith('did:plc:')) {
+      const r = await fetch('https://plc.directory/' + did);
+      if (!r.ok) throw new Error('plc.directory lookup failed for ' + did);
+      doc = await r.json();
+    } else if (did.startsWith('did:web:')) {
+      const host = did.slice('did:web:'.length).split(':').join('/');
+      const r = await fetch('https://' + host + '/.well-known/did.json');
+      if (!r.ok) throw new Error('did:web lookup failed for ' + did);
+      doc = await r.json();
+    } else {
+      throw new Error('Unsupported DID method: ' + did);
+    }
+    const svc = (doc.service || []).find(s => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer');
+    if (!svc) throw new Error('No PDS endpoint in DID document for ' + did);
+    return svc.serviceEndpoint;
+  }
+
+  /**
+   * Sign in. Resolves handle -> DID -> PDS, creates a session against the
+   * user's OWN PDS, sweeps stale own signal records, and populates `.me`.
+   */
+  async login(handleOrDid, appPassword) {
+    const handle = String(handleOrDid).trim().replace(/^@/, '');
+    this.me.handle = handle;
+    this.me.did = handle.startsWith('did:') ? handle : await AtprotoRTC.resolveHandle(handle);
+    this.me.pds = await AtprotoRTC.resolvePds(this.me.did);
+    this.me.password = appPassword;
+    await this._createSession();
+    await this._sweepOwnSignals();
+    this.emit('login', this.me);
+    return this.me;
+  }
+
+  async _createSession() {
+    const r = await fetch(this.me.pds + '/xrpc/com.atproto.server.createSession', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identifier: this.me.handle, password: this.me.password })
+    });
+    if (!r.ok) {
+      const body = await r.json().catch(() => ({}));
+      throw new Error('Sign-in failed: ' + (body.message || r.status));
+    }
+    const j = await r.json();
+    this.me.accessJwt = j.accessJwt;
+    this.me.did = j.did;
+  }
+
+  async _pdsCall(nsid, { method = 'GET', params, body, retried } = {}) {
+    let url = this.me.pds + '/xrpc/' + nsid;
+    if (params) url += '?' + new URLSearchParams(params);
+    const r = await fetch(url, {
+      method,
+      headers: {
+        'Authorization': 'Bearer ' + this.me.accessJwt,
+        ...(body ? { 'Content-Type': 'application/json' } : {})
+      },
+      body: body ? JSON.stringify(body) : undefined
+    });
+    if (r.status === 401 && !retried) {          /* token expired — re-auth once */
+      await this._createSession();
+      return this._pdsCall(nsid, { method, params, body, retried: true });
+    }
+    if (!r.ok) throw new Error(nsid + ' -> ' + r.status);
+    return r.json();
+  }
+
+  /* ================= signaling over ATProto records ================= */
+
+  async _sendSignal(toDid, msgType, payload) {
+    return this._pdsCall('com.atproto.repo.createRecord', {
+      method: 'POST',
+      body: {
+        repo: this.me.did,
+        collection: this.collection,
+        record: {
+          $type: this.collection,
+          to: toDid,
+          msgType: msgType,           /* 'offer' | 'answer' | 'knock' */
+          payload: payload,
+          createdAt: new Date().toISOString()
+        }
+      }
+    });
+  }
+
+  async _deleteOwnRecord(rkey) {
+    try {
+      await this._pdsCall('com.atproto.repo.deleteRecord', {
+        method: 'POST',
+        body: { repo: this.me.did, collection: this.collection, rkey: rkey }
+      });
+    } catch (e) { console.debug('[atproto-rtc] delete failed:', e.message); }
+  }
+
+  async _listMyRecords() {
+    const j = await this._pdsCall('com.atproto.repo.listRecords', {
+      params: { repo: this.me.did, collection: this.collection, limit: 100 }
+    });
+    return j.records || [];
+  }
+
+  /** Unauthenticated read of a peer's repo, straight from their PDS. */
+  async _listPeerRecords(peer) {
+    const url = peer.pds + '/xrpc/com.atproto.repo.listRecords?' +
+      new URLSearchParams({ repo: peer.did, collection: this.collection, limit: '50' });
+    const r = await fetch(url);
+    if (!r.ok) throw new Error('listRecords on ' + peer.handle + ' -> ' + r.status);
+    return (await r.json()).records || [];
+  }
+
+  async _sweepOwnSignals() {
+    /* remove only records past the TTL: another tab signed into the SAME
+       account may have live handshakes in flight — deleting everything
+       would sever them. Fresh garbage ages out and is swept next time. */
+    try {
+      const recs = await this._listMyRecords();
+      let n = 0;
+      for (const rec of recs) {
+        const age = Date.now() - Date.parse(String((rec.value || {}).createdAt || ''));
+        if (isNaN(age) || age > this.signalTtlS * 1000) {
+          await this._deleteOwnRecord(rec.uri.split('/').pop());
+          n++;
+        }
+      }
+      if (n) console.debug('[atproto-rtc] sweep removed', n, 'stale signal records');
+    } catch (e) { console.debug('[atproto-rtc] sweep failed:', e.message); }
+  }
+
+  /* ================= peers state ================= */
+
+  _upsertPeer(did, handle, pds, trusted) {
+    let p = this.peers.get(did);
+    if (p) {
+      if (trusted && !p.trusted) { p.trusted = true; this.emit('statechange', did, p); }
+      return p;
+    }
+    p = {
+      did, handle, pds, trusted: !!trusted,
+      pc: null, dc: null, conn: null,
+      offerRkey: null, answerRkey: null, knockRkey: null,
+      sending: false
+    };
+    this.peers.set(did, p);
+    this.emit('statechange', did, p);
+    return p;
+  }
+
+  /* ================= WebRTC (vanilla ICE: candidates embedded in SDP) ================= */
+
+  _summarizeCandidates(tag, sdp) {
+    const lines = (sdp.match(/a=candidate:[^\r\n]+/g) || []);
+    const types = {};
+    let mdns = 0;
+    for (const l of lines) {
+      const parts = l.split(' ');
+      const typ = parts[parts.indexOf('typ') + 1] || '?';
+      types[typ] = (types[typ] || 0) + 1;
+      if (/\.local\b/.test(l)) mdns++;
+    }
+    console.debug('[atproto-rtc][ice]', tag, lines.length, 'candidates', JSON.stringify(types), mdns + ' mDNS-masked');
+    if (!lines.length) console.debug('[atproto-rtc][ice]', tag, 'WARNING: zero candidates in SDP');
+  }
+
+  async _logSelectedPair(pc, peerId) {
+    try {
+      const stats = await pc.getStats();
+      stats.forEach((s) => {
+        if (s.type === 'candidate-pair' && (s.selected || s.state === 'succeeded') && s.nominated) {
+          const local = stats.get(s.localCandidateId) || {};
+          const remote = stats.get(s.remoteCandidateId) || {};
+          console.debug('[atproto-rtc][ice] selected pair with', peerId, ':',
+            local.candidateType, local.address || local.ip, '<->',
+            remote.candidateType, remote.address || remote.ip);
+        }
+      });
+    } catch (e) { console.debug('[atproto-rtc][ice] getStats failed:', e.message); }
+  }
+
+  _waitIceComplete(pc) {
+    if (pc.iceGatheringState === 'complete') return Promise.resolve();
+    return new Promise((resolve) => {
+      const t = setTimeout(resolve, 3000); /* cap the wait */
+      pc.addEventListener('icegatheringstatechange', () => {
+        if (pc.iceGatheringState === 'complete') { clearTimeout(t); resolve(); }
+      });
+    });
+  }
+
+  _makePC(did) {
+    const pc = new RTCPeerConnection({ iceServers: this.iceServers });
+    pc.oniceconnectionstatechange = () => {
+      console.debug('[atproto-rtc][ice]', did, 'iceConnectionState ->', pc.iceConnectionState);
+      if (pc.iceConnectionState === 'connected' || pc.iceConnectionState === 'completed') {
+        this._logSelectedPair(pc, did);
+      }
+    };
+    pc.onconnectionstatechange = () => {
+      console.debug('[atproto-rtc]', did, '->', pc.connectionState);
+      const p = this.peers.get(did);
+      if (!p) return;
+      if (pc.connectionState === 'connected') {
+        /* signaling done — remove our offer/answer/knock records */
+        if (p.offerRkey)  { this._deleteOwnRecord(p.offerRkey);  p.offerRkey = null; }
+        if (p.answerRkey) { this._deleteOwnRecord(p.answerRkey); p.answerRkey = null; }
+        if (p.knockRkey)  { this._deleteOwnRecord(p.knockRkey);  p.knockRkey = null; }
+      }
+      if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected' || pc.connectionState === 'closed') {
+        p.pc = null; p.dc = null;
+        if (p.conn) p.conn.emit('close');
+        p.conn = null;
+      }
+      this.emit('statechange', did, p);
+      if (p.conn) p.conn.emit('statechange', pc.connectionState);
+    };
+    return pc;
+  }
+
+  _bindDataChannel(dc, did) {
+    dc.binaryType = 'arraybuffer';
+    const p = this.peers.get(did);
+    dc.onopen = () => {
+      console.debug('[atproto-rtc][dc] open with', did);
+      if (p) { p.dc = dc; if (p.conn) { p.conn.channel = dc; p.conn.emit('open'); } this.emit('statechange', did, p); }
+    };
+    dc.onclose = () => {
+      if (p) { p.dc = null; if (p.conn) p.conn.emit('close'); this.emit('statechange', did, p); }
+    };
+    dc.onerror = (ev) => {
+      if (p && p.conn) p.conn.emit('error', ev);
+      this.emit('error', did, ev);
+    };
+    dc.onmessage = (ev) => {
+      if (p && p.conn) p.conn.emit('message', ev.data);
+      this.emit('message', did, ev.data);   /* top-level: covers peer-initiated
+                                               connections that never got a conn
+                                               wrapper via connect() */
+    };
+  }
+
+  async _offerTo(did) {
+    const p = this.peers.get(did);
+    if (!p || p.pc) return;
+    console.debug('[atproto-rtc] offering to', p.handle);
+    const pc = this._makePC(did);
+    p.pc = pc;
+    if (p.conn) p.conn.pc = pc;
+    const dc = pc.createDataChannel('atproto-rtc', { ordered: true });
+    p.dc = dc;
+    if (p.conn) p.conn.channel = dc;
+    this._bindDataChannel(dc, did);
+    try {
+      await pc.setLocalDescription(await pc.createOffer());
+      await this._waitIceComplete(pc);
+      this._summarizeCandidates('local offer to ' + p.handle, pc.localDescription.sdp);
+      const res = await this._sendSignal(did, 'offer', pc.localDescription.sdp);
+      p.offerRkey = res.uri.split('/').pop();
+    } catch (e) {
+      /* failed to publish the offer — reset so the next poll tick retries cleanly */
+      try { pc.close(); } catch (e2) {}
+      p.pc = null; p.dc = null;
+      throw e;
+    }
+    this.emit('statechange', did, p);
+  }
+
+  async _handleOffer(did, sdp) {
+    const p = this.peers.get(did);
+    if (!p) return;
+    if (p.pc && p.pc.connectionState === 'connected') return;  /* already up */
+    if (p.pc) { try { p.pc.close(); } catch (e) {} }
+    console.debug('[atproto-rtc] answering', p.handle);
+    const pc = this._makePC(did);
+    p.pc = pc;
+    if (p.conn) p.conn.pc = pc;
+    pc.ondatachannel = (ev) => {
+      p.dc = ev.channel;
+      if (p.conn) p.conn.channel = ev.channel;
+      this._bindDataChannel(ev.channel, did);
+    };
+    try {
+      this._summarizeCandidates('remote offer from ' + p.handle, sdp);
+      await pc.setRemoteDescription({ type: 'offer', sdp: sdp });
+      await pc.setLocalDescription(await pc.createAnswer());
+      await this._waitIceComplete(pc);
+      this._summarizeCandidates('local answer to ' + p.handle, pc.localDescription.sdp);
+      const res = await this._sendSignal(did, 'answer', pc.localDescription.sdp);
+      p.answerRkey = res.uri.split('/').pop();
+    } catch (e) {
+      /* failed mid-answer — reset; caller unmarks the offer record for retry */
+      try { pc.close(); } catch (e2) {}
+      p.pc = null; p.dc = null;
+      throw e;
+    }
+    this.emit('statechange', did, p);
+  }
+
+  async _handleAnswer(did, sdp) {
+    const p = this.peers.get(did);
+    if (!p || !p.pc || p.pc.signalingState !== 'have-local-offer') return;
+    console.debug('[atproto-rtc] got answer from', p.handle);
+    this._summarizeCandidates('remote answer from ' + p.handle, sdp);
+    await p.pc.setRemoteDescription({ type: 'answer', sdp: sdp });
+  }
+
+  /* ================= poll loop ================= */
+
+  async _pollPeer(did) {
+    const p = this.peers.get(did);
+    if (!p) return;
+    const recs = await this._listPeerRecords(p);
+    /* oldest-first so offer/answer arrive in order */
+    recs.sort((a, b) => String((a.value || {}).createdAt || '').localeCompare(String((b.value || {}).createdAt || '')));
+    for (const rec of recs) {
+      if (this._seenUris.has(rec.uri)) continue;
+      const v = rec.value || {};
+      if (v.to !== this.me.did) continue;
+      const age = Date.now() - Date.parse(String(v.createdAt || ''));
+      if (isNaN(age) || age > this.signalTtlS * 1000) { this._seenUris.set(rec.uri, Date.now()); continue; }
+      this._seenUris.set(rec.uri, Date.now());
+      try {
+        if (v.msgType === 'offer')  await this._handleOffer(did, String(v.payload || ''));
+        if (v.msgType === 'answer') await this._handleAnswer(did, String(v.payload || ''));
+      } catch (e) {
+        /* transient failure (e.g. answer write) — unmark so the record is retried */
+        this._seenUris.delete(rec.uri);
+        throw e;
+      }
+    }
+  }
+
+  async _poll() {
+    /* prune tracking state so hostile record churn can't grow memory unboundedly */
+    const cutoff = Date.now() - this.signalTtlS * 1000;
+    for (const [uri, ts] of this._seenUris) if (ts < cutoff) this._seenUris.delete(uri);
+    if (this._discoverChecked.size > 5000) this._discoverChecked.clear();  /* re-verification is cheap and gated */
+    for (const did of this.peers.keys()) {
+      try {
+        const p = this.peers.get(did);
+        if (!p.trusted) continue;   /* consent gate: no polling, offering, or knocking until accepted */
+        const connected = p.dc && p.dc.readyState === 'open';
+        if (!connected) await this._pollPeer(did);
+        /* glare avoidance: lexicographically smaller DID initiates.
+           The larger DID instead writes a one-time 'knock' so the peer
+           can discover us via the backlink index without typing anything. */
+        if (!p.pc && this.me.did < did) await this._offerTo(did);
+        else if (!p.pc && !p.knockRkey && this.me.did > did) {
+          const res = await this._sendSignal(did, 'knock', '');
+          p.knockRkey = res.uri.split('/').pop();
+          console.debug('[atproto-rtc][knock] sent to', p.handle);
+        }
+      } catch (e) {
+        /* isolate: one peer's bad records or network hiccup must not halt polling of others */
+        console.debug('[atproto-rtc][poll]', did, 'error:', e.message);
+      }
+    }
+    if (this._running) this._pollTimer = setTimeout(() => this._poll(), this.pollMs);
+  }
+
+  /* ================= peer discovery via Constellation backlink index ================
+     constellation.microcosm.blue indexes firehose records by link target
+     (~seconds of latency, verified). Any signal record addressed to our
+     DID — offer or knock — shows up as a backlink, letting us discover a
+     peer we never typed. Each hit is only a HINT (the index may retain
+     deleted records), so we confirm a live, TTL-valid record in the
+     peer's repo before surfacing them. */
+
+  /**
+   * Poll Constellation once for backlinks (signal records addressed to
+   * `me.did`), verify liveness directly against each candidate's repo,
+   * and surface untrusted candidates via `onIncoming`. Returns the list
+   * of DIDs discovered as pending/trusted requests in this pass.
+   */
+  async discoverPeers() {
+    const found = [];
+    try {
+      const q = 'https://constellation.microcosm.blue/xrpc/blue.microcosm.links.getBacklinks?' +
+        new URLSearchParams({ subject: this.me.did, source: this.collection + ':to', limit: '50' });
+      const r = await fetch(q);
+      if (!r.ok) throw new Error('getBacklinks -> ' + r.status);
+      const j = await r.json();
+      for (const rec of (j.records || [])) {
+        const did = rec.did;
+        const key = did + '/' + rec.rkey;  /* per-record: a fresh knock re-triggers verification */
+        if (did === this.me.did || this.peers.has(did) || this._ignoredDids.has(did) || this._discoverChecked.has(key)) continue;
+        this._discoverChecked.add(key);
+        try {
+          const pds = await AtprotoRTC.resolvePds(did);
+          const live = (await this._listPeerRecords({ did, pds, handle: did })).some(x => {
+            const v = x.value || {};
+            const age = Date.now() - Date.parse(String(v.createdAt || ''));
+            return v.to === this.me.did && !isNaN(age) && age <= this.signalTtlS * 1000;
+          });
+          if (!live) continue;             /* stale index entry — ignore */
+          const dr = await fetch(pds + '/xrpc/com.atproto.repo.describeRepo?repo=' + encodeURIComponent(did));
+          const handle = dr.ok ? (await dr.json()).handle : did;
+          console.debug('[atproto-rtc][discover] live signal from', handle);
+
+          const p = this._upsertPeer(did, handle, pds, false);   /* untrusted: pending request */
+          found.push({ did, handle, pds });
+
+          const accept = await this.onIncoming(did);
+          if (accept) {
+            p.trusted = true;
+            this.emit('statechange', did, p);
+          }
+        } catch (e) { console.debug('[atproto-rtc][discover]', did, '->', e.message); }
+      }
+    } catch (e) {
+      console.debug('[atproto-rtc][discover] error:', e.message);
+    }
+    return found;
+  }
+
+  /* ================= public API ================= */
+
+  /**
+   * Start the poll loop and periodic discovery. Idempotent.
+   */
+  start() {
+    if (this._running) return;
+    this._running = true;
+    this._poll();
+    const loop = async () => {
+      if (!this._running) return;
+      await this.discoverPeers();
+      if (this._running) this._discoverTimer = setTimeout(loop, this.discoverMs);
+    };
+    loop();
+  }
+
+  /**
+   * Stop the poll loop and discovery. Does not close existing connections.
+   */
+  stop() {
+    this._running = false;
+    if (this._pollTimer) clearTimeout(this._pollTimer);
+    if (this._discoverTimer) clearTimeout(this._discoverTimer);
+    this._pollTimer = null;
+    this._discoverTimer = null;
+  }
+
+  /**
+   * Explicitly add / connect to a peer by handle or DID. Marks the peer
+   * TRUSTED (user-initiated pairing), enabling polling and offer/knock
+   * exchange for it in the poll loop. Returns an AtprotoRTCConnection
+   * immediately (before the handshake completes); listen for 'open'.
+   */
+  async connect(didOrHandle) {
+    const did = didOrHandle.startsWith('did:')
+      ? didOrHandle
+      : await AtprotoRTC.resolveHandle(didOrHandle);
+    if (did === this.me.did) throw new Error("That's you.");
+    const pds = await AtprotoRTC.resolvePds(did);
+    const handle = didOrHandle.startsWith('did:') ? did : didOrHandle;
+    const p = this._upsertPeer(did, handle, pds, true);   /* user-initiated = trusted */
+    if (!p.conn) {
+      const conn = new AtprotoRTCConnection(did);
+      conn.pc = p.pc;
+      conn.channel = p.dc;
+      p.conn = conn;
+    }
+    console.debug('[atproto-rtc] connecting to', handle);
+    return p.conn;
+  }
+
+  /**
+   * Mark a previously-discovered (untrusted) peer as trusted, enabling
+   * connection attempts. Use from application code driven by onIncoming
+   * if not handled synchronously there.
+   */
+  accept(did) {
+    const p = this.peers.get(did);
+    if (!p) return;
+    p.trusted = true;
+    this.emit('statechange', did, p);
+  }
+
+  /**
+   * Reject/dismiss a discovered peer for this session; further discovery
+   * hits for this DID are ignored until page reload.
+   */
+  ignore(did) {
+    this._ignoredDids.add(did);
+    const p = this.peers.get(did);
+    if (p) {
+      if (p.pc) { try { p.pc.close(); } catch (e) {} }
+      this.peers.delete(did);
+    }
+  }
+
+  /**
+   * Close a connection and forget the peer's live state (offer/answer
+   * rkeys are left for the poll loop / connectionstate handler to clean
+   * up as usual).
+   */
+  disconnect(did) {
+    const p = this.peers.get(did);
+    if (!p) return;
+    if (p.conn) p.conn.close();
+    if (p.pc) { try { p.pc.close(); } catch (e) {} }
+    p.pc = null; p.dc = null; p.conn = null;
+  }
+
+  /**
+   * Best-effort cleanup of in-flight signal records for all peers. Call
+   * from a `beforeunload` handler. Uses `keepalive: true` fetches.
+   */
+  teardown() {
+    for (const p of this.peers.values()) {
+      for (const rkey of [p.offerRkey, p.answerRkey, p.knockRkey]) {
+        if (!rkey || !this.me.accessJwt) continue;
+        fetch(this.me.pds + '/xrpc/com.atproto.repo.deleteRecord', {
+          method: 'POST', keepalive: true,
+          headers: { 'Authorization': 'Bearer ' + this.me.accessJwt, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ repo: this.me.did, collection: this.collection, rkey: rkey })
+        }).catch(() => {});
+      }
+    }
+  }
+}

--- a/bsky/filedrop.html
+++ b/bsky/filedrop.html
@@ -221,21 +221,23 @@
 <input type="file" id="file-input" style="display:none">
 
 <script type="module">
+import { AtprotoRTC } from '/bsky/atproto-rtc.js';
+
 /* ============================================================
    ATProto FileDrop — P2P file transfer, ATProto-record signaling.
    File bytes travel ONLY over WebRTC data channels between the
-   two browsers. ATProto carries just SDP offer/answer text (a
-   few KB) during connection setup: each side writes a signal
-   record into its OWN repo, and polls the PEER's repo for
-   records addressed to it. Records are deleted once consumed
-   and swept at sign-in.
+   two browsers. All identity resolution, session auth, signal
+   records (writes to own repo / reads of peer repo), sweeping,
+   polling, offer/answer/knock, glare avoidance, Constellation
+   discovery, consent gating, and PeerConnection/data-channel
+   setup are owned by atproto-rtc.js. This file owns only the
+   file-transfer protocol layered on top of the resulting data
+   channel, and the UI.
    ============================================================ */
 
-const COLLECTION   = 'com.austegard.filedrop.signal';
-const POLL_MS      = 2000;
-const SIGNAL_TTL_S = 300;           /* signals older than this are stale */
-const CHUNK_SIZE   = 64 * 1024;
-const BUF_HIGH     = 1024 * 1024;   /* backpressure threshold */
+const COLLECTION  = 'com.austegard.filedrop.signal';
+const CHUNK_SIZE  = 64 * 1024;
+const BUF_HIGH    = 1024 * 1024;   /* backpressure threshold */
 
 /* Peers are typically on different networks, connecting across the
    internet via server-reflexive candidates. STUN is therefore required,
@@ -247,7 +249,8 @@ const BUF_HIGH     = 1024 * 1024;   /* backpressure threshold */
 const ICE_SERVERS = location.hash.includes('nostun')
   ? []
   : [{ urls: 'stun:stun.l.google.com:19302' }];
-console.log('[rtc] iceServers:', JSON.stringify(ICE_SERVERS));
+
+const rtc = new AtprotoRTC({ collection: COLLECTION, iceServers: ICE_SERVERS });
 
 /* ---------- tiny DOM helpers ---------- */
 const $ = (id) => document.getElementById(id);
@@ -255,147 +258,20 @@ const setStatus = (t) => { $('status').textContent = t; };
 const showErr = (t) => { const e = $('err'); e.textContent = t; e.classList.add('on'); console.error('[filedrop]', t); };
 const clearErr = () => $('err').classList.remove('on');
 
-/* ---------- ATProto identity + auth ----------
-   Handle -> DID via the public AppView; DID -> PDS endpoint via the
-   DID document (plc.directory for did:plc, .well-known for did:web).
-   Session (accessJwt) is created against the user's OWN PDS. Reads of
-   a PEER's repo use unauthenticated listRecords on the peer's PDS. */
+/* ---------- UI-side peer state (row element, transfer state) ----------
+   The library owns did/handle/pds/trusted/pc/dc; filedrop.html keeps a
+   parallel map for UI + file-transfer state, keyed by the same DID. */
+const rows = new Map();   /* did -> { el, sending, sendQueue, recv } */
 
-async function resolveHandle(handle) {
-  const r = await fetch('https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=' + encodeURIComponent(handle));
-  if (!r.ok) throw new Error('Could not resolve handle ' + handle + ' (' + r.status + ')');
-  return (await r.json()).did;
+function uiFor(did) {
+  let u = rows.get(did);
+  if (!u) { u = { el: null, sending: false, sendQueue: [], recv: null }; rows.set(did, u); }
+  return u;
 }
 
-async function resolvePds(did) {
-  let doc;
-  if (did.startsWith('did:plc:')) {
-    const r = await fetch('https://plc.directory/' + did);
-    if (!r.ok) throw new Error('plc.directory lookup failed for ' + did);
-    doc = await r.json();
-  } else if (did.startsWith('did:web:')) {
-    const host = did.slice('did:web:'.length).split(':').join('/');
-    const r = await fetch('https://' + host + '/.well-known/did.json');
-    if (!r.ok) throw new Error('did:web lookup failed for ' + did);
-    doc = await r.json();
-  } else {
-    throw new Error('Unsupported DID method: ' + did);
-  }
-  const svc = (doc.service || []).find(s => s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer');
-  if (!svc) throw new Error('No PDS endpoint in DID document for ' + did);
-  return svc.serviceEndpoint;
-}
-
-const me = { handle: null, did: null, pds: null, accessJwt: null, password: null };
-
-async function createSession() {
-  const r = await fetch(me.pds + '/xrpc/com.atproto.server.createSession', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ identifier: me.handle, password: me.password })
-  });
-  if (!r.ok) {
-    const body = await r.json().catch(() => ({}));
-    throw new Error('Sign-in failed: ' + (body.message || r.status));
-  }
-  const j = await r.json();
-  me.accessJwt = j.accessJwt;
-  me.did = j.did;
-}
-
-async function pdsCall(nsid, { method = 'GET', params, body, retried } = {}) {
-  let url = me.pds + '/xrpc/' + nsid;
-  if (params) url += '?' + new URLSearchParams(params);
-  const r = await fetch(url, {
-    method,
-    headers: {
-      'Authorization': 'Bearer ' + me.accessJwt,
-      ...(body ? { 'Content-Type': 'application/json' } : {})
-    },
-    body: body ? JSON.stringify(body) : undefined
-  });
-  if (r.status === 401 && !retried) {          /* token expired — re-auth once */
-    await createSession();
-    return pdsCall(nsid, { method, params, body, retried: true });
-  }
-  if (!r.ok) throw new Error(nsid + ' -> ' + r.status);
-  return r.json();
-}
-
-/* ---------- signaling over ATProto records ---------- */
-async function sendSignal(toDid, msgType, payload) {
-  return pdsCall('com.atproto.repo.createRecord', {
-    method: 'POST',
-    body: {
-      repo: me.did,
-      collection: COLLECTION,
-      record: {
-        $type: COLLECTION,
-        to: toDid,
-        msgType: msgType,           /* 'offer' | 'answer' */
-        payload: payload,
-        createdAt: new Date().toISOString()
-      }
-    }
-  });
-}
-
-async function deleteOwnRecord(rkey) {
-  try {
-    await pdsCall('com.atproto.repo.deleteRecord', {
-      method: 'POST',
-      body: { repo: me.did, collection: COLLECTION, rkey: rkey }
-    });
-  } catch (e) { console.log('[sp] delete failed:', e.message); }
-}
-
-async function listMyRecords() {
-  const j = await pdsCall('com.atproto.repo.listRecords', {
-    params: { repo: me.did, collection: COLLECTION, limit: 100 }
-  });
-  return j.records || [];
-}
-
-/* Unauthenticated read of a peer's repo, straight from their PDS. */
-async function listPeerRecords(peer) {
-  const url = peer.pds + '/xrpc/com.atproto.repo.listRecords?' +
-    new URLSearchParams({ repo: peer.did, collection: COLLECTION, limit: '50' });
-  const r = await fetch(url);
-  if (!r.ok) throw new Error('listRecords on ' + peer.handle + ' -> ' + r.status);
-  return (await r.json()).records || [];
-}
-
-async function sweepOwnSignals() {
-  /* remove only records past the TTL: another tab signed into the SAME
-     account may have live handshakes in flight — deleting everything
-     would sever them. Fresh garbage ages out and is swept next time. */
-  try {
-    const recs = await listMyRecords();
-    let n = 0;
-    for (const rec of recs) {
-      const age = Date.now() - Date.parse(String((rec.value || {}).createdAt || ''));
-      if (isNaN(age) || age > SIGNAL_TTL_S * 1000) {
-        await deleteOwnRecord(rec.uri.split('/').pop());
-        n++;
-      }
-    }
-    if (n) console.log('[sweep] removed', n, 'stale signal records');
-  } catch (e) { console.log('[sweep] failed:', e.message); }
-}
-
-/* ---------- peers state ---------- */
-const peers = new Map();   /* did -> { did, handle, pds, trusted, pc, dc, el, recv, offerRkey, answerRkey, knockRkey } */
-const seenUris = new Map();      /* uri -> first-seen ms; pruned past TTL */
-const ignoredDids = new Set();   /* session-scoped: dismissed connection requests */
-
-function upsertPeerRow(did, handle, pds, trusted) {
-  let p = peers.get(did);
-  if (p) {
-    if (trusted && !p.trusted) { p.trusted = true; renderPeer(p, did); }
-    return p;
-  }
-  p = { did, handle, pds, trusted: !!trusted, pc: null, dc: null, el: null, recv: null, offerRkey: null, answerRkey: null, knockRkey: null };
-  peers.set(did, p);
+function ensureRow(did, handle) {
+  let u = uiFor(did);
+  if (u.el) return u;
   const el = document.createElement('div');
   el.className = 'peer';
   el.innerHTML = '<div><div class="pname"></div><div class="pstate">waiting for peer</div></div>' +
@@ -404,21 +280,22 @@ function upsertPeerRow(did, handle, pds, trusted) {
                  '<button class="acc" style="display:none;margin-left:auto">Accept</button>' +
                  '<button class="ign ghost" style="display:none">Ignore</button>' +
                  '<div class="files"></div>';
+  el.querySelector('.pname').textContent = handle;
   el.querySelector('button.send').addEventListener('click', () => pickAndSend(did));
   el.querySelector('button.acc').addEventListener('click', () => {
-    const pp = peers.get(did);
-    if (pp) { pp.trusted = true; renderPeer(pp, did); setStatus('Connecting to ' + pp.handle + '\u2026'); }
+    rtc.accept(did);
+    setStatus('Connecting to ' + handle + '\u2026');
   });
   el.querySelector('button.ign').addEventListener('click', () => {
-    ignoredDids.add(did);
-    const pp = peers.get(did);
-    if (pp) { if (pp.pc) try { pp.pc.close(); } catch (e) {} pp.el.remove(); peers.delete(did); }
+    rtc.ignore(did);
+    el.remove();
+    rows.delete(did);
   });
   /* the peer card itself is a drop target */
   ['dragenter', 'dragover'].forEach((ev) => el.addEventListener(ev, (e) => {
     e.preventDefault();
-    const pp = peers.get(did);
-    if (pp && pp.dc && pp.dc.readyState === 'open') el.classList.add('hover');
+    const p = rtc.peers.get(did);
+    if (p && p.dc && p.dc.readyState === 'open') el.classList.add('hover');
   }));
   el.addEventListener('dragleave', (e) => { e.preventDefault(); el.classList.remove('hover'); });
   el.addEventListener('drop', (e) => {
@@ -428,165 +305,34 @@ function upsertPeerRow(did, handle, pds, trusted) {
     if (f) offerFile(did, f);
   });
   $('peers').appendChild(el);
-  p.el = el;
-  renderPeer(p, did);
-  return p;
+  u.el = el;
+  return u;
 }
 
-function renderPeer(p, did) {
-  p.el.querySelector('.pname').textContent = p.handle;
-  const st = p.el.querySelector('.pstate');
+function renderPeer(did) {
+  const p = rtc.peers.get(did);
+  if (!p) return;
+  const u = ensureRow(did, p.handle);
+  u.el.querySelector('.pname').textContent = p.handle;
+  const st = u.el.querySelector('.pstate');
   const connected = p.dc && p.dc.readyState === 'open';
   st.textContent = !p.trusted ? 'wants to connect'
     : connected ? 'connected' : (p.pc ? 'connecting\u2026' : 'waiting for peer');
   st.classList.toggle('connected', connected);
-  p.el.querySelector('button.send').disabled = !connected;
-  p.el.querySelector('button.send').style.display = p.trusted ? '' : 'none';
-  p.el.querySelector('button.acc').style.display = p.trusted ? 'none' : '';
-  p.el.querySelector('button.ign').style.display = p.trusted ? 'none' : '';
-  p.el.classList.toggle('droppable', connected);
-  p.el.querySelector('.drop-hint').textContent = connected ? 'drop a file here or' : '';
+  u.el.querySelector('button.send').disabled = !connected;
+  u.el.querySelector('button.send').style.display = p.trusted ? '' : 'none';
+  u.el.querySelector('button.acc').style.display = p.trusted ? 'none' : '';
+  u.el.querySelector('button.ign').style.display = p.trusted ? 'none' : '';
+  u.el.classList.toggle('droppable', connected);
+  u.el.querySelector('.drop-hint').textContent = connected ? 'drop a file here or' : '';
 }
 
-/* ---------- WebRTC (vanilla ICE: candidates embedded in SDP) ---------- */
-function summarizeCandidates(tag, sdp) {
-  const lines = (sdp.match(/a=candidate:[^\r\n]+/g) || []);
-  const types = {};
-  let mdns = 0;
-  for (const l of lines) {
-    const parts = l.split(' ');
-    const typ = parts[parts.indexOf('typ') + 1] || '?';
-    types[typ] = (types[typ] || 0) + 1;
-    if (/\.local\b/.test(l)) mdns++;
-  }
-  console.log('[ice]', tag, lines.length, 'candidates', JSON.stringify(types), mdns + ' mDNS-masked');
-  if (!lines.length) console.log('[ice]', tag, 'WARNING: zero candidates in SDP');
-}
-
-async function logSelectedPair(pc, peerId) {
-  try {
-    const stats = await pc.getStats();
-    stats.forEach((s) => {
-      if (s.type === 'candidate-pair' && (s.selected || s.state === 'succeeded') && s.nominated) {
-        const local = stats.get(s.localCandidateId) || {};
-        const remote = stats.get(s.remoteCandidateId) || {};
-        console.log('[ice] selected pair with', peerId, ':',
-          local.candidateType, local.address || local.ip, '<->',
-          remote.candidateType, remote.address || remote.ip);
-      }
-    });
-  } catch (e) { console.log('[ice] getStats failed:', e.message); }
-}
-
-function waitIceComplete(pc) {
-  if (pc.iceGatheringState === 'complete') return Promise.resolve();
-  return new Promise((resolve) => {
-    const t = setTimeout(resolve, 3000); /* cap the wait */
-    pc.addEventListener('icegatheringstatechange', () => {
-      if (pc.iceGatheringState === 'complete') { clearTimeout(t); resolve(); }
-    });
-  });
-}
-
-function makePC(did) {
-  const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
-  pc.oniceconnectionstatechange = () => {
-    console.log('[ice]', did, 'iceConnectionState ->', pc.iceConnectionState);
-    if (pc.iceConnectionState === 'connected' || pc.iceConnectionState === 'completed') {
-      logSelectedPair(pc, did);
-    }
-  };
-  pc.onconnectionstatechange = () => {
-    console.log('[rtc]', did, '->', pc.connectionState);
-    const p = peers.get(did);
-    if (!p) return;
-    if (pc.connectionState === 'connected') {
-      /* signaling done — remove our offer/answer records */
-      if (p.offerRkey)  { deleteOwnRecord(p.offerRkey);  p.offerRkey = null; }
-      if (p.answerRkey) { deleteOwnRecord(p.answerRkey); p.answerRkey = null; }
-      if (p.knockRkey)  { deleteOwnRecord(p.knockRkey);  p.knockRkey = null; }
-    }
-    if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected' || pc.connectionState === 'closed') {
-      p.pc = null; p.dc = null; renderPeer(p, did);
-    } else {
-      renderPeer(p, did);
-    }
-  };
-  return pc;
-}
-
-function bindDataChannel(dc, did) {
-  dc.binaryType = 'arraybuffer';
-  dc.onopen = () => {
-    console.log('[dc] open with', did);
-    const p = peers.get(did); if (p) renderPeer(p, did);
-  };
-  dc.onclose = () => {
-    const p = peers.get(did); if (p) { p.dc = null; renderPeer(p, did); }
-  };
-  dc.onmessage = (ev) => handleChannelMessage(did, ev.data);
-}
-
-async function offerTo(did) {
-  const p = peers.get(did);
-  if (!p || p.pc) return;
-  console.log('[rtc] offering to', p.handle);
-  const pc = makePC(did);
-  p.pc = pc;
-  const dc = pc.createDataChannel('filedrop', { ordered: true });
-  p.dc = dc;
-  bindDataChannel(dc, did);
-  try {
-    await pc.setLocalDescription(await pc.createOffer());
-    await waitIceComplete(pc);
-    summarizeCandidates('local offer to ' + p.handle, pc.localDescription.sdp);
-    const res = await sendSignal(did, 'offer', pc.localDescription.sdp);
-    p.offerRkey = res.uri.split('/').pop();
-  } catch (e) {
-    /* failed to publish the offer — reset so the next poll tick retries cleanly */
-    try { pc.close(); } catch (e2) {}
-    p.pc = null; p.dc = null;
-    throw e;
-  }
-  renderPeer(p, did);
-}
-
-async function handleOffer(did, sdp) {
-  const p = peers.get(did);
-  if (!p) return;
-  if (p.pc && p.pc.connectionState === 'connected') return;  /* already up */
-  if (p.pc) { try { p.pc.close(); } catch (e) {} }
-  console.log('[rtc] answering', p.handle);
-  const pc = makePC(did);
-  p.pc = pc;
-  pc.ondatachannel = (ev) => { p.dc = ev.channel; bindDataChannel(ev.channel, did); };
-  try {
-    summarizeCandidates('remote offer from ' + p.handle, sdp);
-    await pc.setRemoteDescription({ type: 'offer', sdp: sdp });
-    await pc.setLocalDescription(await pc.createAnswer());
-    await waitIceComplete(pc);
-    summarizeCandidates('local answer to ' + p.handle, pc.localDescription.sdp);
-    const res = await sendSignal(did, 'answer', pc.localDescription.sdp);
-    p.answerRkey = res.uri.split('/').pop();
-  } catch (e) {
-    /* failed mid-answer — reset; caller unmarks the offer record for retry */
-    try { pc.close(); } catch (e2) {}
-    p.pc = null; p.dc = null;
-    throw e;
-  }
-  renderPeer(p, did);
-}
-
-async function handleAnswer(did, sdp) {
-  const p = peers.get(did);
-  if (!p || !p.pc || p.pc.signalingState !== 'have-local-offer') return;
-  console.log('[rtc] got answer from', p.handle);
-  summarizeCandidates('remote answer from ' + p.handle, sdp);
-  await p.pc.setRemoteDescription({ type: 'answer', sdp: sdp });
-}
+/* Library statechange fires on any peer add/trust-change/connection-state
+   change — re-render that peer's row. */
+rtc.on('statechange', (did) => renderPeer(did));
 
 /* ---------- file transfer over the data channel ---------- */
-let pendingSend = null;   /* { did, file } awaiting FILE_ACCEPT */
+let pendingSend = null;   /* { did, file, row } awaiting FILE_ACCEPT */
 let pendingOffer = null;  /* { did, meta } shown in toast */
 
 /* Transfers are SERIALIZED per peer per direction. The data channel is one
@@ -599,14 +345,20 @@ async function fileSha256(file) {
   return [...new Uint8Array(digest)].map(b => b.toString(16).padStart(2, '0')).join('');
 }
 
+function dcFor(did) {
+  const p = rtc.peers.get(did);
+  return p ? p.dc : null;
+}
+
 async function offerFile(did, file, row) {
-  const p = peers.get(did);
-  if (!p || !p.dc || p.dc.readyState !== 'open') { showErr('Not connected to ' + (p ? p.handle : did)); return; }
-  if (!row) row = newFileRow(p, file.name, file.size);
-  p.sendQueue = p.sendQueue || [];
-  if (pendingSend || p.sending) {
+  const p = rtc.peers.get(did);
+  const dc = dcFor(did);
+  const u = uiFor(did);
+  if (!dc || dc.readyState !== 'open') { showErr('Not connected to ' + (p ? p.handle : did)); return; }
+  if (!row) row = newFileRow(did, file.name, file.size);
+  if (pendingSend || u.sending) {
     row.set('Queued');
-    p.sendQueue.push({ file: file, row: row });
+    u.sendQueue.push({ file: file, row: row });
     return;
   }
   pendingSend = { did: did, file: file, row: row };   /* reserve BEFORE the hash await
@@ -621,15 +373,16 @@ async function offerFile(did, file, row) {
     sendNext(did);
     return;
   }
-  if (!p.dc || p.dc.readyState !== 'open') { pendingSend = null; row.set('Failed: channel closed', 'bad'); return; }
-  p.dc.send(JSON.stringify({ type: 'FILE_OFFER', name: file.name, size: file.size, mime: file.type, sha256: sha256 }));
+  const dc2 = dcFor(did);
+  if (!dc2 || dc2.readyState !== 'open') { pendingSend = null; row.set('Failed: channel closed', 'bad'); return; }
+  dc2.send(JSON.stringify({ type: 'FILE_OFFER', name: file.name, size: file.size, mime: file.type, sha256: sha256 }));
   row.set('Waiting for accept\u2026');
 }
 
 function sendNext(did) {
-  const p = peers.get(did);
-  if (!p || !p.sendQueue || !p.sendQueue.length) return;
-  const q = p.sendQueue.shift();
+  const u = uiFor(did);
+  if (!u.sendQueue.length) return;
+  const q = u.sendQueue.shift();
   offerFile(did, q.file, q.row);
 }
 
@@ -641,7 +394,8 @@ function pickAndSend(did) {
 }
 
 /* One row per transfer, sender and receiver alike: name, live status, own bar. */
-function newFileRow(p, name, size) {
+function newFileRow(did, name, size) {
+  const u = uiFor(did);
   const el = document.createElement('div');
   el.className = 'file-row';
   el.innerHTML = '<div class="f-line"><span class="f-name"></span>' +
@@ -649,7 +403,7 @@ function newFileRow(p, name, size) {
                  '<div class="bar-wrap"><div class="bar"></div></div>';
   el.querySelector('.f-name').textContent = name;
   el.querySelector('.f-size').textContent = formatBytes(size);
-  p.el.querySelector('.files').appendChild(el);
+  u.el.querySelector('.files').appendChild(el);
   const bar = el.querySelector('.bar');
   const status = el.querySelector('.f-status');
   return {
@@ -668,10 +422,10 @@ function newFileRow(p, name, size) {
 }
 
 function streamFile(did, file, row) {
-  const p = peers.get(did);
-  const dc = p && p.dc;
+  const u = uiFor(did);
+  const dc = dcFor(did);
   if (!dc || dc.readyState !== 'open') { row.set('Failed: channel closed', 'bad'); return; }
-  p.sending = true;
+  u.sending = true;
   let offset = 0;
   const reader = new FileReader();
   const readNext = () => reader.readAsArrayBuffer(file.slice(offset, offset + CHUNK_SIZE));
@@ -684,16 +438,17 @@ function streamFile(did, file, row) {
     } else {
       dc.send(JSON.stringify({ type: 'FILE_DONE' }));
       row.set('Sent \u2713', 'ok');
-      p.sending = false;
+      u.sending = false;
       sendNext(did);
     }
   };
-  reader.onerror = () => { p.sending = false; row.set('Failed: read error', 'bad'); sendNext(did); };
+  reader.onerror = () => { u.sending = false; row.set('Failed: read error', 'bad'); sendNext(did); };
   readNext();
 }
 
 function handleChannelMessage(did, data) {
-  const p = peers.get(did);
+  const p = rtc.peers.get(did);
+  const u = uiFor(did);
   if (!p) return;
   if (typeof data === 'string') {
     let msg;
@@ -703,12 +458,13 @@ function handleChannelMessage(did, data) {
     }
     if (!msg || typeof msg.type !== 'string') return;
     if (msg.type === 'FILE_OFFER') {
-      if (pendingOffer || p.recv) {
+      if (pendingOffer || u.recv) {
         /* one incoming offer at a time, and NEVER while a receive from this
-           peer is streaming — accepting would overwrite p.recv and splice
+           peer is streaming — accepting would overwrite u.recv and splice
            two undemuxable byte streams. Auto-decline; the sender's queue
            (or user) retries after the current transfer. */
-        p.dc.send(JSON.stringify({ type: 'FILE_DECLINE' }));
+        const dc = dcFor(did);
+        if (dc) dc.send(JSON.stringify({ type: 'FILE_DECLINE' }));
         return;
       }
       pendingOffer = { did: did, meta: msg };
@@ -727,20 +483,20 @@ function handleChannelMessage(did, data) {
         sendNext(did);
       }
     } else if (msg.type === 'FILE_DONE') {
-      if (p.recv) finishDownload(did);
+      if (u.recv) finishDownload(did);
     }
   } else {
-    if (!p.recv) return; /* chunks only arrive post-accept by protocol */
-    p.recv.chunks.push(data);
-    p.recv.received += data.byteLength;
-    p.recv.row.progress(p.recv.received, p.recv.meta.size, 'Receiving');
+    if (!u.recv) return; /* chunks only arrive post-accept by protocol */
+    u.recv.chunks.push(data);
+    u.recv.received += data.byteLength;
+    u.recv.row.progress(u.recv.received, u.recv.meta.size, 'Receiving');
   }
 }
 
 async function finishDownload(did) {
-  const p = peers.get(did);
-  const r = p.recv;
-  p.recv = null;
+  const u = uiFor(did);
+  const r = u.recv;
+  u.recv = null;
   const blob = new Blob(r.chunks, { type: r.meta.mime || 'application/octet-stream' });
   let verified = '';
   if (typeof r.meta.sha256 === 'string' && r.meta.sha256.length === 64) {
@@ -769,19 +525,21 @@ $('accept-btn').addEventListener('click', () => {
   if (!pendingOffer) return;
   const { did, meta } = pendingOffer;
   pendingOffer = null;
-  const p = peers.get(did);
-  if (!p || !p.dc || p.dc.readyState !== 'open') { showErr('Sender disconnected'); return; }
-  const row = newFileRow(p, meta.name, meta.size);
+  const dc = dcFor(did);
+  const p = rtc.peers.get(did);
+  if (!dc || dc.readyState !== 'open') { showErr('Sender disconnected'); return; }
+  const row = newFileRow(did, meta.name, meta.size);
   row.set('Receiving\u2026');
-  p.recv = { meta: meta, chunks: [], received: 0, row: row };
-  p.dc.send(JSON.stringify({ type: 'FILE_ACCEPT' }));
+  const u = uiFor(did);
+  u.recv = { meta: meta, chunks: [], received: 0, row: row };
+  dc.send(JSON.stringify({ type: 'FILE_ACCEPT' }));
 });
 
 $('decline-btn').addEventListener('click', () => {
   $('toast').classList.remove('on');
   if (!pendingOffer) return;
-  const p = peers.get(pendingOffer.did);
-  if (p && p.dc && p.dc.readyState === 'open') p.dc.send(JSON.stringify({ type: 'FILE_DECLINE' }));
+  const dc = dcFor(pendingOffer.did);
+  if (dc && dc.readyState === 'open') dc.send(JSON.stringify({ type: 'FILE_DECLINE' }));
   pendingOffer = null;
 });
 
@@ -792,112 +550,28 @@ function formatBytes(b) {
   return (b / 1073741824).toFixed(2) + ' GB';
 }
 
-/* ---------- poll loop ---------- */
-let loginTime = 0;
+/* Data-channel messages via the library's top-level event — covers both
+   self-initiated and peer-initiated connections uniformly. */
+rtc.on('message', (did, data) => handleChannelMessage(did, data));
+rtc.on('statechange', (did) => renderPeer(did));
 
-async function pollPeer(did) {
-  const p = peers.get(did);
-  if (!p) return;
-  const recs = await listPeerRecords(p);
-  /* oldest-first so offer/answer arrive in order */
-  recs.sort((a, b) => String((a.value || {}).createdAt || '').localeCompare(String((b.value || {}).createdAt || '')));
-  for (const rec of recs) {
-    if (seenUris.has(rec.uri)) continue;
-    const v = rec.value || {};
-    if (v.to !== me.did) continue;
-    const age = Date.now() - Date.parse(String(v.createdAt || ''));
-    if (isNaN(age) || age > SIGNAL_TTL_S * 1000) { seenUris.set(rec.uri, Date.now()); continue; }
-    seenUris.set(rec.uri, Date.now());
-    try {
-      if (v.msgType === 'offer')  await handleOffer(did, String(v.payload || ''));
-      if (v.msgType === 'answer') await handleAnswer(did, String(v.payload || ''));
-    } catch (e) {
-      /* transient failure (e.g. answer write) — unmark so the record is retried */
-      seenUris.delete(rec.uri);
-      throw e;
-    }
-  }
-}
-
-async function poll() {
-  /* prune tracking state so hostile record churn can't grow memory unboundedly */
-  const cutoff = Date.now() - SIGNAL_TTL_S * 1000;
-  for (const [uri, ts] of seenUris) if (ts < cutoff) seenUris.delete(uri);
-  if (discoverChecked.size > 5000) discoverChecked.clear();  /* re-verification is cheap and gated */
-  for (const did of peers.keys()) {
-    try {
-      const p = peers.get(did);
-      if (!p.trusted) continue;   /* consent gate: no polling, offering, or knocking until accepted */
-      const connected = p.dc && p.dc.readyState === 'open';
-      if (!connected) await pollPeer(did);
-      /* glare avoidance: lexicographically smaller DID initiates.
-         The larger DID instead writes a one-time 'knock' so the peer
-         can discover us via the backlink index without typing anything. */
-      if (!p.pc && me.did < did) await offerTo(did);
-      else if (!p.pc && !p.knockRkey && me.did > did) {
-        const res = await sendSignal(did, 'knock', '');
-        p.knockRkey = res.uri.split('/').pop();
-        console.log('[knock] sent to', p.handle);
-      }
-    } catch (e) {
-      /* isolate: one peer's bad records or network hiccup must not halt polling of others */
-      console.log('[poll]', did, 'error:', e.message);
-    }
-  }
-  setTimeout(poll, POLL_MS);
-}
-
-/* ---------- peer discovery via Constellation backlink index ----------
-   constellation.microcosm.blue indexes firehose records by link target
-   (~seconds of latency, verified). Any signal record addressed to our
-   DID — offer or knock — shows up as a backlink, letting us discover a
-   peer we never typed. Each hit is only a HINT (the index may retain
-   deleted records), so we confirm a live, TTL-valid record in the
-   peer's repo before adding them. */
-const DISCOVER_MS = 6000;
-const discoverChecked = new Set();
-
-async function discoverPeers() {
-  try {
-    const q = 'https://constellation.microcosm.blue/xrpc/blue.microcosm.links.getBacklinks?' +
-      new URLSearchParams({ subject: me.did, source: COLLECTION + ':to', limit: '50' });
-    const r = await fetch(q);
-    if (!r.ok) throw new Error('getBacklinks -> ' + r.status);
-    const j = await r.json();
-    for (const rec of (j.records || [])) {
-      const did = rec.did;
-      const key = did + '/' + rec.rkey;  /* per-record: a fresh knock re-triggers verification */
-      if (did === me.did || peers.has(did) || ignoredDids.has(did) || discoverChecked.has(key)) continue;
-      discoverChecked.add(key);
-      try {
-        const pds = await resolvePds(did);
-        const live = (await listPeerRecords({ did, pds, handle: did })).some(x => {
-          const v = x.value || {};
-          const age = Date.now() - Date.parse(String(v.createdAt || ''));
-          return v.to === me.did && !isNaN(age) && age <= SIGNAL_TTL_S * 1000;
-        });
-        if (!live) continue;             /* stale index entry — ignore */
-        const dr = await fetch(pds + '/xrpc/com.atproto.repo.describeRepo?repo=' + encodeURIComponent(did));
-        const handle = dr.ok ? (await dr.json()).handle : did;
-        console.log('[discover] live signal from', handle);
-        upsertPeerRow(did, handle, pds, false);   /* untrusted: renders as a connection request */
-        setStatus(handle + ' wants to connect');
-      } catch (e) { console.log('[discover]', did, '->', e.message); }
-    }
-  } catch (e) {
-    console.log('[discover] error:', e.message);
-  } finally {
-    setTimeout(discoverPeers, DISCOVER_MS);
-  }
-}
+/* ---------- consent gate ---------- */
+rtc.onIncoming = async (did) => {
+  /* Surface as a pending row immediately; do not block on a modal.
+     The library already marks the peer untrusted/pending via
+     _upsertPeer before calling this, and statechange has rendered
+     the row. We return false here (don't auto-trust); the user's
+     "Accept" button click calls rtc.accept(did) explicitly. */
+  const p = rtc.peers.get(did);
+  setStatus((p ? p.handle : did) + ' wants to connect');
+  return false;
+};
 
 /* ---------- pairing ---------- */
 async function addPeer(handle) {
-  const did = await resolveHandle(handle);
-  if (did === me.did) throw new Error("That's you.");
-  const pds = await resolvePds(did);
-  upsertPeerRow(did, handle, pds, true);   /* user-initiated = trusted */
+  const conn = await rtc.connect(handle);
   setStatus('Connecting to ' + handle + '\u2026');
+  return conn;
 }
 
 $('pair-btn').addEventListener('click', async () => {
@@ -932,19 +606,13 @@ $('login-btn').addEventListener('click', async () => {
   $('login-btn').disabled = true;
   setStatus('Signing in\u2026');
   try {
-    me.handle = handle;
-    me.did = await resolveHandle(handle);
-    me.pds = await resolvePds(me.did);
-    me.password = password;
-    await createSession();
-    loginTime = Date.now();
+    const meInfo = await rtc.login(handle, password);
     $('login-card').style.display = 'none';
     $('pair-card').style.display = '';
     $('me-wrap').style.display = '';
-    $('my-id').textContent = me.handle;
+    $('my-id').textContent = meInfo.handle;
     setStatus('Signed in \u2014 add a peer or share your link');
-    $('share-link').value = location.origin + location.pathname + '?peer=' + encodeURIComponent(me.handle);
-    await sweepOwnSignals();
+    $('share-link').value = location.origin + location.pathname + '?peer=' + encodeURIComponent(meInfo.handle);
     /* pre-specified recipients: ?peer=a.example,b.example or repeated ?peer= */
     /* ?peer=a.example (repeatable, comma-separable) or a naked ?a.example */
     const qs = new URLSearchParams(location.search);
@@ -954,9 +622,8 @@ $('login-btn').addEventListener('click', async () => {
     for (const h of preset) {
       try { await addPeer(h); } catch (e) { showErr(e.message); }
     }
-    poll();
-    discoverPeers();
-    console.log('[filedrop] ready as', me.handle, me.did, 'pds:', me.pds);
+    rtc.start();
+    console.log('[filedrop] ready as', meInfo.handle, meInfo.did, 'pds:', meInfo.pds);
   } catch (e) {
     showErr(e.message);
     setStatus('Not signed in');
@@ -968,18 +635,7 @@ $('login-password').addEventListener('keydown', (e) => { if (e.key === 'Enter') 
 
 /* ---------- teardown ---------- */
 window.addEventListener('beforeunload', () => {
-  /* best-effort removal of any in-flight signal records; the sweep at
-     next sign-in and the TTL filter cover the cases this misses */
-  for (const p of peers.values()) {
-    for (const rkey of [p.offerRkey, p.answerRkey]) {
-      if (!rkey || !me.accessJwt) continue;
-      fetch(me.pds + '/xrpc/com.atproto.repo.deleteRecord', {
-        method: 'POST', keepalive: true,
-        headers: { 'Authorization': 'Bearer ' + me.accessJwt, 'Content-Type': 'application/json' },
-        body: JSON.stringify({ repo: me.did, collection: COLLECTION, rkey: rkey })
-      }).catch(() => {});
-    }
-  }
+  rtc.teardown();
 });
 </script>
 </body>


### PR DESCRIPTION
Generic serverless-WebRTC-over-ATProto library, extracted from FileDrop. Prior-art check: closest existing work is bevy_symbios_multiuser (Rust/Bevy), which uses ATProto for *identity* but still requires a JWT relay server for signaling. PDS-records-as-signaling with zero servers appears to be ours alone.

**bsky/atproto-rtc.js** (~660 lines, ES module, zero deps) owns: handle/DID/PDS resolution (did:plc + did:web), app-password sessions, signal records (offer/answer/knock), TTL + sweep, glare avoidance (smaller DID offers, larger knocks), Constellation backlink discovery with liveness re-verification, consent gating, per-peer error isolation, PC/data-channel lifecycle, events (`message`/`statechange`/`error` top-level; `open`/`close`/`message` per-connection). Collection is configurable (default `com.austegard.rtc.signal`).

**bsky/filedrop.html** refactored to consume it: keeps its collection (`com.austegard.filedrop.signal` — deployed pairs unaffected), keeps all file-transfer logic (chunking, backpressure, sha256, accept/decline UI), drops ~18 functions now owned by the lib. #nostun preserved.

**Process:** extraction + refactor drafted by Sonnet 5 via API (2 calls, ~31k output tokens); protocol-critical paths diff-reviewed by Muninn against the original (record shape byte-identical; tie-break, consent gate, TTL, isolation, have-local-offer guard verified). One lib API gap Sonnet flagged as a shim (no uniform top-level message event) was fixed in the lib instead; shim removed. Resolvers live-tested in node against plc.directory. `node --check` clean on both.

**Not verified:** end-to-end browser session — needs two browsers post-merge (FileDrop between two of your devices is the regression test; the string-edit app comes next as consumer #2).