### PR TITLE
Currents: iOS fullscreen fix + tilt diagnostics

### DIFF
--- a/fun-and-games/currents.html
+++ b/fun-and-games/currents.html
@@ -13,8 +13,17 @@
 <link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAMAAAAKE/YAAAAAwFBMVEUjSOcsMKg1xupPvZUWNcpWxJgwuddstG1M2eA7t645LWg+wLtBPJQEZ/wFd/wEV/kKhvsGRugUmPsUmegWONYKOtkITPMapfsXMskbpOYWQukUV/4jqtcVSvYqs9Y5ubg0uccWh/8AVewOkfoKiOoUZv8ktv0aK7gmNscVeP8do9oCd+wkPNUkKqgtssoms+YVPuEhrOUkROYpM7hExLdJwqhWxJcLPuFDvagnq8ohq/sAZ+0VLsIXm9whLbUOkOuAgAqrAAAs0ElEQVR42n29i1obSc+13WxCJv883W237fYWbLDZhBDAIYRNCJz/WX3SWpKq2pn3r2uGJGDs27JKJalUquL377Isq2+bzZ+X5WbzMRhcL2RMB5teGoNpr7ceTDEGzVq+U1VVWdb9p9FI/+u3dVk10/fLy8mwX49GfRlPo+Fk8vY2GQ5H/brW1+g1jfz+9uRktf8TT1C3/dFkb+//S2Nv7/DysC9PVvWEZDoFy8vLYvFn8Ef//nK7fD74/Lk4I3W1GSyWvd5GoK8BTdwKozcg9BY/WffWpK77Iw6F7jXT7++Xb8N+S2j52XByeSnUAS3UDakFWr4D6MsO9PcJoYV5en1tzEI9UC7558vyC6DPzn479GazGZDaJF0l6GYwXZzIWExD1JD0MEFT0u1T34ZSv00m+LG+RFCv/u3pr9d9QO/l0G9v8h5LYV7EUOg/A4K9UNL9/tmZPqVA336QWj6V64FwViHpnkIPFier1epkO1iHesiLiiSfIJtmqnIdGXBbt61SC/RQf67QVW+t0HdHq/1GRS2Sfhq9fc+o9/b0GQRaYFar2xejXijPh2pIQINaoK9fDFre0nQQ+lESei2iPrkFtDOLpIc59BvEasy1ClJ+TGgXtVKLpFeEpqgT9d7e5eSw368rg751YSuzzLfr60zSRr3YbIxax8cH1YBCqlw/RD34XbzkUIZDj43QmUWQQ7ypfoIWBRlPT06OGuqHUQu2DYF+OisdWmg5lEaQ/ly/rFynHVr1eNMLahlrQvMVhVpmoqo0mfXD5Tw0aH0HgCazPoDfaX0mqqjHOhUbPrE8RDVsIjMW5N8vJ6OnGtAnFPRUiSlnVQGdiAcu6TNCi81TYX8EdUArNazeoFFJg5mSHimkMo/7o6fQ6Fof0bb+T9Pp3nq9brZ3Ao0nKfHOYIOGqiYyKUajPqEXJ7cyFtf2sYNKlPqWJu9MqfWBmw8RtJlnYw5NMGqZRsbcmn0ANAU9DkaVdAmkGt9TM1751Bhv7+62jX5efITqCCykSnxiz4ZJr6LG3Np8fFBxRdIHBi3Chj3vVW4vSN2snbnObBblLKuHjIBWmDERWyoHPh5iq9yJrEo9Hk/9rfOZqUl9ShyWRqCnoh4nOgM/9JdUlipqTERRjzO8T2g1RsjEjYeJo7aZFJOw7/MQguwBGohtMPvvltkz4u2NG5/j6b25dcejZdIvlDmsGNDF6spEPDgwaMEuYyi1LSvpCQ3bvwd9Hfk8wxo9tnfXJuaYDkkKPfu4/BUcXV/FPqMKS9kUy69NLX10j/rxnEGLsDORZswhgR3x6SKs0Jh1Ct3UMQI3rDOWUaJmDkK26roW1lzw1fNYTB16k0M/HxR1v1CjpfOxljegf/ADzVWuxvSi5Qo5Yyh1jaVufGfKFcTg6cFmUCWCuElyll9d2xLGh/MhDQQNatHqD8MeiMlTSZch6n72t7oj0lzc/CapW1dCQL9WpErQ5BMxC/LrGHC9JHCTdeMfA7409oj1ANALLnMDzseP69ulUhelU4u8R6NRRxfCItUwpZx0/k509GkZ8PmPX3u0Px1VNuK7OxV1kwP3zAQ2ak2mDcbaHgJRT1WtKWxhxuqxEOjl8lmgS1g99zJD1k5NLZhM3Iy2bZ2EbdYsQfcI7SYDeqHMr2NQr9MEDFMyvVPv8W6r5NNpz946VrJQEZgOceQSdJ1BJ3LMCjdF4q5diuMpnqf7Fa2Zt2Aej22uGbP9IIeGrDNmiFkWyNX+/v6K3FMXtbo6iy60MK8UelnoCyh0sUsdNoKesVBPzI/wFaM25egRTZQW2FXYTXsz4/HFxasSN5moe5yfgnx0tL//8+fP/dWRCHyLdWcNP0fdM7cgHzIZE7Q6Hr4cHcrIlSQtVfQxRyZn12ZfONYO3fNIjAq9pqY2Og3xnjx+IDVMDpj/+fnTsafUku0JRpjqjx4WHFCvuIwbs6iA+MRYTZ8i/oAvN5nABe23gRzQFkdxxSBySFKHS9tNday78PgATWaBFh3Z6hBcjTdOFlubiIO1mhBVahkvgDalOLzU8TbamZMaUtG7b5ML1CYXw5cPX+ZiCTQdh6w7qmGfxXps2vHzp1MfHd2Bd7VaCvQC0KBeA52R7kIjl8L1GcyTrm6ryJ/68JPdSHOlztdPkgVQ7r1A1E1u72hhKrgrd3dHqh4Je//kaCXR+uPjzyVlHdwIAzg7C87BolCJQtKTwwSdYtRsGd9drM0ShLbuQJvuNKbPbmEIvTVq4RVOHUIsf9Wh2OrpLVzaELWOgst2rct3GbAwyWIpfLGuR7b+tZQsfJL7mbyRykQpwrzo8VOP91TBEaXrXBHSHvqqP9H5+aoKsv/P4ycZCv34SeS7r2qy+hfwy9ViCjUbmD7LZFwWfVtEzjJoZFkQ+hO7Ln0Kmv1luBWekgpREKod6NI5uQqubT7i/SVzuL0TpVboTwL96df+/r+Ykitl/vXrp1JLtCR6sfJQV6wHP/GzgFYpYyXB6mfiTbbCogVEeMa8Nu++KjvQNVUgfIumA90zYyjjTjSCghZo/Sp/pZx//VIlOVEFWYix01B3Or2+Leoc+nByKEJWzd4jdd9WPVfgXYcyOcciOr6NqjNHezYLG7PlCTrsuCyYbvR+/vrkGi0ao9CfoNu3YlKWgL7WhbHIJpdIGjK+1Nj4OzMv9OgrB+79Ndb+6bunVHXtiq3kHFhj5N8XmXFZJ+rHT78+cfxKg3OS41ZjmQ605uYklt/7bkMsdh6w+CK2zqWkyty4IUsxgoW2zJcoJNZx+ZMuyOvFOnNB9DMgtcAKLpj/JlfoFdTjOpd0rWvinqVOFHpIaPfP8xBk7QvGOi0ZZQQJx8duEWFBLjBeBfbVRN5ZOoX6jmu50QY0wIn/+HhwYOp9XficAjSSJpbv+Q71sLmXmM1h91Wu8ZA9M+DHx21QYy5epOHQVaSusJyLuTZZQ5t/BW+8C8F+VqVWi13Y68FaQ6dV1NQOJOHqFOdCOfB/uEJN5teVwXw8mx2nMJzq4dBU8dwFMUljiXn89JNGJA2HlnfzvNI82XRaJCGdIWEi0NCNSyaW8zC3F4uba8h6HYmGkPNcmWcuapNkQJtfHRmEirZQ1YOT8R/8JadWcINW/RBZF2n2MMuDpNp3JsP7HWYLRCDezJJksTSIwSzU8zrZyEzYrx53BTSMHqg5dEn8+RgzkIuM2j6Zi+pFEdojQSyFNHeX7jxnuZAQNZjLbt4CWmG8hD7OnZPc7uknlVw9CEKg4YScyB/ilh6JA/KJqkGHBIb7QJlhqZk1NRf07c3MNNxnc0XzFI7Ker3Ok0Ohy0J842MI6Pncfz0m8bjJXdgUCqgXIkNdaY2/NAAz0p9YHBVXh/hPYqg/in7EAOblQTPo4bWxTKSsWGfimVdtQn54eLjCuAG0Yis4vRVuJzT5E3gaNaKEhmvPVKhV2PBV/5UhqqyDyBIwFiM4pUxZijaHQ/0UPn84EmkJN+RjslEphkOayqs9QNuPVN5l9ru9TKWqWMgjv7BuLK+qe2D7/0LBVwgHFkjuMcgVX/pwAkzxo6HNl4wGW4aHyXE2q2d7RCJexZrdD29uZsZN5purm5uZ6YdCQ978dUvgyNOUaWvArQn0phlDW6ZbTEzhFj2XCGyhOxAMAWCnAX2oFnoy8ik4GkU0WKcMW+YrmZhnYIYKD2/uZybph6ubH5mkoSXJCtFRMfMf0BqB0xW02H6rEYyK+cjCxq0GAogGPhRaqemMYhkcWnTYCamyj7gKaCUeYuLh6+He3v/+R/X4Qf1wckCXVRaOefrX1cMDeQRADfRajMgRoRnf2t7rYN0bFIcKTaMx0T2PiQdZ7U4StMoGoYc3Mudu8EVn383//hfQOmYz+WLQ82TxzRNM8XCTmZSA1ogGIS6TIdOBIet+4EeBzIHuK10O+/CTvn9/p/vxnTuAWBuMtH+vyd372ax118jXP5FlpeQ/jueCK9/8URTFzU2hP8qFzAnYYMGsPQPr6736IFxmfabKpJS4Sy3fv0u3IcvHApkD9ZIuJw59+W5bTZrGZZbfdg5bNRLDey4c+i7m81gAy2pv7/Dq5nheKPWPH4V+CPImjufnZZ7vlt9M0PqRzTyIU9fKoW3laaYnK3FIhPrfpRmRE4WmO5pBi6K82/7YkJHsetzzlxTs+9kx49vSBK0qTGi1dsdFAe0QUYvWFCL6ebmTOO818/BdRc/atBH1epfi9iqgZQ3/aXkQgV49FppW2jOX35x/UOtfJrY1sU55GFVmOkP4F+Tcgf5xbMw/KGxR6/l5vkuBT727l5SinPHF2N3HNQKMrUMzCaKZseVzoXNQpLqnIaH5HbLAXL7LuOTWRFllSY2qTHGJQs8A/WOmpligD+XvBf8rSO2iLstz+dODdNvmS5GeuTYRRfoSuaV6/Py5wm6xBLgJmnHs5aUv5EzsMofe3eipykxKc4X+IeJUSZew0gWGK8jVYQFR65hjOHS5s5fk4YAvkdPtFF/hhvz8N5Jkoh7LAny6essqaJbPRuSi07pibkPkmqDSP0SaMwVT6MPDm8MrV5CiODwsIGodxp1DVzvbaSJr+k9b3SHVkhbd/Rf/g87S1KHFsYNvJ/rbF9+OKf9h7GnXbbKw0O3MdBm0Uh/PCX0olIcgVWSTeWHU+hhVld5pU+2M2PdaWwZYmOmm6hJDc40tOuQ/Ck0mIb/b903qSZ7XzdeW2NNxaZvF0yVEga4OOTIF+UHlLgL6vEzQeV5infJ8hGZ+Wh1sdfkcGoJeFofcSxl5LtpE/dRZEtPsHmcbxDTTx/SNBKhQdTBmn4oU+I8ka/WZTk97ydXrTBgvr9BI5sgWw0iwb8G8EvWQV3HmFtBDy/lHrj9li9IOMVcJgZ53oWMA1qFzBSldF6q/tnNTJKoJPgYyWL23zizQt0JdpA2LlpJm3cmTU8dmdxZtRc4AknZ3/7zD/CO3IvN50uosGVhmnrb7UpZrhX5wMmooAy9P/wpRF920P3cLdffiyRJ53KptMw9nnTz5uVMDaEfOMeb5AHXVNXW5Y4JlAQbkTuUsRk9cJ/Pytip0EXWR9la4vaLMAj1K0Midtt14y4VFkARtMy9wQZyMNA22254d8mynN0KwMaC3tH5bxi8ntwi2fP8t4i610foe7qOyx7IY5qpHwr8EsULJ/8pYhMDJqrjn87S6nJsSyCpja03YEVo9tycWL3KtmXJGqr3DROQ2Mjbfcui86quNGMZ26XvZZxpECp2rNr99/tX++Apq/uO8DG2J4NOfNRUfNWvE/oCWRWaxVdVAWF64ya1t881XlxGUw4Muy2W47essDOfnIdPciMyV9OvX0682zn1Qo2w6zLulGpHdThs3mgsWIZ8gJlgGNN0W23zTvVlQh2boriGcf/H+j7s5J+q2E+1CK/Jpc4ohD7GH2Sw49inMzZlQOVYKtHniU4WNaj4k1g26StDcT9ayxWxHud9X1//qajjM8kZOTSLH4R8uZ0GWcZo9hMxmJy3kqSNI96q3Gc1tpimNiHqle0fI2+SSfjJmZpjc9xBoCWGHmoShqCOJG9T26c+TBiTkRJ0xawSpMWRObf66vNz98D5f2pjvU+qlpm8OlgZtubzJJNJiSn1Pa+fIEPUsIlXHTho7T9TnCdmhQzHULlr+TKPJpNZWyTQDdAyEIVpdpwqy/FczekUUdchiiCDg3d1Tob6/19SGiJ8ZL8S0+r3ZMXxMfa1slhVuiU3Kvm3YkPk8GfKbPcSTSDUcJ5XTz/XeBmLoidd1VaQ+wfbziiavj/VkiGjrHVHAxKQ9pLu6t6fYQyY4buhtyCJxno+vYecEGmbW4xATdCzuN1d7pP7h+bNUrzPklL/3spig7oEau1wBrfqcYkQNE/fMr55Mrq4U+upKUzNIMN6Q+vwvaFILc4M0KJPRBu0rpXqClkEzao2UvYzEoPVlEfIht2/LJPwlVQ8m02k3sAegon7HeMA7FeSHhz3LiDr04X9QA7owfR6/vmoG/fU/oJVXszoKfXNzT1lbshMpCo7JnkTXoM7V+nZF9XBz19cYceKx+Pu7yVmQryZRK7z3YDlRiwyVkGp92hD6a3Fu/26Ee3//tWm+nu94Uj80BL6KbLZphyC3rcjp6uEd2z6CEKVTdbWecnWR4Nyhkdy9fDfNADVVGnNwmEE7NafjV0Kf70DLN0XclPa4OQ1qj8FUzg59Y9Ca0hT1UOp3+8yTT1FXzZSVIEtA164h/XdXaKV+V5XWt/2f0Gb4zh36vAMNIwe9BrRRzw360KBJrTn4Y6RTZppuwwR88P3XCZe5Pk53qIOnO/2EptcxEkm/+yyMDwfaMXzAMM026wH7liTdEPrrKb4nyEevhFZR00zn6iExMKnl6/3MU/OYiFAQDjcfAr0eIIC5XR08FnUUXks07omPySV/I4JznYwEtg9UMzBukk9NhSnoU8hZkRX41efiV7PTVBK1H4d8uiuq9TGtSDsburFTCFTVWQQCUYuG/HwsYmdLUwgTy9VE6gNF/cMhqfU1zFAfW3IfPpFSC/OYzBymz4LMMkJdxueUNZM4KuikIPdu+louZpxOl2bxLEJF1VtIGushoN/ePOsxGXYGN4BubHmZeVbxq0PqajKnuQvdUObYUeGaOLdEiFBfpZl4MwQ0vySbR+ingG5AvVoeFO54WHHmUI+A6LhHHCaLtkMrrlp9roi6Hiq0EYPt/NwE7woN5sYWGExXBmXifxRwPX7EDp66BxiZoLAsD31/HsX9C5i9IivLb0fJSaFbK9pub39CLw/eBy2HQ1vyTZSBxPSPDJrYXMq/OrYM3SH4MeuMobpjvnxn6OlAUoP842rp0F6hmXngqaQfH5m5prb9Q9/DoLWAQwfegGuLU9s3GpuveRwQG3czF7U5DVd01lzqtt2tNbMLuExFFJVme4adQvq6A3183KHGij3WhU9G8kNtJkLQtC0eCbjr7dQpHrj3V1FoRtZPtCRB3UxtGc9qYes2q62KIwutxi3Qjpsd6Ln7c/8JraI+MmYbKYaZRwAztxqAoW47PdgQ0HvWwUeU7dSWrEkHl+K40hp5+B7PDOoTWgwA6HlKz2Ah3IWOyZhUOaeGrPP0DZlvlJglPYAG9ZOp9ciOWkFBbm8LP9jWOrTnGeMUjkUutq9F6MgXKfRFBk2q0zQiGM+hv0YCwbZt5BUe3FFQ6GEOjQxSRn1SvL3hNB30wjYruD09brgxps4X9rQ0jjnWF2FK6ZjqIdSv+/v/6NC6/1xBmmzuhaz5gEzUumENMYP6Qf1I6DHrGIcpIWoOiMzFHFpzDpa1nN7d3fG4RAnjh8iL0LUnh8x8iKTJ/M/FxTiLY2Ex3J06ZwIE01Yfw7yT60cHGtoR0KORn7TDwSVdXxaqHprodWjLWWryD9RU67ae3Ue6xo+RMJUF5v8D+tShQ599pWk0y3R+XrvtG7pCKzSCj+GsDwtsvtyIZa48NHtScBOgdWhl1jJ9o173uDGU6mXmdZ75gEZ3ocen3ZGgmyiCHJfnlm2ZY6/pXkWdQ1OlBcszo7B6OF8oWl1cTiwBKWLjxq4yH+XUMkRDzNJ10h49MidoDWZP/4+BAhqrcvO0HaHv6ZC5eujaMrTjQG12povhrVAXOAJob8OyIlo9znqiOzsvUXYqvT3xQ9mFoP+JsqpsZMxNVjTW6A6Gba7PhnT1YKGvdBoGcu0J8r4jioIo9KWfAbRaC1UabHgAmuXPeQmbL0A98zpySVssS5HCkT7NbDahYR1VGJXvNN1cpTGhmFsb/TZyumaP9dBhgfIfO8oUB09M0NtXO1TROYRndRC9U/eUutAX9ET2GR3m0ONYhnJoW1e4equXaUmxUIx0sMY8kIFaj8ORHUdeMz9553th2Yka26i0Kqs5tMN85aCm238RZBddaJ54cWiqhzDfq6BBbX78fSizhIdPWVIvSiwKNdNPZgIbHvy/40TcZpV0sR/fMj3LLgFjO3ljhtq8vdeAfjX9SJsR/lh9P5Xtnt54KIdQQJdduMZ2iCIduzK7LFOx0PolE/QJz35tt9xZEu3wNFFTVR1B70D7iugTzWsZL0yrm/z9/QWdZTcFV1aw2Ox5CreorPOjQEU6Qi3Q3ABLe6VYZC5YhZuKBg36tEkg+4TGP4J5HzYwThXlD72wTw/6of4dxNziEGGyckmlvViBBgQnKDvQuqurm6V3NmDIbL+zdVttOm0kwPznH0QD+x3ojLpx6H2DppMAaqsxauPI4A7zzgGVwqx0CegG2/76xM78SuvFlbGdRb1uhd3iJipfzcsbJ2IwB3V6LLBTkayWjNzfWxbS0r3YWMNOd7tb/gX9KA694FiAe4TWasmjBH0hX9dR1ZZBcxsbZGARtotM0lEwbdbaFxdYjzhhxOqcYz8m6Mfon3SB4a5rFk3ZLmMxirxCM+01PHWi0Ce5pMdsEnEMRy/fxDHx8YM3SYfxoN0OHzv/WKKujattbPhpbWTtJrqtd0sK7Ex7MUrLunbx0MpDfcWjrtGjSh+nT7FTYqxKIChc8xw6VuyGW1vJYZIHndp66mUYKc4rQ0XaNlmNvALToVlE2QD6BDWpCj0dhyuZwoHdumhb6MbAgyvyehHMr1pIdeoOdfimWl7fC1FHERmoOpX63TdkVcDie+D8NaHX3CLQkhAZyrz24kTfErEN0NjEPg1qTSGQmgruZxaYfBRovOhpqnfMjjCWCasqs9PfvluY5Nzg5C0C2zPbgEQvHKE+wkFdP9GS1fy3yMbWZZ3OWJ8m6Oo0s4JeqxY7iH5sAeCdcmo/a9KpSOge80/MuoPBaNyWGiopS2jHTXZ4PtI2rCRMx0H8jCSkG5J0Efv2oe96RfXPaZnXU3fQ/Ovf0Ma8Wj5zRbSsQipaXa/T03naDM469uPqNits6kUSoUQo0/g+bZZOivD93KYCyvo6BRP+fN3OD2Wd1fZrKH67Ovj0Sat6bSr2BlbUvM6q0c0epdQaYvLjdFaVxhrBLZ4cRVW+QRspmai2R1Fyr5nb2Yxu4Yc+XfekZtnZbNYGGgePnz4rtIlaiylLr83Jeorci6+YbSrqDrlv7aRqc4VWHRANYT0siBXVapJR62u11FXP9mmjkjOJulPN2VkIcSZx+fjr8+diYgcANKnQptKIMnWdEdLZAwM3G4zKy+yErUGj6o6lM2BGBp11TGnPUL1xe4YyL030g4HxAWQWOoP+JNBvh9ErZ+2nUa3qv/Vk2mT4zhA5QWc1exUTCf/8AzlWlZYplRS0oGoiWrhvIoWuyZMqq8LIj56U6URXt3bWWuYI9CeFlnALGqIfWp4wpQuAjdMHQEPU9+6SkXoeRyXH4gUxbV2dh6gV2jYpUhSoe1llVvFiNYWuBXkdfmf9xmn3lWqHQF++7UC7zaHfMtnT/WaBfqCbnlNnAYFA71uuXQasRDmfI2bVXayrqyvbz7u6uc+hoxovrF0yhuUOtc5D1Q6FvozgpexAM0zDRpfukGlakPGQUXsihNAXgNb3IOI3dEJjy/Ah34bsQOcr2H9CR8oiQUuMqPWE/bOAzlcUQOOUwPd3y88zIzi8z49oVb2AdrOm0MgOIM5+6GxTH9cGnZYnb6eSnTrnvMqOUiVoPX0xon9alTurqarIcPLO3dP3q6hKmFwlk23OuC4vc08CO/R89gPKzOwi03UP0A9O5eimcWF9VrJDYt7Hq43j3DIRT5YGzbrNvs/cMp2yRqM2nYm26fsQ9mPCFPt9fMqArrP8LaE15xXCBrdA6wb+zI8r9pgsk0C06XWqZqPQxg7rVegotXz8rNCpPRh7+WRVqzuiti1+bNAxT6HUx3Y+Q1wkJhSZK0/11TfcNr3yvJdCHx+32XH4iwvmsnq9bgWqVVY9ucM/mN4e/PoP6E57Ax5tGU0uk4IMozIB1oSBTIIumX+qs1L22c1NbMwa9L0uqW0X+oLQXS/EKg2yfaJd6Lrsnjy0M1pJP95dq7FrZgkhLhJ8aZvt8w60n6u8v0mivp8x9PbsiW6EZUpd5hVsyH0wS7MWnSZ0P6POXLdemolODWirp0jLY+jHeOyV4J02XZiczI06te77gjpO8NtJuVhQvHES2l30bXOlWk8XNhG9nZF1nyjrMusbAPVQSjC/Txx6wtqoHLoBNDBzVziCpuNM1nGUKp38HNvB3TLf1WQ23Y8XapmKQUNtrM1V3QlK/Bn0V5V2TyuEOpvX5mHXFpWblU1+ROYcy//YpBDl0KmIX279M7KT/usIGNlmzMWJCYfebrdg/lygodFZ3YU2YVvOsa/1CSi/mGB1uZ+hnMvXl9YbBHUOO9VZWzh7nhl39q44n2d2ZosbgDiPrtDRRck2ip4cWl5kuvpE6PhEzrreaxYb9lFZdMmylXvNEvZ9dplqsqOBQXej/vwkEvwW2Hh1d+O4ku14UT9qnkxILXP60dtgsFgGtMUoZ93jITyKaceeUA4FSQ9TAbsqxyx18GuaOCCZHY+JIwol42KUn4mKTAK6svpuq9qv7QTIkObhKah7g+tbh+7tOK9ZF5qgrmvfWh/G6QYWg8yyuvsmSTq6TniPPNdVUquk9Vfb1Hhg7OcjWvQdBfSTV/wY9GL1/CuDrrpxTxXNN1IjwifsOHmuGEXVUJLssEDnrH7n2wFNDcEeRQadzkeUjDyG3uQnW0QqQB9k0J0Is9N7JHNT8zoQgxZZt1n1+l+H9fL+g5aDiGKj0I+ql4JpKwJ7yo+z+4o47apH9nJ/dUwJ5Sm7VSAt9cOXtiqL3+t65zSIv/GZlxelWvh8NcsbIbLaf2Jnq5ktWCwp6sK9752jgfnxkNJOM3d7WSJQn/Vns/gEsv2cMktqZOmeKKtCoDxru+/Py6mYWfeuoRm0zsRf2rgyNdrAFOos4xm39Zxo8rahrc/F1GcxHS/JDyeYnTblUFN/lSa1v2i4G22dOkqMkCxAp0RCi6gPKOkqzfuy2xsja5LJkxtbTvMQdlBny2/3WcqsnSZKwlRHGPz023an02XeAayftdWlnVboA0j6w/sJD6bd0yC9yJk2Y/absB5z2/G6p+GBTqa8ch82RZZrGvK2Tt6A4EaKHCl/TQDZomc7AN6p1mcgV0I9enM4edNosKfIEPTnYjO4tn64g0WCtkK4ARszTrfrNavlcSrp7q5hzc193iStrFTwCj2zg1PelpaGo41OuPKD4XCn6t+hK9so8u6IbvVqtXjaHhTQgz/XTr3onv2qotuLbSFtSWz1K96oyw+sy+vprOxAl1UvczjdWgJ6iL65MqyntpncKpUJohNllCDo2rIUarS91abfhJ4uOg1dU/M+CYLZeO/EN82ZCC7jvDqMeNln9toW+rYuu51ycyOe+4oZdZwo0v17wEbv2t40g0Z/de31Mb1e5LlS82UGPItLYm0ms697SNtUnBBLDeXjtZNt5Mkzw5nWgv4wFe+iWrDcsY4h8DOPaq9fwKwKUiy02d81WnYt8n7C2FsE9IKtAo+OVuxtcnQiNsSbs+VtdrOKgbazt7POYtaARqtsr0RPWwFl5NPZUNNmBhtmOzSarSv09Pq6V3VzrFXPoXGimNArtPJM1QkW6LcJunXorNdi5OhNhmRGz8nUlD+W1XScjMtKD/1BEzQb51GrXdDa0i3UA+W/J+gRwk6e7D86TY2JzH+yFEXdaeacH4LOPkj1GpUXtdpRAtvZGTD1sJsO9GQ+tIPQLy+3vDxgOsidNGsDPeXxNOi0QGsDmRVONIY3SYtGFQxBd1S609WSczc7Nz20/EXl9rFMG/j+gVsjVmNWSevlAWwRb9bpzJV/DeVIY8XmTicn005n1dhHausudBUteVMnifTB02168hZVHe8s3wzA/QzXlPTBwYFJ+sW0epOgvTLLbmGQAaMHWYv1GMd2XXIQvVAqjEf1tz9Q5QlZa20fyOsdl9K6PKLfO7aIHPq5IPG1dabO/FMWZolKR8OYLQ+aiHZEP6Uqh44Vrm3bTmC7282ozguUcgc+M3ld6A1FjZn4/KX4I2OAbvu9bOba4dxovd80g3RUfjtN8yqvDn/icfOn1CortQ7Y6ell3kld7x53z7TC+2lidmk/9ZeVNSgs2P57kz6avD8eGtjTYoEa56CVOe84Fzt3iEdGT3FmdGdT095EbQH+jiVf93aTNfBqziIsUWoxdQJ+W/BCA4rBTV2CXqdmjYNoK2Qt56puc7G6NWPANnsurHxPM6lf3jhEhTLwpoxlvo2fx9rQELsppQDwhtgGbaUgdKOVuxnI9Id7MtUmG02z09ivpACHI9QBeuW7uTB5hUlsBWU3D+i5+4Emayih5Dplzw/Ha6N3iizVRBfk3SDm8gbfu20114Me/dQBX6FZd5wJfwEErKrTbaaUZRYzpq+2zcpLR+wk+6Dp7JVXO137cbkBrtFRSVPKpUHnzUvTfT8GrYqt7OvuRrwNVDo/BXT9f3SfwmZybQdXtjwPjp4SCr2u8l26FGXqLRcDuNF//lwbNF81h+5gE5oKkl8w0ZUIrw1g2XC3e/Jus4aeHbahOYJfox3PJN4YdA/SZ/+Ka0T+/Cl0FqJxpTxNdJ/Qpt9egYp9UjbIStuRNi8tB6dxzfTkyBb/rK25p8N3Ong0026Gx+s4VqvlwZSv4wEL4tm4qki+apgInS55OYpCF9rUWaHfDhEEK54EZyrgJq7Y8CNrW7clgF51oPt2IMwUYZ3fw9Bs/XYX5LB0s43Qy4PHhVPb3RbqSMPVgLehF0J9UehvOTS5DZoVyrp9tyB1dJvk4cCFQ7NhUh0nC9K1IX4+NoPWbQhvFzBg4DzgoazV8vFRO5d+UDxiy3DhkyyFty/uIS1elgL97Vtp0JW3sEc/OtMPrPsrBjcDXwIgaOjhNMLIo1W0Xmyzbux2Y8M6nyHbEzpRAxqNgSnHUpgf2W/1o2fNMWHmtAWC+s8yCf/o7ReFMpe88OfbmVF7v/KA1rbP13aDxtpFo17IdGDM6sDWdUed+09+iUPZMUWqSQ0tkd1ewCNZS1EObQN6i46rvDmCPscX+dkLDAegvwj07/I3oaszuy7A0KNej+3XrW8/LR9EA0NFx2R7cnRiqRbqhbfdGNpbT8yD7WrFNoP2lDyljLsW0LsU9/xYYEI/SfVDBa22Q/RDoL/9/v2bF4bhZobCyJNr/oHnv/UmnRSNNr9kayQYQlXxMl2Aw+Mpb7yJq63jgqI1a3pWW3sS5btVVWbf0uXBs/lES79169aaOItWE/palvFvoBbob9821uK0KPyqEStZ4K1u8uQHaK9xe8sTut7If6oggOZtS3aANEWAQW0JieVPvufblWuF9oplOGUiD/ilOqQiasxD8exE0oQWDdEr8L7x7g5tZp8z4y46MD97I9ecGtgnBm2tc9kJzs7rJgVhcC+gP+1Tu4XBeNTex9rX9vnAMM3Z9/fw5csXmYki6T8QtEla/t8A+rdddYCLdMIH+WA93MGjdc9VamjiLS6n4DUVJwveLgdmvY7KOsJd8qY1SppP9K9Dn0A1rJvwp8dnk7KHVQpu1CpqGI/rRQbdkTRv/wnPST1wFTS6h6tItGnuLTWc2olGqdgq1R7W1uoQ3eHYH64LvTyglt0mSSdmZpEOPn82aYuYTT9gPdT9KGQWik5DSQw6riwK1wnXkmh1Gbtus1U4WxQvPBQT+JLakXU43+MVD/nBmkW0yzkBs8w9dn033Vi5cnw+SEOg1XxojKXcgDZZf1PbZ8TZrVbwr9QBebZe4fICVG7TDuuS2lhn5Uvrf9lhLv1iGTbaEiGfLJKle350MS9T/Prf0ErNiUhq2Gu7pu0s3cTF2+UUmjPmF3qIo4W1UTOMXFtXJOrynjVmtKKdxIwL12AteWB2ZUkYh779D+gDqAdsnnqlhVrp36rQSm5dnYu4hqvq0cLz/pfn5+jKbq+h1yWoadkquPcYUvu8t8eD/qO++Uw9+CgD3KvAZp9T3DUpdhiNpWnvyM7c6OeOrJcvC5Hxy8ufJGmF/h3QftGjerG8LE8nLbDZK/zRqFd2WwLXyb+gU/EtTi+ZRote3C7gE2gner8NZwlhf3leIXbVy/l2FUQsNe6k3AxcPbguRgNtKEfPb0u8RtoMy5PK45NK+hny4TUgcCc1vBPos/6IvTBR7xfHxJitUpU4kUUCn8/ArzpZ5esJ18GXHSVRG7L8Ag2BeiRmQuNCPN6Y6LECoP02JqEmsuofJpR6gD2Dll/3ax0m4Qqg19aAroY2vo6bToitT/rFTceCbpF4GLgXLDHLI76odii0mbtA5viNa2IxVe0qSPNeVuEbLJcmZvSEjuI/9MB/49m7fvRhZKQGcx4XxNGLy59VVIMOBhY+LoVqpZ+/8D0tXdLidnDsMiu0If+x7S9T7CWuKIErdq2zyf3fMrb/4IxHwBnXLU4X5pd3buKL+7TgIyF1hDtJX9T5X36hlwfdeFFJDzbfigzVtDlBU9TMmn3wXl6mKxe8Y/barpeyjKhdhmUVXmdZtneQj49e58YwrgILC0146STj7mteXSvDiFVzBOWbOqJFUXgpk7hKZyp63Gzr8/Bj85FuuI0NPNt9TA3YynQ1kBO7I6CT44P3wfX+owEkLyHFM8f1nX9gkz8GVPCFhQAD2OYCn6WWQQo4P1SukSJpFTWe4ePDLoK0W0M/VPAfuNg0z96nahirhDZZ4kqkj7zRfrVzpaFa1o8NPlF8wrx/dGO3vcLl+MPvCJRAWwNVrd0sDDqsoF1ZqgE7L6D748nKzm5/5D1GRefgcZXU1i9m9IemmwEt7RSM6e8BsTGxx/eKQ3hie8A+PMyh/VZbPFXcubrZ9HZLIjwjYz5tv9Pj8uMju02yzKCd2hXFM10UtfKVv/mhb7rv4vfvYi9E3T8b6fXSScychEDPklU6dWAqztyn8hVf64OxycqzHqwthz3Mu5fioepDMkNJb3KzsVqHzRkNGaeW6gL+qX91lRaTd/k3tOmOzA152EcXGjNrQxEzS++7JFUPM+OsjA+em1IL3xhJ6lRVXlVX2yW6sSG/yRc4hTGDTGhKW6D32FPt8LA4U9th0BtYaVelLnTl2wxnZy4tYah6b284F+2OOK40XNzaHalR6oc32E/OZEdPqm85tC8h5tNRQ34rNFtm/wXd0f/BtypddZMS+7jbFMxIybwdAtpUmq5WXAi9ybYnAG3Y4Z5JrCehatVZ5Ej97ZurNjQakr5E2buqB4y0WTpSG/TH5lsq2c/LbpNchAQq5hoEq273nC90odv0UlFHFRfRnmUX0mJ16C7NpiM+zewPhb506L5Duyr/CXv5rcprsR2avP0OtN84zJUI1LrWyTP9/0H7Qlzm0KbZZjNStPL/AIKpnGOc+MMoAAAAAElFTkSuQmCC">
 <style>
   /* full-bleed, no chrome, no scroll */
-  html, body { margin: 0; height: 100%; background: #050608; overflow: hidden; }
-  #gl { display: block; position: fixed; inset: 0; width: 100%; height: 100%; }
+  /* iOS: html/body MUST be height:100vh -- 100% or 100dvh breaks
+     viewport-fit=cover + black-translucent (content stops at the safe area). */
+  html, body {
+    margin: 0; padding: 0; overflow: hidden;
+    background: #050608;
+    overscroll-behavior: none;
+    -webkit-user-select: none; user-select: none;
+    touch-action: none;
+    height: 100vh;
+  }
+  #gl { display: block; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh; }
   .overlay {
     position: fixed; pointer-events: none; user-select: none;
     font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -285,6 +294,8 @@
      handing over orientation, so we ask on the first tap (enableTilt, wired into
      the touch/click handlers below). */
   var tiltRequested = false;
+  var tiltPermission = "unknown";
+  var orientCount = 0, lastBG = "-";
   var baseBeta = null, baseGamma = null;
   var tiltMag = 0;               /* 0..1, how hard the device is leaning */
 
@@ -297,6 +308,7 @@
   function onOrient(e) {
     if (e.beta === null && e.gamma === null) return;
     var beta = e.beta || 0, gamma = e.gamma || 0;
+    orientCount++; lastBG = Math.round(beta) + "/" + Math.round(gamma);
     if (baseBeta === null) { baseBeta = beta; baseGamma = gamma; return; }  /* calibrate "level" */
 
     var R = 35.0;                 /* degrees of tilt for full travel to the edge */
@@ -319,11 +331,15 @@
     var DOE = window.DeviceOrientationEvent;
     if (DOE && typeof DOE.requestPermission === "function") {
       DOE.requestPermission().then(function (res) {
+        tiltPermission = res;
         if (res === "granted") window.addEventListener("deviceorientation", onOrient, true);
         else console.warn("[currents] tilt permission denied:", res);
-      }).catch(function (err) { console.warn("[currents] tilt permission error:", err); });
+      }).catch(function (err) { tiltPermission = "error"; console.warn("[currents] tilt permission error:", err); });
     } else if (DOE) {
+      tiltPermission = "granted (no prompt)";
       window.addEventListener("deviceorientation", onOrient, true);
+    } else {
+      tiltPermission = "no DeviceOrientationEvent";
     }
   }
 
@@ -378,6 +394,53 @@
     document.head.appendChild(mLink);
   } catch (e) {
     console.warn("[currents] manifest injection skipped:", e);
+  }
+
+  /* iOS standalone: env()/viewport-fit=cover values are wrong on cold start.
+     Toggle viewport-fit auto->cover to force WebKit to recompute them. */
+  if (window.navigator.standalone) {
+    try {
+      var vp = document.querySelector('meta[name="viewport"]');
+      var vpOrig = vp.getAttribute("content");
+      vp.setAttribute("content", vpOrig.replace("viewport-fit=cover", "viewport-fit=auto"));
+      requestAnimationFrame(function () {
+        vp.setAttribute("content", vpOrig);
+        requestAnimationFrame(resize);
+      });
+    } catch (e) { console.warn("[currents] viewport toggle failed:", e); }
+  }
+
+  /* measure a CSS env() inset from JS via a probe element (CSS-var bridge is buggy) */
+  function measureEnv(prop) {
+    var el = document.createElement("div");
+    el.style.cssText = "position:fixed;top:0;left:0;width:0;height:env(" + prop + ",0px);visibility:hidden;pointer-events:none";
+    document.body.appendChild(el);
+    var v = el.offsetHeight;
+    el.remove();
+    return v;
+  }
+
+  /* optional on-screen diagnostics: append ?debug to the URL */
+  var dbg = null;
+  if (/(^|[?&])debug($|[&=])/.test(location.search)) {
+    dbg = document.createElement("div");
+    dbg.style.cssText = "position:fixed;top:0;left:0;z-index:99;max-width:78vw;" +
+      "margin:6px 0 0 6px;padding:6px 8px;font:11px/1.4 ui-monospace,Menlo,monospace;" +
+      "color:#9ff;background:rgba(0,0,0,0.6);white-space:pre;pointer-events:none;border-radius:6px;";
+    document.body.appendChild(dbg);
+    setInterval(function () {
+      var DOE = window.DeviceOrientationEvent;
+      dbg.textContent =
+        "standalone: " + (!!window.navigator.standalone) +
+        "\nDeviceOrientationEvent: " + (typeof DOE) +
+        "\nrequestPermission: " + (DOE && typeof DOE.requestPermission) +
+        "\ntiltRequested: " + tiltRequested +
+        "\npermission: " + tiltPermission +
+        "\norient events: " + orientCount +
+        "\nlast beta/gamma: " + lastBG +
+        "\ntiltMag: " + tiltMag.toFixed(2) +
+        "\ninset t/b: " + measureEnv("safe-area-inset-top") + "/" + measureEnv("safe-area-inset-bottom");
+    }, 300);
   }
 
   /* fade the hint in, then out */


### PR DESCRIPTION
The bottom black bar was a documented iOS trap: `html, body { height: 100% }` silently breaks `viewport-fit=cover` + `black-translucent`, so content never extends behind the home indicator. `100vh` is the only value that works from a standalone cold start (`100dvh` also breaks until a rotation). Fixed, and adopted the canvas-game full-bleed pattern (`overscroll-behavior:none`, `touch-action:none`, `100vw/100vh` fixed canvas).

Also added the standalone cold-start recalc: toggling `viewport-fit` auto->cover on launch forces WebKit to recompute `env()` insets (which are wrong on first paint).

**Tilt still not firing** and I can't test on-device, so this adds a diagnostic: append **`?debug`** to the URL for a small readout of `navigator.standalone`, whether `DeviceOrientationEvent.requestPermission` exists, the permission result, orientation event count, and live beta/gamma. That will tell us whether iOS is (a) not prompting, (b) denying, or (c) granting but not delivering events -- each has a different fix. Reply with what it shows (open `austegard.com/fun-and-games/currents.html?debug` in the installed app, tap once, tilt).

Note: iOS caches the standalone shell config at install time. After this deploys, **delete and re-add the home-screen app** so the new viewport/meta take effect.

Source stays pure ASCII; `node --check` passes.