### PR TITLE
Currents: fix standalone bottom bar + iOS tilt activation

### DIFF
--- a/fun-and-games/currents.html
+++ b/fun-and-games/currents.html
@@ -14,7 +14,7 @@
 <style>
   /* full-bleed, no chrome, no scroll */
   html, body { margin: 0; height: 100%; background: #050608; overflow: hidden; }
-  #gl { display: block; width: 100vw; height: 100vh; }
+  #gl { display: block; position: fixed; inset: 0; width: 100%; height: 100%; }
   .overlay {
     position: fixed; pointer-events: none; user-select: none;
     font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -44,7 +44,7 @@
 <body>
 <canvas id="gl"></canvas>
 <div id="hint" class="overlay">drift with the cursor &middot; click to shift the mood &middot; space to still it</div>
-<div id="sig" class="overlay">Currents &middot; for Oskar</div>
+<div id="sig" class="overlay">Currents</div>
 <div id="fallback">
   <div>
     <p>Your browser did not hand over a WebGL context, so the piece cannot paint itself.</p>
@@ -335,8 +335,11 @@
     tgt = cloneMood(MOODS[moodIndex]);
     console.log("[currents] mood ->", moodIndex);
   }
+  /* Mood shift + first-tap tilt-enable both ride the click event. On iOS a tap
+     synthesizes a click promptly (fast-tap is on: maximum-scale=1, no delay), and
+     requestPermission() only succeeds from a genuine activation like this -- a
+     passive touchstart gets rejected by WebKit, so we do NOT use one here. */
   window.addEventListener("click", function () { enableTilt(); shiftMood(); });
-  window.addEventListener("touchstart", function () { enableTilt(); shiftMood(); }, { passive: true });
 
   window.addEventListener("keydown", function (e) {
     if (e.code === "Space" || e.key === " ") {


### PR DESCRIPTION
Follow-up to #286 (merged). Three fixes:

- **Bottom black bar in the installed app.** The canvas was `100vw/100vh`; in an iOS standalone web app `100vh` stops short of the home-indicator inset, leaving the dark body showing. Now a fixed full-viewport fill (`position:fixed; inset:0; width/height:100%`) so the art paints edge-to-edge and the indicator overlays it.
- **Tilt never activated.** The passive `touchstart` handler fired before `click`, called `DeviceOrientationEvent.requestPermission()` in a context WebKit rejects, and flipped the one-shot guard so the reliable `click` path never ran. Permission is now requested only from the `click` activation (which WebKit honors, and which also fixes a pre-existing double mood-shift per tap). Drag-steer via `touchmove` is unchanged.
- **Signature** trimmed to just `Currents`.

Source stays pure ASCII; `node --check` passes.

On-device check: open the page, tap once -> iOS Motion & Orientation prompt -> grant -> tilt steers the currents. If the prompt is withheld inside the installed app specifically, grant once in Safari first; it carries over.