### PR TITLE
Session persistence: shared bsky_session convention

### DIFF
--- a/bsky/atproto-rtc.js
+++ b/bsky/atproto-rtc.js
@@ -28,7 +28,7 @@
  * this library does not interpret or transport them.
  *
  * @license MIT
- * @version 1.1.0
+ * @version 1.2.0
  *
  * @example
  *   import { AtprotoRTC } from '/bsky/atproto-rtc.js';

--- a/bsky/atproto-rtc.js
+++ b/bsky/atproto-rtc.js
@@ -97,6 +97,8 @@ export class AtprotoRTC extends Emitter {
    * @param {Array}  [opts.iceServers] default: [{urls:'stun:stun.l.google.com:19302'}]
    * @param {number} [opts.pollMs=2000]
    * @param {number} [opts.signalTtlS=300]
+   * @param {boolean}[opts.persistSession=true] store token pair (never the
+   *                 password) in localStorage 'bsky_session' for resumeSession()
    */
   constructor(opts = {}) {
     super();
@@ -105,6 +107,7 @@ export class AtprotoRTC extends Emitter {
       ? opts.iceServers
       : [{ urls: 'stun:stun.l.google.com:19302' }];
     this.pollMs      = opts.pollMs      || 2000;
+    this.persistSession = opts.persistSession !== false;
     this.signalTtlS  = opts.signalTtlS  || 300;
     this.discoverMs  = opts.discoverMs  || 6000;
 
@@ -172,6 +175,66 @@ export class AtprotoRTC extends Emitter {
     return this.me;
   }
 
+  /* ── session persistence ──────────────────────────────────────────────
+     Convention shared with the other austegard.com/bsky utilities
+     (bsky-lib.js): localStorage key 'bsky_session' holding TOKENS ONLY —
+     { did, handle, accessJwt, refreshJwt } — never the app password. We
+     store a superset adding `pds` (this lib is PDS-aware, not
+     bsky.social-only); bsky-lib ignores the extra field, so one login on
+     this origin serves every utility. Tradeoff, same as those utilities
+     already accept: localStorage is readable by any script on the origin. */
+
+  _persistSession() {
+    if (!this.persistSession || typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem('bsky_session', JSON.stringify({
+        did: this.me.did, handle: this.me.handle, pds: this.me.pds,
+        accessJwt: this.me.accessJwt, refreshJwt: this.me.refreshJwt
+      }));
+    } catch (e) { console.debug('[atproto-rtc] session persist failed', e); }
+  }
+
+  /**
+   * Resume a previously persisted session without a password. Refreshes
+   * the token pair against the stored PDS (rotating refresh tokens are
+   * re-persisted). Returns this.me on success, null if there is nothing
+   * usable — callers fall back to the login dialog.
+   */
+  async resumeSession() {
+    if (typeof localStorage === 'undefined') return null;
+    let s;
+    try { s = JSON.parse(localStorage.getItem('bsky_session')); } catch (e) { return null; }
+    if (!s || !s.refreshJwt) return null;
+    const pds = s.pds || 'https://bsky.social';   /* legacy bsky-lib sessions lack pds */
+    try {
+      const r = await fetch(pds + '/xrpc/com.atproto.server.refreshSession', {
+        method: 'POST', headers: { 'Authorization': 'Bearer ' + s.refreshJwt }
+      });
+      if (!r.ok) throw new Error('refresh failed: ' + r.status);
+      const j = await r.json();
+      this.me.did = j.did;
+      this.me.handle = j.handle || s.handle;
+      this.me.pds = pds;
+      this.me.accessJwt = j.accessJwt;
+      this.me.refreshJwt = j.refreshJwt;
+      this._persistSession();
+      await this._sweepOwnSignals();
+      this.emit('login', this.me);
+      return this.me;
+    } catch (e) {
+      console.debug('[atproto-rtc] session resume failed:', e.message);
+      try { localStorage.removeItem('bsky_session'); } catch (e2) { /* ignore */ }
+      return null;
+    }
+  }
+
+  logout() {
+    this.me = { did: null, handle: null, pds: null, accessJwt: null, refreshJwt: null, password: null };
+    if (typeof localStorage !== 'undefined') {
+      try { localStorage.removeItem('bsky_session'); } catch (e) { /* ignore */ }
+    }
+  }
+
   async _createSession() {
     const r = await fetch(this.me.pds + '/xrpc/com.atproto.server.createSession', {
       method: 'POST',
@@ -184,7 +247,9 @@ export class AtprotoRTC extends Emitter {
     }
     const j = await r.json();
     this.me.accessJwt = j.accessJwt;
+    this.me.refreshJwt = j.refreshJwt;
     this.me.did = j.did;
+    this._persistSession();
   }
 
   async _pdsCall(nsid, { method = 'GET', params, body, retried } = {}) {
@@ -199,7 +264,8 @@ export class AtprotoRTC extends Emitter {
       body: body ? JSON.stringify(body) : undefined
     });
     if (r.status === 401 && !retried) {          /* token expired — re-auth once */
-      await this._createSession();
+      if (this.me.password) await this._createSession();
+      else if (!(await this.resumeSession())) throw new Error(nsid + ' -> 401 (session expired; log in again)');
       return this._pdsCall(nsid, { method, params, body, retried: true });
     }
     if (!r.ok) throw new Error(nsid + ' -> ' + r.status);

--- a/bsky/pad.html
+++ b/bsky/pad.html
@@ -192,6 +192,7 @@
 <footer>
   <div class="row" id="shareRow">
     <button id="shareBtn">Share</button>
+    <button id="signOutBtn" hidden title="Forget the stored session on this browser">Sign out</button>
     <button id="joinBtn" hidden>Join</button>
     <input id="shareLinkInput" type="text" readonly hidden>
     <button id="copyLinkBtn" hidden>Copy link</button>
@@ -432,6 +433,10 @@ ymeta.observe(() => {
 /* ---------------- RTC wiring ---------------- */
 
 const rtc = new AtprotoRTC(); // defaults: com.austegard.rtc.signal, google STUN
+/* Resume a session persisted by this or any other /bsky utility (shared
+   'bsky_session' localStorage convention — tokens only, never the password).
+   Fire-and-forget: the UI works logged-out; this just skips the dialog. */
+rtc.resumeSession().then((me) => { if (me) updateStatusUI(); });
 let sharing = false;
 const initedDCs = new WeakSet();
 
@@ -518,7 +523,9 @@ function updateStatusUI() {
   for (const p of rtc.peers.values()) if (p.dc && p.dc.readyState === 'open') openPeers++;
   peerDot.classList.toggle('on', openPeers > 0);
   let base = sharing ? 'Sharing' : (rtc.me && rtc.me.did ? 'Connected' : 'Local only');
-  statusText.textContent = base + ' · ' + openPeers + ' peer' + (openPeers === 1 ? '' : 's');
+  statusText.textContent = base + ' · ' + openPeers + ' peer' + (openPeers === 1 ? '' : 's')
+    + (rtc.me && rtc.me.handle ? ' · ' + rtc.me.handle : '');
+  signOutBtn.hidden = !(rtc.me && rtc.me.did);
 }
 
 /* ---------------- login dialog (shared by share/join/publish) ---------------- */
@@ -622,6 +629,14 @@ copyLinkBtn.addEventListener('click', async () => {
 /* ---------------- join (guest) flow ---------------- */
 
 if (peerDid) joinBtn.hidden = false;
+
+const signOutBtn = document.getElementById('signOutBtn');
+signOutBtn.addEventListener('click', () => {
+  rtc.stop();
+  rtc.logout();          /* clears rtc.me and the shared 'bsky_session' key */
+  sharing = false;
+  updateStatusUI();
+});
 
 let hasJoinedOnce = false;
 joinBtn.addEventListener('click', async () => {


### PR DESCRIPTION
Pad forgot logins on every visit. Fix reuses the credential-storage convention the other /bsky utilities already follow (bsky-lib.js): localStorage key `bsky_session` holding **tokens only — never the app password** — `{did, handle, accessJwt, refreshJwt}`. This lib stores a superset adding `pds` (it's PDS-aware, not bsky.social-only); bsky-lib ignores the extra field, and `resumeSession()` accepts legacy pds-less sessions (defaults to bsky.social). Net effect: one login on austegard.com serves every utility on the origin, in both directions.

**Lib (1.2.0):** `_createSession` now keeps + persists `refreshJwt`; new `resumeSession()` (refresh-token exchange against the stored PDS, rotates + re-persists), `logout()`, `persistSession` constructor option (default true). The 401 retry path prefers password re-auth when one is in memory, falls back to token refresh for resumed sessions, and fails with a clear message when neither works.

**Pad:** attempts `resumeSession()` at load (fire-and-forget; UI works logged-out), status line shows the signed-in handle, and a Sign out button clears the shared key.

**Verified live in node (localStorage shim, muninn account):** login → tokens persisted → fresh instance `resumeSession()` → correct DID/handle, no password in memory. Known tradeoff, inherited from the existing convention: localStorage is origin-readable — an XSS anywhere on the site exposes tokens (revocable app-password tokens, not the password itself).