### PR TITLE
Pad: self-healing sync via state vectors

### DIFF
--- a/bsky/pad.html
+++ b/bsky/pad.html
@@ -474,13 +474,41 @@ rtc.on('message', (did, data) => {
       const msg = JSON.parse(new TextDecoder().decode(bytes.slice(1)));
       console.debug('[pad] control frame from', did, msg);
     } catch (e) { /* ignore malformed control frame */ }
+  } else if (tag === 0x03) {
+    /* peer sent its state vector: reply with exactly the updates it's missing.
+       This is the self-healing path — incremental frames dropped while a tab
+       was suspended (iOS backgrounds one browser whenever another is front-
+       most) are reconstructed from the CRDT state, idempotently. */
+    const peer = rtc.peers.get(did);
+    if (peer && peer.dc && peer.dc.readyState === 'open') {
+      try {
+        const diff = Y.encodeStateAsUpdate(ydoc, bytes.slice(1));
+        peer.dc.send(frame(0x01, diff));
+      } catch (e) { console.debug('[pad] sync reply failed', e); }
+    }
   }
+});
+
+/* Ask every open peer for whatever we're missing (they answer with a 0x01
+   diff against our state vector). Cheap: a state vector is a few bytes/client. */
+function requestSync() {
+  const sv = frame(0x03, Y.encodeStateVector(ydoc));
+  for (const peer of rtc.peers.values()) {
+    if (peer.dc && peer.dc.readyState === 'open') {
+      try { peer.dc.send(sv); } catch (e) { console.debug('[pad] sync req failed', e); }
+    }
+  }
+}
+setInterval(requestSync, 10000);
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') { requestSync(); updateStatusUI(); }
 });
 
 rtc.on('statechange', (did, peer) => {
   if (peer.dc && peer.dc.readyState === 'open' && !initedDCs.has(peer.dc)) {
     initedDCs.add(peer.dc);
     sendFullState(peer.dc); // full state + informational hello on every new open channel
+    requestSync();          // and pull whatever THEY have that we don't
   }
   updateStatusUI();
 });

--- a/bsky/pad.html
+++ b/bsky/pad.html
@@ -623,6 +623,7 @@ copyLinkBtn.addEventListener('click', async () => {
 
 if (peerDid) joinBtn.hidden = false;
 
+let hasJoinedOnce = false;
 joinBtn.addEventListener('click', async () => {
   if (!peerDid) return;
   if (!rtc.me.did) {
@@ -631,15 +632,17 @@ joinBtn.addEventListener('click', async () => {
   }
   rtc.start();
   joinBtn.disabled = true;
-  joinBtn.textContent = 'Joining…';
+  joinBtn.textContent = hasJoinedOnce ? 'Reconnecting…' : 'Joining…';
   try {
     const conn = await rtc.connect(peerDid);
-    conn.on('open', () => { joinBtn.textContent = 'Joined'; updateStatusUI(); });
-    conn.on('close', () => { joinBtn.textContent = 'Join'; joinBtn.disabled = false; updateStatusUI(); });
+    conn.on('open', () => { hasJoinedOnce = true; joinBtn.textContent = 'Connected'; updateStatusUI(); });
+    /* after a drop this is a reconnect to the SAME pad/peer, not a fresh join —
+       label it accordingly */
+    conn.on('close', () => { joinBtn.textContent = hasJoinedOnce ? 'Reconnect' : 'Join'; joinBtn.disabled = false; updateStatusUI(); });
   } catch (e) {
     alert('Could not connect: ' + e.message);
     joinBtn.disabled = false;
-    joinBtn.textContent = 'Join';
+    joinBtn.textContent = hasJoinedOnce ? 'Reconnect' : 'Join';
   }
   updateStatusUI();
 });


### PR DESCRIPTION
Fixes the truncated-reply bug from same-device iOS testing (host received only "I ca" of a longer reply).

**Root cause:** incremental Yjs frames were fire-and-forget. iOS suspends the backgrounded browser — and testing two browsers on one device guarantees one is always backgrounded — so frames sent while a peer's tab was suspended were dropped with no reconciliation path. First keystrokes arrived; the rest vanished.

**Fix:** new frame tag 0x03 = Yjs state vector. Receiver replies with `Y.encodeStateAsUpdate(doc, sv)` — exactly the updates the requester is missing, idempotent by CRDT construction. `requestSync()` broadcasts an 0x03 on: channel open (pulling the peer's state, complementing the existing full-state push), `visibilitychange → visible` (the iOS resume moment), and a 10s interval (belt/braces + keepalive). A state vector is a few bytes per client; diffs only carry what's missing.

**Limit that remains:** this heals a *live* channel. If iOS suspension kills the RTCPeerConnection entirely, the Join button resets (existing `conn.on('close')` handler) and re-pairing is manual — auto-reconnect belongs in atproto-rtc.js if we want it, not the app.

Retest: same two-browser dance; background/foreground each side mid-typing. Text should now converge within ~10s of both tabs being visible.