### PR TITLE
Modem: fix iOS loudspeaker on send (audioSession ordering)

### DIFF
--- a/modem.html
+++ b/modem.html
@@ -734,14 +734,16 @@
         setStatus(sendStatus, "payload must be 1.." + M.CFG.maxPayload + " bytes", "bad");
         return;
       }
-      var ac = audioCtx();
-      /* iOS routes Web Audio to the earpiece when a mic stream is live or the
-         audio session is in voice mode. Force the loudspeaker for send, unless
-         this same device is also listening (the single-machine demo needs the
-         play-and-record route). No-op without the AudioSession API. */
+      /* iOS binds the audio-session route when the AudioContext activates, so
+         set the type BEFORE creating/resuming the context — flipping it on an
+         already-running context does not re-route its output (that was the
+         earpiece bug this fix was meant to solve). Force the loudspeaker for
+         send, unless this same device is also listening (the single-machine
+         demo needs the play-and-record route). No-op without the API. */
       if (!listening && "audioSession" in navigator) {
         try { navigator.audioSession.type = "playback"; } catch (e) { console.warn("[link] audioSession playback failed:", e); }
       }
+      var ac = audioCtx();
       var pcm = M.encodeToPcm(bytes, ac.sampleRate);
       var buf = ac.createBuffer(1, pcm.length, ac.sampleRate);
       buf.getChannelData(0).set(pcm);
@@ -1046,10 +1048,13 @@
       setStatus(rxStatus, "no microphone API \u2014 needs HTTPS (or localhost)", "bad");
       return;
     }
-    var ac = audioCtx();
+    /* Set the record route before the context activates (same ordering as
+       send). getUserMedia below re-activates under record anyway, but ordering
+       it correctly keeps the two paths consistent and non-fragile. */
     if ("audioSession" in navigator) {
       try { navigator.audioSession.type = "play-and-record"; } catch (e) { console.warn("[link] audioSession play-and-record failed:", e); }
     }
+    var ac = audioCtx();
     setStatus(rxStatus, "requesting microphone\u2026", "busy");
     navigator.mediaDevices.getUserMedia({
       audio: {


### PR DESCRIPTION
*Filed by Muninn*

**Symptom (Oskar, on iOS):** the modem's send path routes to the earpiece receiver instead of the loudspeaker — the PR #282 `audioSession.type = "playback"` fix did not take effect.

**Root cause:** both the send and listen handlers set `navigator.audioSession.type` *after* calling `audioCtx()`, which creates **and resumes** the `AudioContext`. iOS/WebKit binds the audio-session route when the context activates; flipping the type on an already-running context does not re-route its output. So `"playback"` was set too late and send stayed on whatever route the context activated under. The listen path masked the same ordering bug because the subsequent `getUserMedia` re-activates the session under the record category regardless — send has nothing to force re-activation.

**Fix:** set `audioSession.type` *before* `audioCtx()` in both handlers. Minimal reorder, no behavior change off-iOS (still feature-detected + try/catch, still `!listening`-guarded on send).

**Verification:** JS syntax checked (`node --check` on extracted inline scripts, OK). The audio-route behavior itself is iOS-WebKit-only and cannot be tested headless in the container — needs an on-device check that send now plays through the loudspeaker.

**Residual known edge (not addressed):** same-device *stop-listening-then-send* — the context is still live under `play-and-record` and a resume() no-op won't re-route it, so that one send may stay on earpiece until the page is reloaded. Left alone rather than bolt on an async suspend/resume that risks a send-timing race; the single-machine Listen+Send demo is already `!listening`-excluded from the playback forcing by design.