### PR TITLE
Modem: await AudioContext resume before send (iOS no-sound fix)

### DIFF
--- a/modem.html
+++ b/modem.html
@@ -727,7 +727,7 @@
   }
   sendText.addEventListener("input", updateEstimate);
 
-  sendBtn.addEventListener("click", function () {
+  sendBtn.addEventListener("click", async function () {
     try {
       var bytes = enc.encode(sendText.value);
       if (bytes.length < 1 || bytes.length > M.CFG.maxPayload) {
@@ -744,6 +744,14 @@
         try { navigator.audioSession.type = "playback"; } catch (e) { console.warn("[link] audioSession playback failed:", e); }
       }
       var ac = audioCtx();
+      /* iOS: audioCtx() calls resume() but the context settles asynchronously,
+         and after switching to the "playback" session it can come up suspended
+         or interrupted. Starting a source before the context is actually running
+         plays into silence — the "speaker icon appears in the Dynamic Island but
+         no sound" symptom. Await the running state before scheduling the tone. */
+      if (ac.state !== "running") {
+        try { await ac.resume(); } catch (e) { console.warn("[link] resume failed:", e); }
+      }
       var pcm = M.encodeToPcm(bytes, ac.sampleRate);
       var buf = ac.createBuffer(1, pcm.length, ac.sampleRate);
       buf.getChannelData(0).set(pcm);


### PR DESCRIPTION
*Filed by Muninn*

Follow-up to #287 (merged). #287 fixed the *route* — the Dynamic Island now shows the loudspeaker on Send — but exposed a latent bug: **Send produces the speaker icon and no sound.**

**Root cause:** `audioCtx()` calls `ctx.resume()` but never awaits it. Before #287 the context was created+resumed under the default session and produced (earpiece) sound in time; after switching the session to `"playback"` first, the fresh context comes up suspended/interrupted and `resume()` settles a beat later. `src.start()` fires synchronously into a not-yet-running context, so the tone is scheduled into silence.

**Fix:** make the Send handler `async` and `await ac.resume()` (when not already `running`) before scheduling the tone. Standard iOS Web-Audio remedy. Listen path untouched — it already re-activates via `getUserMedia`.

**Verification:** JS syntax checked (`node --check`, OK). Audio routing/timing is iOS-WebKit-only and un-headless-testable here — needs an on-device check that Send now plays through the loudspeaker.

**If this still fails:** the `[link]` console logs (Safari Web Inspector) will show `ac.state`; and the honest fallback is to roll the iOS special-casing back out entirely (accept default routing) rather than keep iterating blind.