### PR TITLE
Currents in Motion: handle iOS home-screen apps refusing the motion prompt

### DIFF
--- a/fun-and-games/currents-motion.html
+++ b/fun-and-games/currents-motion.html
@@ -47,6 +47,16 @@
     font-size: 10px; line-height: 1.7; opacity: 0.55; white-space: pre;
     text-shadow: 0 1px 8px rgba(0,0,0,0.8); display: none;
   }
+  /* escape hatch shown when a home-screen app refuses the motion prompt:
+     a real link so iOS opens it in actual Safari, where the prompt works */
+  #escape {
+    left: 0; right: 0; bottom: calc(16% + env(safe-area-inset-bottom)); text-align: center;
+    font-size: 13px; opacity: 0; text-transform: lowercase;
+    color: #fff; text-decoration: underline; text-underline-offset: 4px;
+    text-shadow: 0 1px 12px rgba(0,0,0,0.6);
+    transition: opacity 1s ease;
+  }
+  #escape.show { opacity: 0.85; pointer-events: auto; }
   /* iOS requires a user gesture before it will hand over the gyroscope.
      This gate doubles as the title card; elsewhere it fades on first tap too. */
   #gate {
@@ -72,6 +82,7 @@
 <div id="hint" class="overlay"></div>
 <div id="sig" class="overlay">Currents &middot; Motion</div>
 <div id="hud" class="overlay"></div>
+<a id="escape" class="overlay" target="_blank" rel="noopener">open in safari for motion &#8599;</a>
 <div id="gate">
   <div>
     <h1>currents in motion</h1>
@@ -114,6 +125,13 @@
   var hint = document.getElementById("hint");
   var gate = document.getElementById("gate");
   var hud = document.getElementById("hud");
+  var escBtn = document.getElementById("escape");
+
+  /* home-screen ("standalone") web apps run in their own WebKit container
+     that frequently refuses to show the motion prompt at all */
+  var isStandalone = (window.navigator.standalone === true) ||
+    (window.matchMedia && window.matchMedia("(display-mode: standalone), (display-mode: fullscreen)").matches);
+  escBtn.href = window.location.href;
 
   var gl = null;
   try {
@@ -399,12 +417,19 @@
     permInFlight = true;
     var t0 = performance.now();
     function deniedMsg() {
-      /* an instant settle means iOS never showed the prompt: it is replaying
-         a remembered "don't allow" for this site. Only a fresh tab clears
-         that -- there is no motion entry under aA -> website settings. */
+      /* an instant settle means iOS never showed the prompt. In a browser
+         tab that is a remembered "don't allow" (a fresh tab clears it). In
+         a home-screen app the container often cannot prompt at all -- the
+         only way out is a real Safari tab, so offer one. */
       var ms = Math.round(performance.now() - t0);
       console.warn("[motion] orientation permission denied after", ms, "ms",
-                   ms < 400 ? "(instant -- remembered denial, no prompt shown)" : "(user declined)");
+                   ms < 400 ? "(instant -- no prompt was shown)" : "(user declined)",
+                   isStandalone ? "[standalone]" : "[browser]");
+      if (isStandalone && ms < 400) {
+        say("ios refused the motion prompt inside this home-screen app");
+        escBtn.classList.add("show");
+        return;
+      }
       say(ms < 400
         ? "ios is replaying an earlier &ldquo;don&rsquo;t allow&rdquo; &middot; close this tab, reopen the page, and allow motion"
         : "motion access declined &middot; tap to be asked again");
@@ -498,7 +523,8 @@
     hud.textContent =
       "alpha " + fmt(lastRaw.alpha, 1) + "  beta " + fmt(lastRaw.beta, 1) + "  gamma " + fmt(lastRaw.gamma, 1) + "\n" +
       "hue " + ((hue % TAU + TAU) % TAU / TAU * 360).toFixed(0) + "  L " + light.toFixed(2) + "  C " + chroma.toFixed(3) + "\n" +
-      "energy " + energy.toFixed(2) + "  src " + (hasOrientation ? "gyro" : "pointer") + "  perm " + permState;
+      "energy " + energy.toFixed(2) + "  src " + (hasOrientation ? "gyro" : "pointer") + "  perm " + permState +
+      "  mode " + (isStandalone ? "app" : "browser");
   }
 
   document.addEventListener("visibilitychange", function () {
@@ -517,9 +543,11 @@
   try {
     var iconEl = document.querySelector('link[rel="apple-touch-icon"]');
     var iconHref = iconEl ? iconEl.href : "";
+    /* display "standalone", not "fullscreen": matches motion-player, whose
+       home-screen install demonstrably gets motion on iOS */
     var manifest = {
       name: "Currents in Motion", short_name: "Motion",
-      display: "fullscreen", orientation: "any",
+      display: "standalone", orientation: "any",
       background_color: "#050608", theme_color: "#050608",
       start_url: ".",
       icons: iconHref ? [{ src: iconHref, sizes: "180x180", type: "image/png" }] : []

--- a/fun-and-games/currents-motion_README.md
+++ b/fun-and-games/currents-motion_README.md
@@ -52,9 +52,16 @@ whatever color neighborhood the device selects.
 ## Install as an app
 
 Like Currents, the page carries the meta tags and a runtime-generated
-manifest to be installed full-screen from Share → *Add to Home Screen* (iOS)
-or the install prompt (Android). Everything — icon included — is inlined in
-the one HTML file.
+manifest (`display: standalone`, matching motion-player) to be installed
+from Share → *Add to Home Screen* (iOS) or the install prompt (Android).
+Everything — icon included — is inlined in the one HTML file.
+
+**iOS home-screen caveat**: standalone web apps run in their own WebKit
+container, which frequently refuses to show the motion permission prompt at
+all — `requestPermission()` settles `"denied"` instantly with no dialog,
+while the same page prompts fine in Safari. When the page detects this
+(standalone mode + instant denial) it says so and shows an *"open in safari
+for motion"* link, which iOS opens in real Safari.
 
 ## Implementation notes
 


### PR DESCRIPTION
## Summary

Follow-up to #308. In home-screen ("standalone") mode the motion prompt never appears — iOS standalone web apps run in their own WebKit container, which frequently refuses to show the motion permission dialog at all: `requestPermission()` settles `"denied"` instantly, while the identical page prompts fine in a Safari tab. The piece then runs on the Lorenz undulation alone, which reads as a "pre-recorded" animation.

## Changes

- **Standalone detection + honest messaging**: on an instant denial in standalone mode (`navigator.standalone` / `display-mode` media query), the page says "ios refused the motion prompt inside this home-screen app" and shows an **"open in safari for motion"** link — a real anchor with `target="_blank"`, which iOS opens in actual Safari, where the prompt works.
- **Manifest `display` changed `fullscreen` → `standalone`**, matching motion-player's install configuration (the PWA whose home-screen motion demonstrably works). Note: an already-installed icon must be deleted and re-added for a manifest change to take effect.
- **HUD gains a `mode app/browser` field** for debugging, alongside the existing `perm` state.
- README documents the home-screen caveat.

## Testing

Headless Chromium: faked `navigator.standalone` + instant denial → standalone message shown, escape link visible/clickable with correct href and `target="_blank"`, HUD reports `mode app`. Browser-mode denial messaging (replayed-denial vs genuine-decline) and the full smoke test (shader link, pointer steering, simulated orientation takeover, shake energy) unchanged and green.

On-device after merge: delete the old home-screen icon, re-add from `austegard.com/fun-and-games/currents-motion.html`, launch, tap. Either iOS shows the prompt (ideal) or the page now says it was refused and offers the Safari link.

## Preview

[Branch Preview workflow runs](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml) — the `*.pages.dev` URL is in the latest run's job summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEhiyXFacURVKqwHRmNEEf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEhiyXFacURVKqwHRmNEEf)_