### PR TITLE
Fix homepage scrollbar from Currents canvas sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,6 @@
         #bgfx {
             position: fixed;
             inset: 0;
-            width: 100vw;
-            height: 100vh;
             display: block;
             z-index: -20;
             pointer-events: none;


### PR DESCRIPTION
The Currents background (#284) sized `#bgfx` with `width: 100vw; height: 100vh` on top of `inset: 0`. Viewport units include the scrollbar gutters while `inset: 0` does not, so the fixed canvas overhung the content area by the scrollbar width, forcing an extra scrollbar (visible as the vertical one against `body { min-height: 100vh }`).

Fix: remove the two viewport-unit lines. `position: fixed; inset: 0` already stretches the canvas to the viewport content area exactly. The render loop reads `canvas.clientWidth/clientHeight`, so no JS change is needed.

CSS-only, one rule. No build/test gate on a static homepage; verified by construction (0 remaining `100vw`/`100vh` in the file).