### PR TITLE
Ball Maze: endless runtime-generated levels, saved progress, SW cache bump

### DIFF
--- a/fun-and-games/ball-maze/README.md
+++ b/fun-and-games/ball-maze/README.md
@@ -13,9 +13,13 @@ green goal.
   permission, as required.
 - **Points for distance** — you earn 1 point for every cell-length of ground
   the ball covers.
-- **5 levels, easy to hard** — each level generates a fresh random maze
-  (recursive backtracker), growing from 6×9 up to 14×21 cells.
-- **Level bonus** — completing level *N* awards 100 × *N* points.
+- **Endless levels, generated at runtime** — each level generates a fresh
+  random maze (recursive backtracker), starting at 6×9 cells and growing
+  every level until cells would drop below 22 px on the current screen;
+  after that, difficulty keeps ramping through hole count (up to 14 on the
+  path plus 18 decoys).
+- **Level bonus** — completing level *N* awards 100 × *N* points, so the
+  stakes keep rising.
 - **Holes** — from level 2 on, holes appear in the board. Roll over one and
   the ball drops in: −25 points and back to the start. Like the physical
   toy, most holes sit **on** the solution path, offset to one side of the

--- a/fun-and-games/ball-maze/README.md
+++ b/fun-and-games/ball-maze/README.md
@@ -27,6 +27,10 @@ green goal.
   rest are decoys in dead ends. The geometry guarantees the open side is
   always passable, so every maze stays winnable.
 - **Best score** — persisted in `localStorage`.
+- **Continue where you left off** — the run (current level + score) is saved
+  to `localStorage` on every score change and level transition. Reopening
+  the app offers "Continue · Level N" alongside "Start over"; resuming
+  regenerates a fresh maze of the saved level.
 
 No tilt sensor? Arrow keys / WASD or dragging on the board work as
 fallbacks, so it's playable on desktop too.

--- a/fun-and-games/ball-maze/game.js
+++ b/fun-and-games/ball-maze/game.js
@@ -10,15 +10,19 @@
   'use strict';
 
   // ---------------------------------------------------------------- levels
-  // pathHoles sit ON the solution path, offset to one side of the corridor
-  // so a narrow safe edge remains; the rest go in dead ends as decoys.
-  const LEVELS = [
-    { cols: 6,  rows: 9,  holes: 0,  pathHoles: 0 },
-    { cols: 8,  rows: 12, holes: 2,  pathHoles: 1 },
-    { cols: 10, rows: 15, holes: 5,  pathHoles: 2 },
-    { cols: 12, rows: 18, holes: 8,  pathHoles: 3 },
-    { cols: 14, rows: 21, holes: 12, pathHoles: 5 },
-  ];
+  // Levels are endless and generated at runtime. The grid grows every level
+  // until cells would drop below MIN_CELL px on this screen; after that,
+  // difficulty keeps ramping through hole count alone. pathHoles sit ON the
+  // solution path, offset to one side of the corridor so a narrow safe edge
+  // remains; the rest go in dead ends as decoys.
+  const MIN_CELL = 22;
+  function levelSpec(n, availW, availH) {
+    const cols = Math.max(4, Math.min(6 + 2 * (n - 1), Math.floor(availW / MIN_CELL)));
+    const rows = Math.max(6, Math.min(9 + 3 * (n - 1), Math.floor(availH / MIN_CELL)));
+    const pathHoles = n < 2 ? 0 : Math.min(n - 1, 14);
+    const holes = n < 2 ? 0 : pathHoles + Math.min(2 * n - 3, 18);
+    return { cols, rows, holes, pathHoles };
+  }
   const LEVEL_BONUS = 100;   // × level number on completion
   const HOLE_PENALTY = 25;
   const BEST_KEY = 'ball-maze-best';
@@ -61,7 +65,7 @@
   // ---------------------------------------------------------------- state
   const game = {
     state: 'idle',           // idle | playing | falling | between
-    level: 0,                // 0-based index into LEVELS
+    level: 0,                // 0-based level index (endless)
     score: 0,
     best: Number(localStorage.getItem(BEST_KEY)) || 0,
     distAcc: 0,              // px rolled since last distance point
@@ -135,13 +139,13 @@
   }
 
   function buildLevel(levelIndex) {
-    const spec = LEVELS[levelIndex];
+    const availW = boardWrap.clientWidth - 8;
+    const availH = boardWrap.clientHeight - 8;
+    const spec = levelSpec(levelIndex + 1, availW, availH);
     const { cols, rows } = spec;
     const cells = generateMaze(cols, rows);
 
     // fit square cells into the board area
-    const availW = boardWrap.clientWidth - 8;
-    const availH = boardWrap.clientHeight - 8;
     const cs = Math.floor(Math.min(availW / cols, availH / rows));
     const ox = Math.floor((boardWrap.clientWidth - cols * cs) / 2);
     const oy = Math.floor((boardWrap.clientHeight - rows * cs) / 2);
@@ -441,7 +445,7 @@
     game.distAcc = 0;
     game.fall = null;
     resetBall();
-    levelEl.textContent = (levelIndex + 1) + '/5';
+    levelEl.textContent = String(levelIndex + 1);
     game.state = 'playing';
   }
 
@@ -454,29 +458,20 @@
   }
 
   function completeLevel() {
-    const bonus = LEVEL_BONUS * (game.level + 1);
+    const level = game.level + 1;
+    const bonus = LEVEL_BONUS * level;
     addScore(bonus);
     if (navigator.vibrate) navigator.vibrate([30, 40, 30]);
     game.state = 'between';
-    if (game.level + 1 < LEVELS.length) {
-      showMessage(
-        'Level ' + (game.level + 1) + ' complete!',
-        '+' + bonus,
-        'Next up: a bigger maze' +
-          (LEVELS[game.level + 1].holes > LEVELS[game.level].holes
-            ? ' with more holes.' : '.'),
-        'Level ' + (game.level + 2),
-        () => startLevel(game.level + 1));
-    } else {
-      showMessage(
-        '🏆 You beat all 5 levels!',
-        game.score + ' points',
-        game.score >= game.best
-          ? 'That’s your best run yet.'
-          : 'Best so far: ' + game.best + '.',
-        'Play again',
-        () => { game.score = 0; scoreEl.textContent = '0'; startLevel(0); });
-    }
+    const milestone = level % 5 === 0;
+    showMessage(
+      (milestone ? '🏆 ' : '') + 'Level ' + level + ' complete!',
+      '+' + bonus,
+      milestone
+        ? level + ' levels down, ' + game.score + ' points. The mazes keep coming — how far can you get?'
+        : 'Next: a fresh maze, a little meaner.',
+      'Level ' + (level + 1),
+      () => startLevel(game.level + 1));
   }
 
   let messageAction = null;

--- a/fun-and-games/ball-maze/game.js
+++ b/fun-and-games/ball-maze/game.js
@@ -26,6 +26,7 @@
   const LEVEL_BONUS = 100;   // × level number on completion
   const HOLE_PENALTY = 25;
   const BEST_KEY = 'ball-maze-best';
+  const PROGRESS_KEY = 'ball-maze-progress';
 
   // physics constants (scaled by cell size where noted)
   const STEP = 1 / 120;      // fixed physics timestep, s
@@ -56,6 +57,7 @@
   const toastEl = document.getElementById('toast');
   const startOverlay = document.getElementById('start-overlay');
   const startBtn = document.getElementById('start-btn');
+  const continueBtn = document.getElementById('continue-btn');
   const msgOverlay = document.getElementById('message-overlay');
   const msgTitle = document.getElementById('message-title');
   const msgPoints = document.getElementById('message-points');
@@ -420,6 +422,29 @@
       bestEl.textContent = game.best;
       localStorage.setItem(BEST_KEY, String(game.best));
     }
+    saveProgress();
+  }
+
+  // ---------------------------------------------------------------- progress
+  // The run (level + score) survives closing the app: saved on every score
+  // change and level transition, restored via the Continue button. A resume
+  // regenerates a fresh maze of the saved level — mazes are random anyway.
+  function saveProgress(level = game.level) {
+    try {
+      localStorage.setItem(PROGRESS_KEY,
+        JSON.stringify({ level, score: game.score }));
+    } catch { /* storage full/blocked — play on without persistence */ }
+  }
+
+  function loadProgress() {
+    try {
+      const p = JSON.parse(localStorage.getItem(PROGRESS_KEY));
+      if (p && Number.isInteger(p.level) && p.level >= 0 &&
+          Number.isInteger(p.score) && p.score >= 0) {
+        return p;
+      }
+    } catch { /* corrupt entry — treat as no progress */ }
+    return null;
   }
 
   let toastTimer = 0;
@@ -447,6 +472,7 @@
     resetBall();
     levelEl.textContent = String(levelIndex + 1);
     game.state = 'playing';
+    saveProgress();
   }
 
   function startFall(hole) {
@@ -461,6 +487,7 @@
     const level = game.level + 1;
     const bonus = LEVEL_BONUS * level;
     addScore(bonus);
+    saveProgress(game.level + 1); // quitting at the overlay resumes at next level
     if (navigator.vibrate) navigator.vibrate([30, 40, 30]);
     game.state = 'between';
     const milestone = level % 5 === 0;
@@ -620,13 +647,26 @@
   });
 
   // ---------------------------------------------------------------- start
-  startBtn.addEventListener('click', async () => {
+  async function beginGame(level, score) {
     const tiltOk = await enableTilt();
     startOverlay.classList.add('hidden');
     keepAwake();
-    startLevel(0);
+    game.score = score;
+    scoreEl.textContent = score;
+    startLevel(level);
     if (!tiltOk) toast('No tilt sensor — use keys or drag');
-  });
+  }
+
+  const savedRun = loadProgress();
+  if (savedRun && (savedRun.level > 0 || savedRun.score > 0)) {
+    continueBtn.textContent = 'Continue · Level ' + (savedRun.level + 1);
+    continueBtn.classList.remove('hidden');
+    startBtn.textContent = 'Start over';
+    startBtn.classList.add('secondary');
+  }
+  continueBtn.addEventListener('click', () =>
+    beginGame(savedRun.level, savedRun.score));
+  startBtn.addEventListener('click', () => beginGame(0, 0));
 
   // expose internals for automated tests when loaded with ?debug
   if (new URLSearchParams(location.search).has('debug')) {

--- a/fun-and-games/ball-maze/index.html
+++ b/fun-and-games/ball-maze/index.html
@@ -181,7 +181,8 @@
       big bonus for finishing each maze. From level&nbsp;2 on, holes sit right
       in your path — hug the wall to skirt around them, or the ball drops in
       and goes back to the start.</p>
-    <p>5 levels, easy to hard. New maze every time.</p>
+    <p>Endless levels, generated fresh every time — each maze bigger and
+      meaner than the last. How far can you get?</p>
     <button id="start-btn">Start</button>
     <div class="fine-print">No tilt sensor? Use arrow keys / WASD, or drag on the board.</div>
   </div>

--- a/fun-and-games/ball-maze/index.html
+++ b/fun-and-games/ball-maze/index.html
@@ -123,8 +123,15 @@
       border-radius: 999px;
       padding: 0.8rem 2.4rem;
       cursor: pointer;
+      margin-top: 0.5rem;
     }
     .overlay button:active { transform: scale(0.97); }
+    .overlay button.secondary {
+      background: transparent;
+      color: #f0ead8;
+      border: 1.5px solid rgba(240, 234, 216, 0.4);
+    }
+    .overlay button.hidden { display: none; }
 
     .overlay .fine-print {
       margin-top: 1.25rem;
@@ -183,6 +190,7 @@
       and goes back to the start.</p>
     <p>Endless levels, generated fresh every time — each maze bigger and
       meaner than the last. How far can you get?</p>
+    <button id="continue-btn" class="hidden">Continue</button>
     <button id="start-btn">Start</button>
     <div class="fine-print">No tilt sensor? Use arrow keys / WASD, or drag on the board.</div>
   </div>

--- a/fun-and-games/ball-maze/manifest.webmanifest
+++ b/fun-and-games/ball-maze/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Ball Maze",
   "short_name": "Ball Maze",
-  "description": "Tilt your phone to roll a ball through 5 mazes, easy to hard. Points for distance, bonuses per level, holes to dodge.",
+  "description": "Tilt your phone to roll a ball through endless generated mazes, each harder than the last. Points for distance, bonuses per level, holes to dodge.",
   "start_url": "./",
   "scope": "./",
   "display": "standalone",

--- a/fun-and-games/ball-maze/sw.js
+++ b/fun-and-games/ball-maze/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ball-maze-v2';
+const CACHE_NAME = 'ball-maze-v3';
 const PRECACHE_URLS = [
   './',
   'index.html',

--- a/fun-and-games/ball-maze/sw.js
+++ b/fun-and-games/ball-maze/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ball-maze-v1';
+const CACHE_NAME = 'ball-maze-v2';
 const PRECACHE_URLS = [
   './',
   'index.html',


### PR DESCRIPTION
## Summary

- **Endless levels, generated at runtime.** The fixed 5-level table is replaced by `levelSpec(n)`: the maze grid grows every level (from 6×9, +2 cols / +3 rows per level) until cells would drop below 22 px on the current screen (18×33 on a typical phone), after which difficulty keeps ramping through hole count alone — up to 14 on-path holes plus 18 dead-end decoys. Level bonus stays 100 × N so stakes keep rising; every 5th level gets a 🏆 milestone overlay. The "beat all 5 levels" win screen is gone.
- **Saved progress / continue.** The run (current level + score) persists to `localStorage` on every score change and level transition; completing a level checkpoints the *next* level so quitting at the level-complete overlay doesn't replay the finished one. Reopening offers "Continue · Level N" (primary) alongside "Start over" (secondary); resuming regenerates a fresh maze of the saved level. Corrupt/absent saves fall back to a normal start.
- **Service-worker cache bump (v1 → v3).** Explains "I still don't see on-path holes": the stale-while-revalidate cache serves the previous build on the first load after a deploy, so #309's on-path redesign wasn't visible until a second reload. Bumping `CACHE_NAME` forces a fresh precache on service-worker update.

## Verification

Headless Chromium (Playwright) via the `?debug` hook:
- Endless progression through level 8 with correct rising bonuses (100…700) and the level-5 milestone overlay.
- Grid growth and cap: level 1 → 6×9 @ 68px cells, level 5 → 14×21 @ 29px, level 10 → 18×33 @ 22px (capped), level 20 → 18×33 with 32 holes (14 on-path) — cells never drop below 22 px.
- State management: fresh visitor sees only Start; after playing to level 3, reload shows "Continue · Level 3" and restores exact level + score; quitting at the level-complete overlay resumes at the next level; "Start over" resets run and save.
- Hole-placement invariants re-verified over 25 mazes per level; physics drive-bys: open lane past an on-path hole passed 8/8 with zero falls, corridor center fell 5/5.
- Hole penalty/reset, containment under full tilt, no console errors.
- Generated annotated renderings (solution path + on-path holes ringed) confirming holes sit on the path across levels 2/3/5/10.

## Preview

Branch preview deploys to Cloudflare Pages — find the `*.pages.dev` URL in the job summary of the latest [Branch Preview workflow run](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5