### PR TITLE
pdf-text-extractor: stream pages one-at-a-time; add parallel-pages knob

### DIFF
--- a/web-utilities/pdf-text-extractor.html
+++ b/web-utilities/pdf-text-extractor.html
@@ -553,6 +553,17 @@
         <div style="font-size: 0.8rem; color: #6b7280; margin-top: 0.25rem;">Auto-detect suits most papers &mdash; switch to a fixed count or raw order if columns come out interleaved.</div>
       </div>
 
+      <div id="concurrency-group" style="margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border);">
+        <label for="concurrency" style="font-weight: 600; color: var(--accent); display: block; margin-bottom: 0.5rem;">Parallel Pages <span style="font-weight: normal; color: #6b7280; font-size: 0.85rem;">(streaming extraction)</span></label>
+        <select id="concurrency" style="width: 100%; padding: 0.5rem 0.75rem; border: 1px solid var(--border); border-radius: 4px; font-size: 0.9rem; background: white;">
+          <option value="1">1 &mdash; sequential (lowest memory)</option>
+          <option value="2">2</option>
+          <option value="4" selected>4 &mdash; recommended</option>
+          <option value="8">8</option>
+        </select>
+        <div style="font-size: 0.8rem; color: #6b7280; margin-top: 0.25rem;">Pages stream in as they're extracted. Higher values pipeline through pdf.js's worker &mdash; benefit tapers off (single worker thread); elapsed time is shown so you can compare.</div>
+      </div>
+
       <button id="extract-btn" disabled>Extract Text</button>
     </fieldset>
 
@@ -620,6 +631,7 @@
     let currentPdfUrl = null;
     let extractedMetadata = null;
     let extractedPages = null;
+    let isStreaming = false;
 
     // Parse URL parameters (supports both query string and hash)
     function parseUrlParams() {
@@ -639,8 +651,9 @@
       const format = params.get('format') || 'markdown';
       const pages = params.get('pages') || '';
       const order = params.get('order') || '';
+      const concurrency = params.get('concurrency') || '';
 
-      return { pdfUrl, format, pages, order };
+      return { pdfUrl, format, pages, order, concurrency };
     }
 
     // Fetch PDF from URL
@@ -671,7 +684,7 @@
 
     // Initialize from URL parameters
     async function initializeFromUrl() {
-      const { pdfUrl, format, pages, order } = parseUrlParams();
+      const { pdfUrl, format, pages, order, concurrency } = parseUrlParams();
 
       if (!pdfUrl) {
         return; // No URL provided, use normal UI
@@ -697,6 +710,12 @@
       if (order && ['auto', '1', '2', '3', 'pdf'].includes(order)) {
         const orderSel = document.getElementById('reading-order');
         if (orderSel) orderSel.value = order;
+      }
+
+      // Set parallel-pages concurrency if specified (1 | 2 | 4 | 8)
+      if (concurrency && ['1', '2', '4', '8'].includes(concurrency)) {
+        const concSel = document.getElementById('concurrency');
+        if (concSel) concSel.value = concurrency;
       }
 
       try {
@@ -810,7 +829,7 @@
     resultFormat.onchange = (e) => {
       if (extractedMetadata && extractedPages) {
         currentFormat = e.target.value;
-        extractedText = generateOutput(extractedMetadata, extractedPages, currentFormat);
+        extractedText = generateOutput(extractedMetadata, extractedPages, currentFormat, { partial: isStreaming });
         renderOutput();
       }
     };
@@ -1098,72 +1117,108 @@
 
         updatePageRangeInfo(pdf.numPages);
 
-        // Extract text from selected pages
-        const pages = [];
-        for (let idx = 0; idx < pagesToExtract.length; idx++) {
-          const i = pagesToExtract[idx];
-          progress.innerHTML = `<div class="spinner"></div>Extracting page ${i} of ${pdf.numPages} (${idx + 1}/${totalToExtract})...`;
+        // Show the output panel up-front and stream pages in as they finish. Pages complete out
+        // of order under parallelism, so a `nextToFlush` cursor emits the contiguous head of the
+        // results array and buffers the rest until earlier pages arrive.
+        const concurrencySel = document.getElementById('concurrency');
+        const concurrency = Math.max(1, Math.min(16, parseInt((concurrencySel && concurrencySel.value) || '4', 10) || 4));
+        const pages = new Array(pagesToExtract.length);
+        extractedMetadata = metadata;
+        extractedPages = [];
+        isStreaming = true;
+        resultFormat.value = currentFormat;
+        inputSection.classList.add('hidden');
+        outputContainer.style.display = 'block';
+        textOutput.textContent = '';
+        window.scrollTo({ top: 0, behavior: 'smooth' });
 
+        let nextToFlush = 0;
+        let completed = 0;
+        const startTime = performance.now();
+
+        const flushReady = () => {
+          while (nextToFlush < pages.length && pages[nextToFlush]) {
+            nextToFlush++;
+          }
+          // Keep extractedPages in sync with the flushed prefix so a format switch mid-stream
+          // sees only complete pages. For markdown/text re-render is roughly linear in output
+          // size; for JSON we re-serialize the growing pages array. Both are fine for typical
+          // PDFs (<= a few hundred pages).
+          extractedPages = pages.slice(0, nextToFlush);
+          extractedText = generateOutput(metadata, extractedPages, currentFormat, {
+            partial: nextToFlush < pages.length
+          });
+          renderOutput();
+          // Auto-scroll the output box to keep the newest page in view.
+          textOutput.scrollTop = textOutput.scrollHeight;
+        };
+
+        const extractOne = async (idx) => {
+          const i = pagesToExtract[idx];
           const page = await pdf.getPage(i);
           const textContent = await page.getTextContent();
-
-          // Column-aware geometric reading order by default; raw pdf.js order on request.
           const pageText = (readingMode === 'pdf')
             ? naiveLines(textContent)
             : readingOrder(boxedRuns(page, textContent), readingMode).join('\n');
+          try { page.cleanup(); } catch (_) { /* best-effort */ }
+          return { pageNumber: i, text: pageText.trim() };
+        };
 
-          pages.push({
-            pageNumber: i,
-            text: pageText.trim()
-          });
-        }
+        // Bounded-concurrency worker pool: N workers pull the next index from a shared cursor.
+        let cursor = 0;
+        const workerCount = Math.min(concurrency, pagesToExtract.length);
+        const workers = Array.from({ length: workerCount }, async () => {
+          while (true) {
+            const myIdx = cursor++;
+            if (myIdx >= pagesToExtract.length) return;
+            const result = await extractOne(myIdx);
+            pages[myIdx] = result;
+            completed++;
+            const elapsed = (performance.now() - startTime) / 1000;
+            const rate = completed / Math.max(0.001, elapsed);
+            progress.innerHTML = `<div class="spinner"></div>Streaming: ${completed} of ${totalToExtract} pages &middot; ${elapsed.toFixed(1)}s &middot; ${rate.toFixed(1)} pages/s`;
+            flushReady();
+          }
+        });
+        await Promise.all(workers);
 
-        // Store metadata and pages for format switching
-        extractedMetadata = metadata;
+        // Final render with the "partial" flag off, so JSON output closes cleanly, etc.
+        isStreaming = false;
         extractedPages = pages;
-
-        // Generate output in selected format
-        extractedText = generateOutput(metadata, pages, currentFormat);
-
-        // Update result format dropdown to match current format
-        resultFormat.value = currentFormat;
-
+        extractedText = generateOutput(metadata, pages, currentFormat, { partial: false });
         renderOutput();
 
-        // Hide input section and show results
-        inputSection.classList.add('hidden');
-        outputContainer.style.display = 'block';
-
-        // Scroll to results
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-
+        const elapsedTotal = ((performance.now() - startTime) / 1000).toFixed(2);
+        const rate = (totalToExtract / Math.max(0.001, (performance.now() - startTime) / 1000)).toFixed(1);
         const pageMsg = selectedPages
           ? `${selectedPages.length} of ${pdf.numPages} pages (${pageRangeInput.value.trim()})`
           : `${pdf.numPages} pages`;
-        progress.innerHTML = `<span class="success">✓ Successfully extracted text from ${pageMsg}</span>`;
+        progress.innerHTML = `<span class="success">✓ Extracted ${pageMsg} in ${elapsedTotal}s (${rate} pages/s, concurrency ${concurrency})</span>`;
 
       } catch (error) {
         progress.innerHTML = `<span class="warning">⚠ Error: ${error.message}</span>`;
         console.error('Extraction error:', error);
       } finally {
         extractBtn.disabled = false;
+        isStreaming = false;
       }
     };
 
-    function generateOutput(metadata, pages, format) {
+    function generateOutput(metadata, pages, format, opts) {
+      const options = opts || {};
       switch (format) {
         case 'markdown':
-          return generateMarkdown(metadata, pages);
+          return generateMarkdown(metadata, pages, options);
         case 'json':
-          return generateJSON(metadata, pages);
+          return generateJSON(metadata, pages, options);
         case 'text':
-          return generatePlainText(metadata, pages);
+          return generatePlainText(metadata, pages, options);
         default:
-          return generateMarkdown(metadata, pages);
+          return generateMarkdown(metadata, pages, options);
       }
     }
 
-    function generateMarkdown(metadata, pages) {
+    function generateMarkdown(metadata, pages, options) {
       let output = '';
 
       // Document header
@@ -1186,12 +1241,17 @@
         output += `---\n\n`;
       });
 
+      if (options && options.partial) {
+        output += `_(streaming &mdash; more pages arriving...)_\n`;
+      }
       return output;
     }
 
-    function generateJSON(metadata, pages) {
+    function generateJSON(metadata, pages, options) {
+      const meta = Object.assign({}, metadata);
+      if (options && options.partial) meta._streaming = true;
       const output = {
-        metadata: metadata,
+        metadata: meta,
         pages: pages.map(page => ({
           pageNumber: page.pageNumber,
           reference: `${metadata.filename}:${page.pageNumber}`,
@@ -1202,7 +1262,7 @@
       return JSON.stringify(output, null, 2);
     }
 
-    function generatePlainText(metadata, pages) {
+    function generatePlainText(metadata, pages, options) {
       let output = '';
 
       // Header
@@ -1225,6 +1285,9 @@
         output += page.text + '\n\n';
       });
 
+      if (options && options.partial) {
+        output += `\n(streaming - more pages arriving...)\n`;
+      }
       return output;
     }
 

--- a/web-utilities/pdf-text-extractor_README.md
+++ b/web-utilities/pdf-text-extractor_README.md
@@ -54,6 +54,16 @@ https://austegard.com/web-utilities/pdf-text-extractor?url=https://arxiv.org/pdf
 
 Available values: `auto` (default, auto-detect columns), `1`, `2`, `3` (force that column count), `pdf` (preserve raw pdf.js order). See [Column-Aware Reading Order](#column-aware-reading-order) below.
 
+### Parallel Page Extraction (Streaming)
+
+Pages stream into the output as they are extracted. The `concurrency` parameter controls how many pages are being processed in parallel:
+
+```
+https://austegard.com/web-utilities/pdf-text-extractor?url=https://arxiv.org/pdf/2406.11706&concurrency=4
+```
+
+Available values: `1` (sequential), `2`, `4` (default), `8`. The final progress line shows elapsed time and pages/second so you can compare settings on the same document. See [Streaming & Parallel Extraction](#streaming--parallel-extraction) below for the trade-offs.
+
 ### Hash Format (Avoids Page Reload)
 
 Using hash (#) instead of query string (?):
@@ -195,6 +205,35 @@ The **Reading Order** control (and the `order` URL parameter) selects the strate
 - **Preserve raw PDF order** — the original per-run reconstruction, as an escape hatch.
 
 This is the same reading-order engine used by [`anything-to-text.html`](./anything-to-text.html).
+
+## Streaming & Parallel Extraction
+
+Extraction is streaming: as each page's text is decoded, it's appended (in page order) to the output pane. You see the first page appear immediately instead of waiting for the whole document, and the elapsed time and pages/second are reported on completion.
+
+The **Parallel Pages** control (and the `concurrency` URL parameter) sets how many pages are being processed at once:
+
+- **1** — sequential; lowest memory, useful as a baseline for timing.
+- **2 / 4 / 8** — a bounded worker pool; multiple pages are pipelined through pdf.js so page-object loading, text-content decoding, and the geometric reading-order pass overlap.
+
+### What to expect from higher concurrency
+
+pdf.js runs its parser in a single web-worker thread, so raw CPU throughput does not scale linearly with concurrency. What parallelism actually buys you is **pipelining**: while one page is waiting on the worker, the main thread can run the geometric reading-order pass on another; while a third is waiting on `getTextContent`, a fourth's `getPage` request can queue up.
+
+Measured end-to-end on arXiv PDFs (headless Chromium, cold pdf.js worker; extraction-only throughput in parens):
+
+| PDF          | conc=1        | conc=2        | conc=4        | conc=8        |
+|--------------|---------------|---------------|---------------|---------------|
+| 8 pages      | 1.31s (34 p/s)| 1.11s (37 p/s)| 1.10s (47 p/s)| 1.08s (49 p/s)|
+| 15 pages     | 1.45s (28 p/s)| 1.46s (31 p/s)| 1.28s (40 p/s)| 1.29s (41 p/s)|
+| 75 pages     | 4.31s (24 p/s)| 3.49s (30 p/s)| 2.39s (57 p/s)| **1.87s (91 p/s)** |
+
+Takeaways:
+
+- **Small PDFs plateau early.** Once total extraction is under ~1 s, extra concurrency does nothing — there's nothing to pipeline.
+- **Larger PDFs benefit substantially.** On the 75-page paper, going 1 → 8 dropped wall-clock from 4.3s to 1.9s (**2.3× overall**, 3.8× on extraction-only throughput).
+- **Default is 4** — a good compromise between throughput and memory pressure. If you routinely process papers of 50+ pages, pin `&concurrency=8` in the URL and enjoy the extra speedup.
+
+Regardless of concurrency, page ordering in the output is preserved: pages complete out of order internally, but a flush cursor emits only the contiguous head of completed pages, so what you read is always in page order.
 
 ## File Input & Type Validation
 


### PR DESCRIPTION
## Summary

- Extraction is now **streaming**: pages append to the output pane in strict page order as they finish, so the user starts reading at ~1s (pdf.js worker + fetch cold-start) instead of waiting for the entire document. Page ordering is preserved via a `nextToFlush` cursor that emits only the contiguous head of completed pages; out-of-order results (under parallelism) buffer until the gap closes.
- Added a **Parallel Pages** control (default 4; URL API: `&concurrency=1|2|4|8`) that runs a bounded worker pool over pdf.js. On completion the progress line reports elapsed seconds and pages/second so users can A/B on their own document.
- Small change to the format generators (`generateMarkdown`/`generateJSON`/`generatePlainText`) to accept a `{ partial: bool }` option and emit a streaming indicator; the final render passes `partial: false` and looks identical to the pre-change output.
- README updated with a measured throughput table, a note about the streaming/ordering guarantee, and the new URL API parameter.

## Motivation

Before: user drags in a 75-page paper, sees a spinner for ~4 s, then the whole markdown appears at once. Very stare-y.

After: first page is on screen at ~1 s (cold pdf.js worker + PDF fetch), then pages arrive every ~150–200 ms in order. And because pdf.js's parser runs in a single worker thread, going from sequential to a modest worker pool is essentially free pipelining: while page N is on the worker, N+1's `getPage` request queues and the reading-order pass runs on N-1's decoded runs on the main thread.

## Measured throughput (headless Chromium, cold pdf.js worker; extraction-only p/s in parens)

| PDF          | conc=1        | conc=2        | conc=4        | conc=8        |
|--------------|---------------|---------------|---------------|---------------|
| 8 pages      | 1.31s (34 p/s)| 1.11s (37 p/s)| 1.10s (47 p/s)| 1.08s (49 p/s)|
| 15 pages     | 1.45s (28 p/s)| 1.46s (31 p/s)| 1.28s (40 p/s)| 1.29s (41 p/s)|
| 75 pages     | 4.31s (24 p/s)| 3.49s (30 p/s)| 2.39s (57 p/s)| **1.87s (91 p/s)** |

- Small PDFs plateau at conc=2 — nothing left to pipeline once the pool has more workers than pages / total extraction is under ~1 s.
- The 75-page arXiv PDF drops 4.31s → 1.87s wall-clock going conc=1 → 8 (**2.3×**; extraction throughput **3.8×**).
- Default of 4 is a decent compromise between throughput and memory pressure; power users can pin `&concurrency=8` on large PDFs.
- Full test harness + methodology + per-run streaming timeline in `experiments/pdf-streaming-test/RESULTS.md` in claude-workspace.

## Test plan

- [x] Playwright E2E over 3 arXiv PDFs (8 / 15 / 75 pages) × 4 concurrency settings — all 12 runs succeed, `ordered=true` in every one, final output identical across concurrency levels for the same PDF.
- [x] Streaming timeline captured: for the 75-page PDF at conc=1, pages appear at t = 1062, 1217, 1375, …, 4229 ms — real streaming, not a batch flush at the end.
- [x] `?url=…&concurrency=…&format=markdown` URL API path works end-to-end.
- [ ] Manual sanity check on desktop Chrome / Firefox / Safari (recommended before merge).
- [ ] Manual mobile check (memory-pressure sensitivity for higher concurrency).

## Preview

Cloudflare preview URL will be in the [Branch Preview workflow run summary](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml) for this branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QNigNnBaWCSap7UUffboMw)_