### PR TITLE
Add selectable 2/4/8-tone chord modes to the acoustic modem

### DIFF
--- a/modem.html
+++ b/modem.html
@@ -90,6 +90,15 @@
       <button id="sendBtn">Send</button>
       <span id="sendInfo" class="info"></span>
     </div>
+    <div class="row">
+      <label class="info" for="chordMode">chord density</label>
+      <select id="chordMode">
+        <option value="1">1 tone &middot; 4 bits/sym (1.0&times;, most robust)</option>
+        <option value="2">2 tones &middot; 6 bits/sym (1.5&times;)</option>
+        <option value="4">4 tones &middot; 10 bits/sym (2.5&times;)</option>
+        <option value="8">8 tones &middot; 13 bits/sym (3.25&times;, densest)</option>
+      </select>
+    </div>
     <div id="sendStatus" class="status"></div>
   </div>
 
@@ -127,7 +136,7 @@
   <div class="card notes">
     <h2>Notes</h2>
     <p><b>Demo on one machine:</b> press Listen, then Send &mdash; the mic hears the speaker across the air gap between them. Two machines: one listens, the other sends.</p>
-    <p><b>Frame format:</b> 250 ms pilot &middot; 8-symbol sync &middot; version + length header block &middot; payload + CRC-16/CCITT, all carried in RS(15,11) codewords (11 data + 4 parity nibbles each). Every tone is one GF(16) symbol; each 15-symbol block corrects 2 errors or 4 erasures. A ~200-byte packed SDP is about 12 seconds of audio.</p>
+    <p><b>Frame format:</b> 250 ms pilot &middot; 8-symbol sync &middot; version + mode + length header block &middot; payload + CRC-16/CCITT, all carried in RS(15,11) codewords (11 data + 4 parity symbols each), each block correcting 2 symbol errors or 4 erasures. <b>Chord density is selectable:</b> the payload lights k = 1, 2, 4 or 8 tones per symbol, and each constant-weight k-of-16 chord is one symbol in GF(2<sup>4/6/10/13</sup>) &mdash; so a misdetected chord is still exactly one correctable RS symbol. That trades robustness for rate: 4, 6, 10 or 13 bits per symbol (up to 3.25&times;). Sync and the header always stay single-tone, so acquisition is mode-independent and the receiver auto-detects the mode. Per-tone amplitude is split 1/k to stay clear of clipping, so denser chords are quieter &mdash; the physical robustness/throughput trade.</p>
     <p><b>Validated headless (Node invariant suite):</b> GF(16) arithmetic, RS errata recovery across 400 random error/erasure patterns, clean loopback at 48 k and 44.1 k, random silence padding, AWGN to 6 dB SNR (decodes to 4 dB), 48 k &#8594; 44.1 k resample mismatch, 25% gain wobble, all combined, and recovery from a steady in-band interfering tone; pure noise never false-decodes (CRC + sync gate).</p>
     <p><b>Browser-path (cannot be tested headless):</b> mic requires HTTPS and a user grant; the getUserMedia constraints disable echo cancellation / noise suppression / AGC, but some stacks ignore them &mdash; OS-level noise suppression can eat the tones; AudioWorklet loads from a Blob URL and falls back to ScriptProcessorNode automatically; on iOS, sending forces the loudspeaker route instead of the earpiece; speaker volume around 60&ndash;80% works best; decode passes cost ~100&ndash;250 ms of CPU each while listening.</p>
     <p><b>Known limits:</b> RS(15,11) corrects up to 2 wrong tones or 4 erasures per 15-symbol block; a burst ruining 3+ symbols in one block still fails that frame (CRC catches it, resend is the fallback). Broadband noise spread thin across a long frame is the hard case, not localized transients. Range is conference-room scale, not hallway scale.</p>
@@ -153,176 +162,168 @@
   "use strict";
 
   var CFG = {
-    version: 2,                 /* frame format version (nibble in header) */
+    version: 3,                 /* frame format v3: header carries chord mode */
     f0: 4000.0,                 /* first tone, Hz */
     df: 187.5,                  /* tone spacing, Hz (4x symbol rate: orthogonal) */
-    toneCount: 16,              /* 4 bits per symbol */
-    symbolSec: 1.0 / 46.875,    /* 21.333 ms per symbol, ~187.5 raw bps */
+    toneCount: 16,              /* 16 tones in the band */
+    symbolSec: 1.0 / 46.875,    /* 21.333 ms per symbol */
     analysisFrac: 0.75,         /* fraction of the symbol analyzed (edge guard) */
     rampSec: 0.004,             /* raised-cosine edge per symbol */
     pilotFreq: 3500.0,          /* just below the data band */
     pilotSec: 0.25,
     gapSec: 0.06,
     tailSec: 0.05,
-    sync: [2, 7, 13, 0, 11, 5, 9, 14],  /* v2 sync (distinct from v1 lock) */
+    sync: [2, 7, 13, 0, 11, 5, 9, 14],  /* single-tone sync, mode-independent */
     amplitude: 0.8,
     maxPayload: 1024,
-    eraseRatio: 1.7,            /* top1/top2 energy ratio below which -> erasure */
-    rsN: 15, rsK: 11, rsNsym: 4 /* RS(15,11), 4 parity, corrects t=2 */
+    eraseRatio: 1.7,            /* weakest-on / strongest-off ratio below which -> erasure */
+    rsN: 15, rsK: 11, rsNsym: 4,/* RS(15,11), 4 parity, corrects t=2 per block */
+    chordK: 1                   /* SEND mode: tones lit per payload symbol (1|2|4|8) */
+  };
+  /* chord modes: k tones -> C(16,k) chords -> truncated to 2^bits for a clean
+     GF(2^bits) so RS(15,11) runs over the field unchanged (one chord = one
+     field symbol; a misdetected chord is exactly one correctable symbol). */
+  var MODES = {
+    1: { k: 1, bits: 4,  prim: 0x13 },     /* GF(16)   */
+    2: { k: 2, bits: 6,  prim: 0x43 },     /* GF(64)   */
+    4: { k: 4, bits: 10, prim: 0x409 },    /* GF(1024) */
+    8: { k: 8, bits: 13, prim: 0x201B }    /* GF(8192) */
   };
 
-  /* =============================================================== GF(16) */
-  /* prim poly x^4 + x + 1 (0x13), generator alpha = 2, field_charac = 15 */
-  var FC = 15;
-  var GFEXP = new Int16Array(30);
-  var GFLOG = new Int16Array(16);
-  (function initGF() {
+  /* ===================================================================== GF */
+  function makeGF(m, prim) {
+    var size = 1 << m, fc = size - 1;
+    var exp = new Int32Array(2 * fc), log = new Int32Array(size).fill(-1);
     var x = 1, i;
-    for (i = 0; i < 15; i++) {
-      GFEXP[i] = x; GFLOG[x] = i;
-      x <<= 1; if (x & 0x10) { x ^= 0x13; }
-    }
-    for (i = 15; i < 30; i++) { GFEXP[i] = GFEXP[i - 15]; }
-  })();
-  function gmul(a, b) { if (a === 0 || b === 0) { return 0; } return GFEXP[GFLOG[a] + GFLOG[b]]; }
-  function gdiv(a, b) { if (a === 0) { return 0; } return GFEXP[(GFLOG[a] - GFLOG[b] + FC) % FC]; }
-  function ginv(a) { return GFEXP[(FC - GFLOG[a]) % FC]; }
-  function gpow(a, p) {
-    if (a === 0) { return 0; }
-    var e = (GFLOG[a] * p) % FC; if (e < 0) { e += FC; }
-    return GFEXP[e];
+    for (i = 0; i < fc; i++) { exp[i] = x; log[x] = i; x <<= 1; if (x & size) { x ^= prim; } }
+    for (i = fc; i < 2 * fc; i++) { exp[i] = exp[i - fc]; }
+    return {
+      m: m, size: size, fc: fc, exp: exp, log: log,
+      mul: function (a, b) { return (a === 0 || b === 0) ? 0 : exp[log[a] + log[b]]; },
+      div: function (a, b) { return a === 0 ? 0 : exp[((log[a] - log[b]) % fc + fc) % fc]; },
+      inv: function (a) { return exp[(fc - log[a]) % fc]; },
+      pow: function (a, p) { if (a === 0) { return 0; } var e = ((log[a] * p) % fc + fc) % fc; return exp[e]; }
+    };
   }
+  var FIELDS = {};
+  (function () { for (var kk in MODES) { var M2 = MODES[kk]; FIELDS[kk] = makeGF(M2.bits, M2.prim); } })();
 
-  /* ---------------------------------------------------------- poly over GF */
-  function polyScale(p, x) { var r = new Array(p.length), i; for (i = 0; i < p.length; i++) { r[i] = gmul(p[i], x); } return r; }
-  function polyAdd(p, q) {
-    var n = Math.max(p.length, q.length), r = new Array(n).fill(0), i;
-    for (i = 0; i < p.length; i++) { r[i + n - p.length] = p[i]; }
-    for (i = 0; i < q.length; i++) { r[i + n - q.length] ^= q[i]; }
-    return r;
-  }
-  function polyMul(p, q) {
-    var r = new Array(p.length + q.length - 1).fill(0), i, j;
-    for (j = 0; j < q.length; j++) { for (i = 0; i < p.length; i++) { r[i + j] ^= gmul(p[i], q[j]); } }
-    return r;
-  }
-  function polyEval(p, x) { var y = p[0], i; for (i = 1; i < p.length; i++) { y = gmul(y, x) ^ p[i]; } return y; }
-
-  /* ---------------------------------------------------------- RS encode */
-  var GEN = (function () {
-    var g = [1], i;
-    for (i = 0; i < CFG.rsNsym; i++) { g = polyMul(g, [1, gpow(2, i)]); }  /* fcr = 0 */
-    return g;
-  })();
-  function rsEncode(msg) {
-    /* msg: rsK data symbols -> returns rsN codeword (systematic) */
-    var out = msg.concat(new Array(CFG.rsNsym).fill(0));
-    var i, j;
-    for (i = 0; i < msg.length; i++) {
-      var coef = out[i];
-      if (coef !== 0) {
-        for (j = 1; j < GEN.length; j++) { out[i + j] ^= gmul(GEN[j], coef); }
-      }
-    }
-    var rem = out.slice(msg.length);
-    return msg.concat(rem);
-  }
-
-  /* ---------------------------------------------------------- RS decode */
-  function calcSyndromes(msg, nsym) {
-    var s = [0], i;
-    for (i = 0; i < nsym; i++) { s.push(polyEval(msg, gpow(2, i))); }
-    return s;   /* leading 0, then nsym syndromes */
-  }
-  function forneySyndromes(synd, pos, nmess) {
-    var fsynd = synd.slice(1), i, j;
-    for (i = 0; i < pos.length; i++) {
-      var x = gpow(2, nmess - 1 - pos[i]);
-      for (j = 0; j < fsynd.length - 1; j++) { fsynd[j] = gmul(fsynd[j], x) ^ fsynd[j + 1]; }
-    }
-    return fsynd;
-  }
-  function findErrorLocator(synd, nsym, eraseCount) {
-    var errLoc = [1], oldLoc = [1], i, j;
-    var syndShift = (synd.length > nsym) ? (synd.length - nsym) : 0;
-    for (i = 0; i < nsym - eraseCount; i++) {
-      var K = i + syndShift;
-      var delta = synd[K];
-      for (j = 1; j < errLoc.length; j++) { delta ^= gmul(errLoc[errLoc.length - 1 - j], synd[K - j]); }
-      oldLoc = oldLoc.concat([0]);
-      if (delta !== 0) {
-        if (oldLoc.length > errLoc.length) {
-          var newLoc = polyScale(oldLoc, delta);
-          oldLoc = polyScale(errLoc, ginv(delta));
-          errLoc = newLoc;
-        }
-        errLoc = polyAdd(errLoc, polyScale(oldLoc, delta));
-      }
-    }
-    while (errLoc.length && errLoc[0] === 0) { errLoc.shift(); }
-    var errs = errLoc.length - 1;
-    if ((errs - eraseCount) * 2 + eraseCount > nsym) { return null; }  /* too many */
-    return errLoc;
-  }
-  function findErrors(errLocRev, nmess) {
-    var errs = errLocRev.length - 1, errPos = [], i;
-    for (i = 0; i < nmess; i++) {
-      if (polyEval(errLocRev, gpow(2, i)) === 0) { errPos.push(nmess - 1 - i); }
-    }
-    if (errPos.length !== errs) { return null; }
-    return errPos;
-  }
-  function findErrataLocator(coefPos) {
-    var eLoc = [1], i;
-    for (i = 0; i < coefPos.length; i++) { eLoc = polyMul(eLoc, polyAdd([1], [gpow(2, coefPos[i]), 0])); }
-    return eLoc;
-  }
-  function findErrorEvaluator(synd, errLoc, nsym) {
-    var r = polyMul(synd, errLoc);
-    return r.slice(r.length - (nsym + 1));
-  }
-  function correctErrata(msg, synd, errPos) {
-    var coefPos = errPos.map(function (p) { return msg.length - 1 - p; });
-    var errLoc = findErrataLocator(coefPos);
-    var syndRev = synd.slice().reverse();
-    var errEval = findErrorEvaluator(syndRev, errLoc, errLoc.length - 1).reverse();
-    var X = [], i, j;
-    for (i = 0; i < coefPos.length; i++) { X.push(gpow(2, coefPos[i])); }
-    var E = new Array(msg.length).fill(0);
-    for (i = 0; i < X.length; i++) {
-      var Xi = X[i], XiInv = ginv(Xi);
-      var prime = 1;
-      for (j = 0; j < X.length; j++) { if (j !== i) { prime = gmul(prime, 1 ^ gmul(XiInv, X[j])); } }
-      var y = polyEval(errEval.slice().reverse(), XiInv);
-      y = gmul(gpow(Xi, 1), y);   /* fcr = 0 -> gpow(Xi, 1-fcr) = Xi */
-      if (prime === 0) { return null; }
-      E[errPos[i]] = gdiv(y, prime);
-    }
-    return polyAdd(msg, E);
-  }
-  function rsCorrect(recv, erasePos) {
-    /* recv: rsN symbols; erasePos: indices 0..rsN-1 (<= rsNsym). Returns
-       corrected rsN array, or null if uncorrectable. */
+  /* ----------------------------------------------------- poly + RS over a GF */
+  function makeRS(gf) {
     var nsym = CFG.rsNsym;
-    var msg = recv.slice();
-    var ep = (erasePos || []).slice();
-    if (ep.length > nsym) { return null; }
-    var i;
-    for (i = 0; i < ep.length; i++) { msg[ep[i]] = 0; }
-    var synd = calcSyndromes(msg, nsym);
-    var maxS = 0; for (i = 0; i < synd.length; i++) { if (synd[i] > maxS) { maxS = synd[i]; } }
-    if (maxS === 0) { return msg; }  /* clean (given erasures were zeroed and vanished) */
-    var fsynd = forneySyndromes(synd, ep, msg.length);
-    var errLoc = findErrorLocator(fsynd, nsym, ep.length);
-    if (!errLoc) { return null; }
-    var errPos = findErrors(errLoc.slice().reverse(), msg.length);
-    if (!errPos) { return null; }
-    var corrected = correctErrata(msg, synd, ep.concat(errPos));
-    if (!corrected) { return null; }
-    var chk = calcSyndromes(corrected, nsym);
-    var maxC = 0; for (i = 0; i < chk.length; i++) { if (chk[i] > maxC) { maxC = chk[i]; } }
-    if (maxC > 0) { return null; }
-    return corrected;
+    function scale(p, x) { var r = new Array(p.length), i; for (i = 0; i < p.length; i++) { r[i] = gf.mul(p[i], x); } return r; }
+    function padd(p, q) {
+      var n = Math.max(p.length, q.length), r = new Array(n).fill(0), i;
+      for (i = 0; i < p.length; i++) { r[i + n - p.length] = p[i]; }
+      for (i = 0; i < q.length; i++) { r[i + n - q.length] ^= q[i]; }
+      return r;
+    }
+    function pmul(p, q) {
+      var r = new Array(p.length + q.length - 1).fill(0), i, j;
+      for (j = 0; j < q.length; j++) { for (i = 0; i < p.length; i++) { r[i + j] ^= gf.mul(p[i], q[j]); } }
+      return r;
+    }
+    function peval(p, x) { var y = p[0], i; for (i = 1; i < p.length; i++) { y = gf.mul(y, x) ^ p[i]; } return y; }
+    var GEN = (function () { var g = [1], i; for (i = 0; i < nsym; i++) { g = pmul(g, [1, gf.pow(2, i)]); } return g; })();
+    function encode(msg) {
+      var out = msg.concat(new Array(nsym).fill(0)), i, j;
+      for (i = 0; i < msg.length; i++) { var c = out[i]; if (c !== 0) { for (j = 1; j < GEN.length; j++) { out[i + j] ^= gf.mul(GEN[j], c); } } }
+      return msg.concat(out.slice(msg.length));
+    }
+    function calcSynd(msg) { var s = [0], i; for (i = 0; i < nsym; i++) { s.push(peval(msg, gf.pow(2, i))); } return s; }
+    function forney(synd, pos, nmess) {
+      var f = synd.slice(1), i, j;
+      for (i = 0; i < pos.length; i++) { var x = gf.pow(2, nmess - 1 - pos[i]); for (j = 0; j < f.length - 1; j++) { f[j] = gf.mul(f[j], x) ^ f[j + 1]; } }
+      return f;
+    }
+    function errLocator(synd, eraseCount) {
+      var eL = [1], oL = [1], i, j;
+      var shift = (synd.length > nsym) ? (synd.length - nsym) : 0;
+      for (i = 0; i < nsym - eraseCount; i++) {
+        var Ki = i + shift, delta = synd[Ki];
+        for (j = 1; j < eL.length; j++) { delta ^= gf.mul(eL[eL.length - 1 - j], synd[Ki - j]); }
+        oL = oL.concat([0]);
+        if (delta !== 0) {
+          if (oL.length > eL.length) { var nL = scale(oL, delta); oL = scale(eL, gf.inv(delta)); eL = nL; }
+          eL = padd(eL, scale(oL, delta));
+        }
+      }
+      while (eL.length && eL[0] === 0) { eL.shift(); }
+      var errs = eL.length - 1;
+      if ((errs - eraseCount) * 2 + eraseCount > nsym) { return null; }
+      return eL;
+    }
+    function findErrs(eLrev, nmess) {
+      var errs = eLrev.length - 1, pos = [], i;
+      for (i = 0; i < nmess; i++) { if (peval(eLrev, gf.pow(2, i)) === 0) { pos.push(nmess - 1 - i); } }
+      return (pos.length !== errs) ? null : pos;
+    }
+    function errataLoc(coefPos) { var e = [1], i; for (i = 0; i < coefPos.length; i++) { e = pmul(e, padd([1], [gf.pow(2, coefPos[i]), 0])); } return e; }
+    function errEval(synd, eL) { var r = pmul(synd, eL); return r.slice(r.length - (nsym + 1)); }
+    function correct(recv, erasePos) {
+      var msg = recv.slice(), ep = (erasePos || []).slice(), i;
+      if (ep.length > nsym) { return null; }
+      for (i = 0; i < ep.length; i++) { msg[ep[i]] = 0; }
+      var synd = calcSynd(msg), maxS = 0; for (i = 0; i < synd.length; i++) { if (synd[i] > maxS) { maxS = synd[i]; } }
+      if (maxS === 0) { return msg; }
+      var f = forney(synd, ep, msg.length);
+      var eL = errLocator(f, ep.length); if (!eL) { return null; }
+      var epos = findErrs(eL.slice().reverse(), msg.length); if (!epos) { return null; }
+      var allPos = ep.concat(epos);
+      var coefPos = allPos.map(function (p) { return msg.length - 1 - p; });
+      var eLoc = errataLoc(coefPos);
+      var syndRev = synd.slice().reverse();
+      var ev = errEval(syndRev, eLoc).reverse();
+      var X = [], j; for (i = 0; i < coefPos.length; i++) { X.push(gf.pow(2, coefPos[i])); }
+      var E = new Array(msg.length).fill(0);
+      for (i = 0; i < X.length; i++) {
+        var Xi = X[i], XiInv = gf.inv(Xi), prime = 1;
+        for (j = 0; j < X.length; j++) { if (j !== i) { prime = gf.mul(prime, 1 ^ gf.mul(XiInv, X[j])); } }
+        var y = peval(ev.slice().reverse(), XiInv); y = gf.mul(Xi, y);
+        if (prime === 0) { return null; }
+        E[allPos[i]] = gf.div(y, prime);
+      }
+      var corrected = padd(msg, E);
+      var chk = calcSynd(corrected), maxC = 0; for (i = 0; i < chk.length; i++) { if (chk[i] > maxC) { maxC = chk[i]; } }
+      return (maxC > 0) ? null : corrected;
+    }
+    return { encode: encode, correct: correct };
+  }
+  var RS = {}; (function () { for (var kk in FIELDS) { RS[kk] = makeRS(FIELDS[kk]); } })();
+
+  /* --------------------------------------------------------- combinadic k-of-16 */
+  var CH = (function () { var c = [], i, j; for (i = 0; i <= 16; i++) { c[i] = [1]; for (j = 1; j <= i; j++) { c[i][j] = (c[i - 1][j - 1] || 0) + (c[i - 1][j] || 0); } } return c; })();
+  function choose(n, k) { if (k < 0 || k > n) { return 0; } return CH[n][k]; }
+  function unrankComb(v, n, k) {
+    var res = [], x = 0, r = v, i, c;
+    for (i = 0; i < k; i++) { for (;;) { c = choose(n - 1 - x, k - 1 - i); if (r < c) { res.push(x); x++; break; } r -= c; x++; } }
+    return res;
+  }
+  function rankComb(comb, n, k) {
+    var r = 0, x = 0, i;
+    for (i = 0; i < k; i++) { for (; x < comb[i]; x++) { r += choose(n - 1 - x, k - 1 - i); } x++; }
+    return r;
+  }
+
+  /* --------------------------------------------------- bit pack bytes<->m-sym */
+  function packBits(bytes, m) {
+    var out = [], acc = 0, nb = 0, i, mask = (1 << m) - 1;
+    for (i = 0; i < bytes.length; i++) {
+      acc = ((acc << 8) | bytes[i]); nb += 8;
+      while (nb >= m) { nb -= m; out.push((acc >>> nb) & mask); }
+      acc &= (nb > 0 ? ((1 << nb) - 1) : 0);
+    }
+    if (nb > 0) { out.push((acc & ((1 << nb) - 1)) << (m - nb)); }
+    return out;
+  }
+  function unpackBits(syms, m, nbytes) {
+    var out = [], acc = 0, nb = 0, i;
+    for (i = 0; i < syms.length && out.length < nbytes; i++) {
+      acc = ((acc << m) | syms[i]); nb += m;
+      while (nb >= 8 && out.length < nbytes) { nb -= 8; out.push((acc >>> nb) & 0xFF); }
+      acc &= (nb > 0 ? ((1 << nb) - 1) : 0);
+    }
+    return out;
   }
 
   /* ------------------------------------------------------------- CRC-16 */
@@ -335,65 +336,79 @@
     return crc;
   }
 
-  /* -------------------------------------------------- bytes -> symbols */
-  function nibblesOfBytes(bytes) {
-    var out = [], i;
-    for (i = 0; i < bytes.length; i++) { out.push((bytes[i] >> 4) & 0xF, bytes[i] & 0xF); }
-    return out;
+  /* -------------------- header (always k=1 / GF16): version, mode, length -- */
+  function headerNibbles(k, len) {
+    return [CFG.version, k & 0xF, (len >> 12) & 0xF, (len >> 8) & 0xF, (len >> 4) & 0xF, len & 0xF];
   }
-  function chunkEncode(nibs) {
-    /* pad to multiple of rsK, RS-encode each block, concat 15-symbol codewords */
-    var out = [], i, j;
-    var padded = nibs.slice();
+  function rsEncodeBlockGF16(dataSyms) {   /* pad to rsK, RS(15,11) over GF16 */
+    var padded = dataSyms.slice();
     while (padded.length % CFG.rsK !== 0) { padded.push(0); }
-    for (i = 0; i < padded.length; i += CFG.rsK) {
-      var block = padded.slice(i, i + CFG.rsK);
-      var cw = rsEncode(block);
-      for (j = 0; j < cw.length; j++) { out.push(cw[j]); }
-    }
+    var out = [], i, j;
+    for (i = 0; i < padded.length; i += CFG.rsK) { var cw = RS[1].encode(padded.slice(i, i + CFG.rsK)); for (j = 0; j < cw.length; j++) { out.push(cw[j]); } }
     return out;
   }
-  function headerNibbles(len) {
-    return [CFG.version, (len >> 12) & 0xF, (len >> 8) & 0xF, (len >> 4) & 0xF, len & 0xF];
+
+  /* mode-aware frame sizing */
+  function payloadSymCount(len, k) {
+    var m = MODES[k].bits, bits = (len + 2) * 8;   /* payload + 2 CRC bytes */
+    return Math.ceil(bits / m);
   }
   function payloadBlockCount(len) {
-    var dataNibs = 2 * len + 4;   /* payload nibbles + 4 CRC nibbles */
-    return Math.ceil(dataNibs / CFG.rsK);
+    return Math.ceil(payloadSymCount(len, CFG.chordK) / CFG.rsK);
   }
-  function frameSymbolCount(len) {
-    return CFG.sync.length + CFG.rsN + payloadBlockCount(len) * CFG.rsN;
+  function payloadBlockCountK(len, k) {
+    return Math.ceil(payloadSymCount(len, k) / CFG.rsK);
   }
+  function frameSymbolCountK(len, k) {
+    return CFG.sync.length + CFG.rsN + payloadBlockCountK(len, k) * CFG.rsN;
+  }
+  function frameSymbolCount(len) { return frameSymbolCountK(len, CFG.chordK); }
   function estimateSeconds(len) {
     return CFG.pilotSec + CFG.gapSec + frameSymbolCount(len) * CFG.symbolSec + CFG.tailSec;
   }
-  function bytesToSymbols(bytes) {
-    if (bytes.length < 1 || bytes.length > CFG.maxPayload) {
-      throw new Error("payload must be 1.." + CFG.maxPayload + " bytes");
-    }
-    var syms = CFG.sync.slice();
-    /* header block: version + 16-bit length, RS(15,11) */
-    syms = syms.concat(chunkEncode(headerNibbles(bytes.length)));
-    /* payload blocks: payload nibbles + CRC-16 nibbles, RS(15,11) */
+
+  /* -------------------- build the transmit chord sequence (tones per symbol) */
+  function bytesToChords(bytes, k) {
+    if (bytes.length < 1 || bytes.length > CFG.maxPayload) { throw new Error("payload must be 1.." + CFG.maxPayload + " bytes"); }
+    var m = MODES[k].bits, maxSym = 1 << m;
+    var chords = [], i, j;
+    /* sync: single tones */
+    for (i = 0; i < CFG.sync.length; i++) { chords.push([CFG.sync[i]]); }
+    /* header block: GF16 single tones */
+    var hdr = rsEncodeBlockGF16(headerNibbles(k, bytes.length));
+    for (i = 0; i < hdr.length; i++) { chords.push([hdr[i]]); }
+    /* payload: bytes + CRC -> m-bit symbols -> RS(15,11) over GF(2^m) -> chords */
     var c = crc16(bytes);
-    var pnibs = nibblesOfBytes(bytes).concat([(c >> 12) & 0xF, (c >> 8) & 0xF, (c >> 4) & 0xF, c & 0xF]);
-    syms = syms.concat(chunkEncode(pnibs));
-    return syms;
+    var dataBytes = Array.prototype.slice.call(bytes).concat([(c >> 8) & 0xFF, c & 0xFF]);
+    var syms = packBits(dataBytes, m);
+    while (syms.length % CFG.rsK !== 0) { syms.push(0); }
+    var coded = [];
+    for (i = 0; i < syms.length; i += CFG.rsK) { var cw = RS[k].encode(syms.slice(i, i + CFG.rsK)); for (j = 0; j < cw.length; j++) { coded.push(cw[j]); } }
+    for (i = 0; i < coded.length; i++) {
+      var v = coded[i] % maxSym;                 /* guard (encoder never exceeds) */
+      chords.push(unrankComb(v, CFG.toneCount, k));
+    }
+    return chords;
+  }
+  /* k=1 flat-symbol helper kept for the invariant suite */
+  function bytesToSymbols(bytes) {
+    return bytesToChords(bytes, 1).map(function (ch) { return ch[0]; });
   }
 
-  /* ------------------------------------------------- symbols -> PCM */
-  function synthesize(symbols, sampleRate) {
+  /* ------------------------------------------------- chords -> PCM */
+  function toneFreq(t) { return CFG.f0 + t * CFG.df; }
+  function synthesize(chords, sampleRate) {
     var sr = sampleRate;
     var symF = CFG.symbolSec * sr;
     var pilotN = Math.round(CFG.pilotSec * sr);
     var gapN = Math.round(CFG.gapSec * sr);
     var tailN = Math.round(CFG.tailSec * sr);
-    var dataN = Math.round(symbols.length * symF);
+    var dataN = Math.round(chords.length * symF);
     var total = pilotN + gapN + dataN + tailN;
     var pcm = new Float32Array(total);
     var twoPi = Math.PI * 2;
-    var phase = 0;
     var rampN = Math.max(1, Math.round(CFG.rampSec * sr));
-    var i, n;
+    var i, n, j, phase = 0;
 
     var pf = twoPi * CFG.pilotFreq / sr;
     for (n = 0; n < pilotN; n++) {
@@ -405,24 +420,23 @@
     }
 
     var base = pilotN + gapN;
-    for (i = 0; i < symbols.length; i++) {
-      var freq = CFG.f0 + symbols[i] * CFG.df;
-      var inc = twoPi * freq / sr;
-      var s0 = Math.round(i * symF);
-      var s1 = Math.round((i + 1) * symF);
-      var segN = s1 - s0;
-      for (n = 0; n < segN; n++) {
-        var e = 1.0;
-        if (n < rampN) { e = 0.5 - 0.5 * Math.cos(Math.PI * n / rampN); }
-        if (segN - n <= rampN) { e = Math.min(e, 0.5 - 0.5 * Math.cos(Math.PI * (segN - n) / rampN)); }
-        pcm[base + s0 + n] = CFG.amplitude * e * Math.sin(phase);
-        phase += inc;
-        if (phase > twoPi) { phase -= twoPi; }
+    for (i = 0; i < chords.length; i++) {
+      var tones = chords[i], perTone = CFG.amplitude / tones.length;
+      var s0 = Math.round(i * symF), s1 = Math.round((i + 1) * symF), segN = s1 - s0;
+      for (j = 0; j < tones.length; j++) {
+        var inc = twoPi * toneFreq(tones[j]) / sr, ph = 0;
+        for (n = 0; n < segN; n++) {
+          var e = 1.0;
+          if (n < rampN) { e = 0.5 - 0.5 * Math.cos(Math.PI * n / rampN); }
+          if (segN - n <= rampN) { e = Math.min(e, 0.5 - 0.5 * Math.cos(Math.PI * (segN - n) / rampN)); }
+          pcm[base + s0 + n] += perTone * e * Math.sin(ph);
+          ph += inc;
+        }
       }
     }
     return pcm;
   }
-  function encodeToPcm(bytes, sampleRate) { return synthesize(bytesToSymbols(bytes), sampleRate); }
+  function encodeToPcm(bytes, sampleRate) { return synthesize(bytesToChords(bytes, CFG.chordK), sampleRate); }
 
   /* ---------------------------------------------------------- Goertzel */
   function goertzelPower(buf, len, freq, sr) {
@@ -445,7 +459,7 @@
     var minStart = Math.max(0, opts.minStart | 0);
     var K = CFG.toneCount;
     var freqs = new Float64Array(K), k;
-    for (k = 0; k < K; k++) { freqs[k] = CFG.f0 + k * CFG.df; }
+    for (k = 0; k < K; k++) { freqs[k] = toneFreq(k); }
     var hann = makeHann(anaN);
     var scratch = new Float32Array(anaN);
     var energies = new Float64Array(K);
@@ -458,6 +472,7 @@
       return energies;
     }
     function argmax(arr) { var bi = 0, bv = -Infinity, j; for (j = 0; j < arr.length; j++) { if (arr[j] > bv) { bv = arr[j]; bi = j; } } return bi; }
+    /* k=1 soft symbol (top1/top2) — used for sync + header */
     function softAt(startSample, index) {
       var center = startSample + Math.round((index + 0.5) * symF);
       var e = toneEnergiesAt(center);
@@ -470,7 +485,23 @@
       var ratio = (v2 > 0) ? (v1 / v2) : Infinity;
       return { tone: b1, ratio: ratio };
     }
-    function readBlock(startSample, idx) {
+    /* top-k chord symbol over GF(2^bits) — used for payload */
+    function chordAt(startSample, index, kk) {
+      var center = startSample + Math.round((index + 0.5) * symF);
+      var e = toneEnergiesAt(center);
+      if (!e) { return null; }
+      var idx = [], j; for (j = 0; j < K; j++) { idx.push(j); }
+      idx.sort(function (a, b) { return e[b] - e[a]; });
+      var comb = idx.slice(0, kk).sort(function (a, b) { return a - b; });
+      var v = rankComb(comb, K, kk);
+      var maxSym = 1 << MODES[kk].bits;
+      var kth = e[idx[kk - 1]], kp1 = e[idx[kk]];
+      var ratio = (kp1 > 0) ? (kth / kp1) : Infinity;
+      var erased = (v >= maxSym) || (ratio < CFG.eraseRatio);
+      return { sym: (v >= maxSym) ? 0 : v, tones: comb, ratio: ratio, erased: erased };
+    }
+    /* header: 15 GF16 single-tone symbols */
+    function readHeaderBlock(startSample, idx) {
       var syms = new Array(CFG.rsN), cand = [], j;
       for (j = 0; j < CFG.rsN; j++) {
         var s = softAt(startSample, idx + j);
@@ -480,8 +511,24 @@
       }
       cand.sort(function (a, b) { return a.ratio - b.ratio; });
       var erase = cand.slice(0, CFG.rsNsym).map(function (c) { return c.pos; });
-      var corr = rsCorrect(syms, erase);
-      if (!corr) { corr = rsCorrect(syms, []); }
+      var corr = RS[1].correct(syms, erase);
+      if (!corr) { corr = RS[1].correct(syms, []); }
+      if (!corr) { return null; }
+      return corr.slice(0, CFG.rsK);
+    }
+    /* payload: 15 GF(2^bits) chord symbols in mode kk */
+    function readPayloadBlock(startSample, idx, kk) {
+      var syms = new Array(CFG.rsN), cand = [], j;
+      for (j = 0; j < CFG.rsN; j++) {
+        var s = chordAt(startSample, idx + j, kk);
+        if (!s) { return null; }
+        syms[j] = s.sym;
+        if (s.erased) { cand.push({ pos: j, ratio: s.ratio }); }
+      }
+      cand.sort(function (a, b) { return a.ratio - b.ratio; });
+      var erase = cand.slice(0, CFG.rsNsym).map(function (c) { return c.pos; });
+      var corr = RS[kk].correct(syms, erase);
+      if (!corr) { corr = RS[kk].correct(syms, []); }
       if (!corr) { return null; }
       return corr.slice(0, CFG.rsK);
     }
@@ -547,7 +594,11 @@
       return out;
     }
 
-    return { symF: symF, softAt: softAt, readBlock: readBlock, acquire: acquire, symbolPresent: symbolPresent };
+    return {
+      symF: symF, softAt: softAt, chordAt: chordAt,
+      readHeaderBlock: readHeaderBlock, readPayloadBlock: readPayloadBlock,
+      acquire: acquire, symbolPresent: symbolPresent
+    };
   }
 
   /* --------- utf-8 helper (partial-safe for the live view) --------- */
@@ -556,21 +607,28 @@
     if (_dec) { try { return _dec.decode(bytes); } catch (e) { return ""; } }
     var s = "", i; for (i = 0; i < bytes.length; i++) { s += String.fromCharCode(bytes[i]); } return s;
   }
-  function rawSymbols(ctx, s0, uptoIndex) {
-    var out = [], idx, hdrIdx = CFG.sync.length;
-    for (idx = hdrIdx; idx < uptoIndex; idx++) {
-      var s = ctx.softAt(s0, idx);
-      if (!s) { break; }
-      var rel = idx - hdrIdx;
-      var inBlock = rel % CFG.rsN;
-      var kind = (rel < CFG.rsN) ? "header" : (inBlock < CFG.rsK ? "data" : "parity");
-      out.push({ tone: s.tone, erased: s.ratio < CFG.eraseRatio, kind: kind });
-    }
-    return out;
+
+  /* parse a header block -> {k, len} or null */
+  function parseHeader(hdr) {
+    if (!hdr || hdr[0] !== CFG.version) { return null; }
+    var k = hdr[1];
+    if (!MODES[k]) { return null; }
+    var len = (hdr[2] << 12) | (hdr[3] << 8) | (hdr[4] << 4) | hdr[5];
+    if (len < 1 || len > CFG.maxPayload) { return null; }
+    return { k: k, len: len };
+  }
+  /* coded payload symbols -> payload bytes (or null on CRC fail) */
+  function payloadToBytes(dataSyms, k, len) {
+    var m = MODES[k].bits;
+    var bytesOut = unpackBits(dataSyms, m, len + 2);
+    if (bytesOut.length < len + 2) { return null; }
+    var payload = bytesOut.slice(0, len);
+    var rxCrc = (bytesOut[len] << 8) | bytesOut[len + 1];
+    if (rxCrc !== crc16(payload)) { return null; }
+    return new Uint8Array(payload);
   }
 
   /* ------------------------------------------------------------ decode */
-  /* Returns { ok, bytes, startSample, endSample, syncScore, reason } */
   function decodeFromPcm(pcm, sampleRate, opts) {
     var ctx = mkCtx(pcm, sampleRate, opts);
     var picks = ctx.acquire();
@@ -579,38 +637,29 @@
     var sawCrc = false, crcStart = -1, crcScore = 0;
     for (i = 0; i < picks.length; i++) {
       var s0 = picks[i].s0;
-      var hdr = ctx.readBlock(s0, S.length);
-      if (!hdr || hdr[0] !== CFG.version) { continue; }
-      var len = (hdr[1] << 12) | (hdr[2] << 8) | (hdr[3] << 4) | hdr[4];
-      if (len < 1 || len > CFG.maxPayload) { continue; }
-      var nb = payloadBlockCount(len);
-      var totalSyms = frameSymbolCount(len);
+      var hdr = ctx.readHeaderBlock(s0, S.length);
+      var ph = parseHeader(hdr);
+      if (!ph) { continue; }
+      var k = ph.k, len = ph.len;
+      var nb = payloadBlockCountK(len, k);
+      var totalSyms = frameSymbolCountK(len, k);
       if (!ctx.symbolPresent(s0, totalSyms - 1)) { continue; }
-      var nibs = [], bad = false, bIdx = S.length + CFG.rsN, blk;
+      var dataSyms = [], bad = false, bIdx = S.length + CFG.rsN, blk;
       for (blk = 0; blk < nb; blk++) {
-        var data = ctx.readBlock(s0, bIdx + blk * CFG.rsN);
+        var data = ctx.readPayloadBlock(s0, bIdx + blk * CFG.rsN, k);
         if (!data) { bad = true; break; }
-        nibs = nibs.concat(data);
+        dataSyms = dataSyms.concat(data);
       }
       if (bad) { continue; }
-      var need = 2 * len + 4;
-      if (nibs.length < need) { continue; }
-      var bytes = new Uint8Array(len), b2;
-      for (b2 = 0; b2 < len; b2++) { bytes[b2] = (nibs[2 * b2] << 4) | nibs[2 * b2 + 1]; }
-      var rxCrc = (nibs[2 * len] << 12) | (nibs[2 * len + 1] << 8) | (nibs[2 * len + 2] << 4) | nibs[2 * len + 3];
-      if (rxCrc !== crc16(bytes)) {
-        if (!sawCrc) { sawCrc = true; crcStart = s0; crcScore = picks[i].score; }
-        continue;
-      }
-      return { ok: true, bytes: bytes, startSample: s0, endSample: s0 + Math.round(totalSyms * ctx.symF), syncScore: picks[i].score, reason: "ok" };
+      var bytes = payloadToBytes(dataSyms, k, len);
+      if (!bytes) { if (!sawCrc) { sawCrc = true; crcStart = s0; crcScore = picks[i].score; } continue; }
+      return { ok: true, bytes: bytes, chordK: k, startSample: s0, endSample: s0 + Math.round(totalSyms * ctx.symF), syncScore: picks[i].score, reason: "ok" };
     }
     if (sawCrc) { return { ok: false, reason: "crc", startSample: crcStart, syncScore: crcScore }; }
     return { ok: false, reason: "noframe" };
   }
 
   /* ------------------------------- streaming progress (live view only) */
-  /* Cosmetic partial decode for the reveal; authoritative result is still
-     decodeFromPcm. state: nosync|locked|receiving|complete. */
   function decodeProgress(pcm, sampleRate, opts) {
     var ctx = mkCtx(pcm, sampleRate, opts);
     var picks = ctx.acquire();
@@ -623,36 +672,43 @@
         if (i === picks.length - 1) { return { state: "locked", startSample: s0, syncScore: picks[i].score, symbols: [], nibbles: [], text: "", blocksDone: 0, blocks: 0 }; }
         continue;
       }
-      var hdr = ctx.readBlock(s0, hdrIdx);
-      if (!hdr || hdr[0] !== CFG.version) { continue; }
-      var len = (hdr[1] << 12) | (hdr[2] << 8) | (hdr[3] << 4) | hdr[4];
-      if (len < 1 || len > CFG.maxPayload) { continue; }
-      var nb = payloadBlockCount(len), nibs = [], blocksDone = 0, blk;
+      var hdr = ctx.readHeaderBlock(s0, hdrIdx);
+      var ph = parseHeader(hdr);
+      if (!ph) { continue; }
+      var k = ph.k, len = ph.len, m = MODES[k].bits;
+      var nb = payloadBlockCountK(len, k), dataSyms = [], blocksDone = 0, blk;
+      var symbols = [];
       for (blk = 0; blk < nb; blk++) {
         var bi = payIdx + blk * CFG.rsN;
         if (!ctx.symbolPresent(s0, bi + CFG.rsN - 1)) { break; }
-        var data = ctx.readBlock(s0, bi);
+        var jj;
+        for (jj = 0; jj < CFG.rsN; jj++) {
+          var cs = ctx.chordAt(s0, bi + jj, k);
+          if (!cs) { break; }
+          var relInBlk = jj;
+          symbols.push({ sym: cs.sym, tones: cs.tones, erased: cs.erased, kind: (relInBlk < CFG.rsK ? "data" : "parity") });
+        }
+        var data = ctx.readPayloadBlock(s0, bi, k);
         if (!data) { break; }
-        nibs = nibs.concat(data); blocksDone++;
+        dataSyms = dataSyms.concat(data); blocksDone++;
       }
-      var totalSyms = frameSymbolCount(len), lastPresent = hdrIdx;
-      while (lastPresent < totalSyms && ctx.symbolPresent(s0, lastPresent)) { lastPresent++; }
-      var syms = rawSymbols(ctx, s0, lastPresent);
-      var payNibs = nibs.slice(0, 2 * len), nbytes = payNibs.length >> 1, b2;
-      var pbytes = new Uint8Array(nbytes);
-      for (b2 = 0; b2 < nbytes; b2++) { pbytes[b2] = (payNibs[2 * b2] << 4) | payNibs[2 * b2 + 1]; }
-      var text = utf8Partial(pbytes);
-      var verified = false, outBytes = null;
-      if (blocksDone >= nb && nibs.length >= 2 * len + 4) {
-        var full = new Uint8Array(len), c2;
-        for (c2 = 0; c2 < len; c2++) { full[c2] = (nibs[2 * c2] << 4) | nibs[2 * c2 + 1]; }
-        var rxCrc = (nibs[2 * len] << 12) | (nibs[2 * len + 1] << 8) | (nibs[2 * len + 2] << 4) | nibs[2 * len + 3];
-        if (rxCrc === crc16(full)) { verified = true; outBytes = full; text = utf8Partial(full); }
+      var text = "", verified = false, outBytes = null;
+      if (blocksDone > 0) {
+        var partial = unpackBits(dataSyms, m, len + 2);
+        var pbytes = new Uint8Array(Math.min(len, Math.max(0, partial.length - 0)).valueOf());
+        var nb2 = Math.min(len, partial.length); var b2;
+        pbytes = new Uint8Array(nb2);
+        for (b2 = 0; b2 < nb2; b2++) { pbytes[b2] = partial[b2]; }
+        text = utf8Partial(pbytes);
+      }
+      if (blocksDone >= nb) {
+        var full = payloadToBytes(dataSyms, k, len);
+        if (full) { verified = true; outBytes = full; text = utf8Partial(full); }
       }
       return {
         state: (blocksDone >= nb) ? "complete" : "receiving",
-        startSample: s0, syncScore: picks[i].score, version: hdr[0], length: len,
-        blocks: nb, blocksDone: blocksDone, symbols: syms, nibbles: nibs,
+        startSample: s0, syncScore: picks[i].score, version: hdr[0], chordK: k, length: len,
+        blocks: nb, blocksDone: blocksDone, symbols: symbols, nibbles: dataSyms,
         text: text, verified: verified, bytes: outBytes
       };
     }
@@ -660,9 +716,10 @@
   }
 
   return {
-    CFG: CFG,
+    CFG: CFG, MODES: MODES,
     crc16: crc16,
     bytesToSymbols: bytesToSymbols,
+    bytesToChords: bytesToChords,
     encodeToPcm: encodeToPcm,
     decodeFromPcm: decodeFromPcm,
     decodeProgress: decodeProgress,
@@ -671,10 +728,10 @@
     payloadBlockCount: payloadBlockCount,
     goertzelPower: goertzelPower,
     makeHann: makeHann,
-    /* exposed for the invariant suite */
-    rsEncode: rsEncode,
-    rsCorrect: rsCorrect,
-    _gf: { gmul: gmul, gdiv: gdiv, ginv: ginv, gpow: gpow }
+    /* exposed for the invariant suite (GF16 / k=1) */
+    rsEncode: function (m) { return RS[1].encode(m); },
+    rsCorrect: function (r, e) { return RS[1].correct(r, e); },
+    _gf: { gmul: FIELDS[1].mul, gdiv: FIELDS[1].div, ginv: FIELDS[1].inv, gpow: FIELDS[1].pow }
   };
 });
 
@@ -711,21 +768,27 @@
   var sendText = $("sendText");
   var sendInfo = $("sendInfo");
   var sendStatus = $("sendStatus");
+  var chordMode = $("chordMode");
   var enc = new TextEncoder();
   var dec = new TextDecoder("utf-8");
 
   function updateEstimate() {
     try {
+      var k = parseInt(chordMode.value, 10) || 1;
+      M.CFG.chordK = k;
+      var bits = M.MODES[k].bits, mult = (bits / 4).toFixed(bits % 4 ? 2 : 0);
       var n = enc.encode(sendText.value).length;
-      if (n < 1) { sendInfo.textContent = "empty"; return; }
+      if (n < 1) { sendInfo.textContent = "empty \u00B7 " + bits + " bits/sym (" + mult + "\u00D7)"; return; }
       if (n > M.CFG.maxPayload) {
         sendInfo.textContent = n + " bytes \u2014 over the " + M.CFG.maxPayload + " byte cap";
         return;
       }
-      sendInfo.textContent = n + " bytes \u00B7 ~" + M.estimateSeconds(n).toFixed(1) + " s of air time";
+      sendInfo.textContent = n + " bytes \u00B7 ~" + M.estimateSeconds(n).toFixed(1) +
+        " s \u00B7 " + bits + " bits/sym (" + mult + "\u00D7)";
     } catch (e) { console.error("[link] estimate failed:", e); }
   }
   sendText.addEventListener("input", updateEstimate);
+  chordMode.addEventListener("change", updateEstimate);
 
   sendBtn.addEventListener("click", async function () {
     try {
@@ -937,17 +1000,22 @@
     if (p.state === "locked") { setChip("locked", "locked \u00B7 reading header"); return; }
     if (frameId !== liveFrameId || liveLen !== p.length) { liveFrameId = frameId; buildGrid(p.length); }
 
-    /* raw hex from payload data symbols (pre-correction) */
-    var rawNibs = [], s;
-    for (s = 0; s < p.symbols.length; s++) { if (p.symbols[s].kind === "data") { rawNibs.push(p.symbols[s]); } }
-    var rawBytes = Math.min(liveLen, rawNibs.length >> 1), i;
-    for (i = liveRawShown; i < rawBytes; i++) {
-      var c = liveCells[i]; if (!c || c.classList.contains("done")) { continue; }
-      var er = rawNibs[2 * i].erased || rawNibs[2 * i + 1].erased;
-      c.className = "cell raw" + (er ? " erased" : "");
-      c.textContent = hex1(rawNibs[2 * i].tone) + hex1(rawNibs[2 * i + 1].tone);
+    /* raw hex from payload data symbols (pre-correction). One data symbol is one
+       byte-nibble only in k=1/GF(16); chord modes pack m>4 bits per symbol with
+       no clean per-byte tile, so the raw reveal is k=1-only. Chord modes fill
+       cells from the corrected text as each RS block lands. */
+    if (p.chordK === 1) {
+      var rawNibs = [], s;
+      for (s = 0; s < p.symbols.length; s++) { if (p.symbols[s].kind === "data") { rawNibs.push(p.symbols[s]); } }
+      var rawBytes = Math.min(liveLen, rawNibs.length >> 1), i;
+      for (i = liveRawShown; i < rawBytes; i++) {
+        var c = liveCells[i]; if (!c || c.classList.contains("done")) { continue; }
+        var er = rawNibs[2 * i].erased || rawNibs[2 * i + 1].erased;
+        c.className = "cell raw" + (er ? " erased" : "");
+        c.textContent = hex1(rawNibs[2 * i].sym) + hex1(rawNibs[2 * i + 1].sym);
+      }
+      liveRawShown = Math.max(liveRawShown, rawBytes);
     }
-    liveRawShown = Math.max(liveRawShown, rawBytes);
 
     /* interpreted chars replace hex as blocks correct */
     var interp = Math.min(liveLen, p.text.length), j;
@@ -1104,28 +1172,34 @@
     setStatus(testStatus, "running\u2026", "busy");
     setTimeout(function () {
       try {
-        var msg = "Self-test " + new Date().toISOString() + " \u2014 in-memory loopback, 15 dB SNR.";
-        var bytes = enc.encode(msg);
-        var sr = 48000;
-        var pcm = M.encodeToPcm(bytes, sr);
-        var padded = new Float32Array(Math.round(sr * 0.5) + pcm.length + Math.round(sr * 0.3));
-        padded.set(pcm, Math.round(sr * 0.5));
-        var rms = 0, na = 0;
-        for (var i = 0; i < padded.length; i++) {
-          if (Math.abs(padded[i]) > 0.01) { rms += padded[i] * padded[i]; na++; }
+        var sr = 48000, modes = [1, 2, 4, 8], saveK = M.CFG.chordK;
+        var results = [], allOk = true, lastPadded = null, lastSr = sr, totMs = 0;
+        for (var mi = 0; mi < modes.length; mi++) {
+          var k = modes[mi];
+          M.CFG.chordK = k;
+          var msg = "Self-test k=" + k + " " + new Date().toISOString() + " \u2014 in-memory loopback, 15 dB SNR.";
+          var bytes = enc.encode(msg);
+          var pcm = M.encodeToPcm(bytes, sr);
+          var padded = new Float32Array(Math.round(sr * 0.5) + pcm.length + Math.round(sr * 0.3));
+          padded.set(pcm, Math.round(sr * 0.5));
+          var rms = 0, na = 0, i;
+          for (i = 0; i < padded.length; i++) { if (Math.abs(padded[i]) > 0.01) { rms += padded[i] * padded[i]; na++; } }
+          rms = Math.sqrt(rms / Math.max(1, na));
+          var sigma = rms / Math.pow(10, 15 / 20), j;
+          for (j = 0; j < padded.length; j++) { padded[j] += sigma * gaussPair(); }
+          var t0 = performance.now();
+          var res = M.decodeFromPcm(padded, sr);
+          var ms = performance.now() - t0; totMs += ms;
+          var ok = res.ok && res.chordK === k && dec.decode(res.bytes) === msg;
+          results.push("k=" + k + ":" + (ok ? "\u2713" : "\u2717"));
+          if (!ok) { allOk = false; }
+          lastPadded = padded; lastSr = sr;
+          console.log("[link] self-test k=" + k + ":", ok ? "PASS" : "FAIL", "(" + ms.toFixed(0) + " ms)", res.reason);
         }
-        rms = Math.sqrt(rms / Math.max(1, na));
-        var sigma = rms / Math.pow(10, 15 / 20);
-        for (var j = 0; j < padded.length; j++) { padded[j] += sigma * gaussPair(); }
-        var t0 = performance.now();
-        var res = M.decodeFromPcm(padded, sr);
-        var ms = (performance.now() - t0).toFixed(0);
-        streamPreview(padded, sr);
-        var ok = res.ok && dec.decode(res.bytes) === msg;
-        console.log("[link] self-test:", ok ? "PASS" : "FAIL", "(" + ms + " ms)", res.reason);
-        setStatus(testStatus, ok
-          ? "PASS \u2014 " + bytes.length + " bytes through synthetic noise in " + ms + " ms"
-          : "FAIL \u2014 " + res.reason, ok ? "ok" : "bad");
+        M.CFG.chordK = saveK;
+        if (lastPadded) { streamPreview(lastPadded, lastSr); }
+        setStatus(testStatus, (allOk ? "PASS" : "FAIL") + " \u2014 all chord modes [" + results.join("  ") +
+          "] through synthetic noise in " + totMs.toFixed(0) + " ms", allOk ? "ok" : "bad");
       } catch (e) {
         console.error("[link] self-test failed:", e);
         setStatus(testStatus, "FAIL \u2014 " + e.message, "bad");
@@ -1137,7 +1211,7 @@
   updateEstimate();
   console.log("[link] ready. band " + M.CFG.f0 + "\u2013" +
     (M.CFG.f0 + (M.CFG.toneCount - 1) * M.CFG.df) + " Hz, " +
-    (1 / M.CFG.symbolSec).toFixed(1) + " sym/s, 4 bits/symbol.");
+    (1 / M.CFG.symbolSec).toFixed(1) + " sym/s, chord modes k=1/2/4/8 = 4/6/10/13 bits/symbol.");
 })();
 </script>
 </body>


### PR DESCRIPTION
## Selectable chord density: 2, 4, 8 tones per symbol

Adds a **chord-density selector** (k = 1 / 2 / 4 / 8 tones lit per payload symbol) to the Send card. Higher k packs more bits per symbol for faster transfer, at the cost of per-tone power (robustness).

### Design — matched code preserved
The modem's core strength is that one tone = one GF(16) symbol = one RS symbol, so a misdetected tone is exactly one correctable error. Chords keep this by **scaling the field with the chord**: a constant-weight k-of-16 chord is one symbol in GF(2^m).

| mode | tones (k) | field | bits/sym | throughput | 100 B airtime |
|------|-----------|-------|----------|-----------|---------------|
| 1 | 1 | GF(16) | 4 | 1.0× | 6.93 s |
| 2 | 2 | GF(64) | 6 | 1.5× | 5.01 s |
| 4 | 4 | GF(1024) | 10 | 2.5× | 3.41 s |
| 8 | 8 | GF(8192) | 13 | 3.25× | 2.77 s |

- **RS(15,11) is unchanged** — same 15-symbol blocks, t=2 (or 4 erasures) per block, just over a bigger field. Block cadence and the streaming decoder are identical.
- **Chord space is truncated to 2^m** (64 of 120, 1024 of 1820, 8192 of 12870) so the field is clean binary. Detection stays calibration-free: pick the **top-k** bins by energy (argmax generalized), no absolute threshold. A chord that ranks outside the used 2^m, or an ambiguous k-th/(k+1)-th boundary, is flagged as an erasure.
- **Sync + header are always single-tone / GF(16)**, so acquisition is mode-independent and the header carries the mode (frame version bumped 2→3) — the receiver **auto-detects** k.
- Per-tone amplitude is split **1/k** to guarantee no clipping, so denser chords are quieter — the honest power-split trade.

### Verification (headless, Node)
Built and brute-force-verified standalone before integration, then re-verified the spliced module:
- all four GF fields primitive; GF mul/inv sanity;
- combinadic chord↔symbol bijection **exhaustive** per k;
- bit-pack round-trip;
- **RS errors+erasures 2000/2000 per field** (within 2e+s≤4);
- full acoustic round-trip (chord synth → Goertzel top-k → RS → CRC) clean **and at 15 dB AWGN**, 20–40/40 per mode;
- integrated-module encode→decode **25/25 per mode**, correct auto-detected k, and no false-accept under heavy payload corruption (CRC gate holds).

The in-page self-test now loops all four modes.

### Flags for on-device validation (cannot be tested headless)
- **k=8 is quiet** (each tone at 1/8 amplitude). On a phone speaker in a room this is the SNR-limited case; expect shorter range than k=1. A PAPR-aware scheme (phase-staggered tones at ~1/√k with a soft-clip guard) is a deferred optimization — v1 uses the safe 1/k.
- The **live hex-reveal tile view is k=1-only** (a data symbol maps to a byte-nibble only in GF(16)); chord modes fill cells from corrected text as each RS block lands. Authoritative decode works for all modes.

Single self-contained `modem.html`; no dependencies.
