### PR TITLE
Currents in Motion: diagnose sticky iOS motion denial on screen, retry on click

### DIFF
--- a/fun-and-games/currents-motion.html
+++ b/fun-and-games/currents-motion.html
@@ -393,19 +393,33 @@
      gesture task -- no await before it -- or Safari silently denies.
      Orientation and motion are requested independently: a rejection of
      one must not cost us the other (Promise.all would). */
+  var permInFlight = false;
   function requestSensorPermission() {
+    if (permInFlight) return;
+    permInFlight = true;
+    var t0 = performance.now();
+    function deniedMsg() {
+      /* an instant settle means iOS never showed the prompt: it is replaying
+         a remembered "don't allow" for this site. Only a fresh tab clears
+         that -- there is no motion entry under aA -> website settings. */
+      var ms = Math.round(performance.now() - t0);
+      console.warn("[motion] orientation permission denied after", ms, "ms",
+                   ms < 400 ? "(instant -- remembered denial, no prompt shown)" : "(user declined)");
+      say(ms < 400
+        ? "ios is replaying an earlier &ldquo;don&rsquo;t allow&rdquo; &middot; close this tab, reopen the page, and allow motion"
+        : "motion access declined &middot; tap to be asked again");
+    }
     DeviceOrientationEvent.requestPermission().then(function (state) {
+      permInFlight = false;
       console.log("[motion] orientation permission:", state);
       permState = state;
-      if (state === "granted") {
-        startSensors();
-      } else {
-        say("motion access denied &middot; tap to retry &middot; if no prompt appears, reset it under aA &rarr; website settings");
-      }
+      if (state === "granted") startSensors();
+      else deniedMsg();
     }).catch(function (err) {
+      permInFlight = false;
       console.warn("[motion] orientation permission threw:", err);
       permState = "denied";
-      say("motion access denied &middot; tap to retry &middot; if no prompt appears, reset it under aA &rarr; website settings");
+      deniedMsg();
     });
     if (typeof DeviceMotionEvent !== "undefined" &&
         typeof DeviceMotionEvent.requestPermission === "function") {
@@ -422,10 +436,16 @@
   }
 
   /* one window-level handler: the first tap opens the gate and (on iOS)
-     requests the sensors; any later tap retries while they are still off. */
+     requests the sensors; any later tap retries while they are still off.
+     The request also arms on click (fires at tap-end) as belt-and-suspenders
+     for engines picky about which gesture event carries user activation --
+     permInFlight keeps one tap to one prompt. */
   window.addEventListener("pointerdown", function () {
     if (needsGesture && !sensorsOn) requestSensorPermission();
     if (!gate.classList.contains("gone")) openGate();
+  });
+  window.addEventListener("click", function () {
+    if (needsGesture && !sensorsOn) requestSensorPermission();
   });
 
   /* Android / desktop need no gesture for sensors -- attach immediately so


### PR DESCRIPTION
## Summary

Follow-up to #307. On iOS, once a motion prompt on an origin has been denied **or dismissed**, every later `requestPermission()` returns `"denied"` instantly without showing a prompt — Safari replays the remembered answer until the tab is closed. The previous build reported this as a generic "motion access denied" with recovery instructions that were wrong (motion has no entry under aA → Website Settings).

## Changes

- **Timing-based diagnosis**: a denial that settles in <400ms means no prompt was shown — the on-screen message now says iOS is replaying an earlier "don't allow" and gives the correct recovery: close the tab, reopen the page, allow motion. A slow denial is a genuine decline and says so, inviting a retry tap.
- **Retry also arms on `click`** (tap-end) alongside `pointerdown`, guarded by an in-flight flag so one tap yields at most one prompt — belt-and-suspenders in case an engine is picky about which gesture event carries user activation.
- Both paths log elapsed ms to console for debugging.

## Testing

Headless Chromium with mocked `requestPermission`: instant denial on tap 1 shows the "replaying an earlier don't allow" message and attaches no sensors; grant on tap 2 attaches sensors; tap 3 issues no further permission calls. Original smoke test (shader link, pointer steering, simulated orientation takeover, shake energy) still green.

To verify on a phone after merge: `austegard.com/fun-and-games/currents-motion.html` — same origin where motion-player already prompts successfully. If iOS still claims denial there, the on-screen message now distinguishes a replayed denial from a fresh decline.

## Preview

[Branch Preview workflow runs](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml) — the `*.pages.dev` URL is in the latest run's job summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEhiyXFacURVKqwHRmNEEf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEhiyXFacURVKqwHRmNEEf)_