### PR TITLE
Modem: iOS loudspeaker on send + web-utilities index link

### DIFF
--- a/modem.html
+++ b/modem.html
@@ -100,7 +100,7 @@
     <p><b>Demo on one machine:</b> press Listen, then Send &mdash; the mic hears the speaker across the air gap between them. Two machines: one listens, the other sends.</p>
     <p><b>Frame format:</b> 250 ms pilot &middot; 8-symbol sync &middot; version + length header block &middot; payload + CRC-16/CCITT, all carried in RS(15,11) codewords (11 data + 4 parity nibbles each). Every tone is one GF(16) symbol; each 15-symbol block corrects 2 errors or 4 erasures. A ~200-byte packed SDP is about 12 seconds of audio.</p>
     <p><b>Validated headless (Node invariant suite):</b> GF(16) arithmetic, RS errata recovery across 400 random error/erasure patterns, clean loopback at 48 k and 44.1 k, random silence padding, AWGN to 6 dB SNR (decodes to 4 dB), 48 k &#8594; 44.1 k resample mismatch, 25% gain wobble, all combined, and recovery from a steady in-band interfering tone; pure noise never false-decodes (CRC + sync gate).</p>
-    <p><b>Browser-path (cannot be tested headless):</b> mic requires HTTPS and a user grant; the getUserMedia constraints disable echo cancellation / noise suppression / AGC, but some stacks ignore them &mdash; OS-level noise suppression can eat the tones; AudioWorklet loads from a Blob URL and falls back to ScriptProcessorNode automatically; speaker volume around 60&ndash;80% works best; decode passes cost ~100&ndash;250 ms of CPU each while listening.</p>
+    <p><b>Browser-path (cannot be tested headless):</b> mic requires HTTPS and a user grant; the getUserMedia constraints disable echo cancellation / noise suppression / AGC, but some stacks ignore them &mdash; OS-level noise suppression can eat the tones; AudioWorklet loads from a Blob URL and falls back to ScriptProcessorNode automatically; on iOS, sending forces the loudspeaker route instead of the earpiece; speaker volume around 60&ndash;80% works best; decode passes cost ~100&ndash;250 ms of CPU each while listening.</p>
     <p><b>Known limits:</b> RS(15,11) corrects up to 2 wrong tones or 4 erasures per 15-symbol block; a burst ruining 3+ symbols in one block still fails that frame (CRC catches it, resend is the fallback). Broadband noise spread thin across a long frame is the hard case, not localized transients. Range is conference-room scale, not hallway scale.</p>
     <p><b>Deploy:</b> single self-contained file, zero dependencies &mdash; drop <code>modem.html</code> at the site root; GitHub&nbsp;Pages serves it at <code>/modem</code>.</p>
   </div>
@@ -637,6 +637,13 @@
         return;
       }
       var ac = audioCtx();
+      /* iOS routes Web Audio to the earpiece when a mic stream is live or the
+         audio session is in voice mode. Force the loudspeaker for send, unless
+         this same device is also listening (the single-machine demo needs the
+         play-and-record route). No-op without the AudioSession API. */
+      if (!listening && "audioSession" in navigator) {
+        try { navigator.audioSession.type = "playback"; } catch (e) { console.warn("[link] audioSession playback failed:", e); }
+      }
       var pcm = M.encodeToPcm(bytes, ac.sampleRate);
       var buf = ac.createBuffer(1, pcm.length, ac.sampleRate);
       buf.getChannelData(0).set(pcm);
@@ -852,6 +859,9 @@
       return;
     }
     var ac = audioCtx();
+    if ("audioSession" in navigator) {
+      try { navigator.audioSession.type = "play-and-record"; } catch (e) { console.warn("[link] audioSession play-and-record failed:", e); }
+    }
     setStatus(rxStatus, "requesting microphone\u2026", "busy");
     navigator.mediaDevices.getUserMedia({
       audio: {

--- a/web-utilities/index.html
+++ b/web-utilities/index.html
@@ -17,6 +17,9 @@
     <p><a href="/fd">FileDrop</a> &mdash; send a file directly between two browsers,
     no server in the middle; connect by link or by scanning QR codes.</p>
 
+    <p><a href="/modem">Acoustic Link</a> &mdash; send short data between two devices
+    over sound; no pairing, no camera, just a speaker and a mic.</p>
+
     <github-toc
         repo-path="https://github.com/oaustegard/oaustegard.github.io/tree/main/web-utilities"
         link-prefix="./"


### PR DESCRIPTION
Two follow-ups after the v2 FEC release.

**1. iOS earpiece-on-send fix.** When a mic stream is live, iOS Safari puts the audio session in voice mode and routes output to the earpiece receiver — quiet, directional, and rolled off at the top of the band, which is why sending from the phone failed while short frames slipped through. The send handler now sets `navigator.audioSession.type = "playback"` (feature-detected, no-op elsewhere) to force the loudspeaker, but only when this device isn't also listening — the single-machine Listen+Send demo still needs play-and-record. The listen handler sets `play-and-record` explicitly so the two roles don't fight.

**2. Index link.** Adds a manual `/modem` line to web-utilities/index.html next to `/fd`; both are root-level tools the github-toc doesn't auto-list.

The tested modem core is byte-identical to the one shipped in #281 — this PR only touches the app-layer plumbing and page copy. `node modem_test.js` still 31/31; app-layer JS passes `node --check`. The AudioSession fix is browser-path, so it can't be covered headless.