### PR TITLE
Fix Currents canvas collapsing to top third on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
         #bgfx {
             position: fixed;
             inset: 0;
+            width: 100%;
+            height: 100%;
             display: block;
             z-index: -20;
             pointer-events: none;


### PR DESCRIPTION
Follow-up to #289. That PR removed `width:100vw;height:100vh` from `#bgfx` and relied on `inset:0` alone — which works for non-replaced elements but not for `<canvas>`. A canvas is a **replaced element**: with `inset:0` and no explicit height it uses its intrinsic ~150px, so on mobile the flow field renders as a band across the top ~1/3 and flat `--bg` below.

Fix: size it the same way the working `fun-and-games/currents.html` does — `width:100%; height:100%`. `100%` resolves to the fixed element's containing block (the viewport **content** box, scrollbar excluded), so it keeps #289's scrollbar fix *and* gives the canvas a real height.

```css
#bgfx { position: fixed; inset: 0; width: 100%; height: 100%; display: block; z-index: -20; pointer-events: none; }
```

Verified against currents.html's `#gl` rule (identical sizing). CSS-only.