### PR TITLE
Ball Maze: score only new ground so hole penalties stick

### DIFF
--- a/fun-and-games/ball-maze/README.md
+++ b/fun-and-games/ball-maze/README.md
@@ -11,8 +11,10 @@ green goal.
 - **Tilt to move** — the ball accelerates in the direction you tilt the
   device (DeviceOrientation). On iOS the Start button requests motion
   permission, as required.
-- **Points for distance** — you earn 1 point for every cell-length of ground
-  the ball covers.
+- **Points for distance** — you earn 1 point for each *new* cell of ground
+  you reach. Backtracking (or re-covering ground after falling in a hole)
+  earns nothing, so hole penalties actually stick — repeated deaths can't
+  be farmed back into a rising score.
 - **Endless levels, generated at runtime** — each level generates a fresh
   random maze (recursive backtracker), starting at 6×9 cells and growing
   every level until cells would drop below 22 px on the current screen;

--- a/fun-and-games/ball-maze/game.js
+++ b/fun-and-games/ball-maze/game.js
@@ -70,7 +70,7 @@
     level: 0,                // 0-based level index (endless)
     score: 0,
     best: Number(localStorage.getItem(BEST_KEY)) || 0,
-    distAcc: 0,              // px rolled since last distance point
+    visited: new Set(),      // cells credited with a distance point this level
     maze: null,
     ball: { x: 0, y: 0, vx: 0, vy: 0, r: 0 },
     fall: null,              // { hole, t } during fall animation
@@ -405,10 +405,14 @@
       }
     }
 
-    // distance points: one per cell-length rolled
-    game.distAcc += Math.hypot(b.x - px, b.y - py);
-    while (game.distAcc >= cs) {
-      game.distAcc -= cs;
+    // distance points: 1 per NEW cell of ground reached. Backtracking and
+    // re-treading after a hole fall earn nothing, so penalties stick —
+    // repeatedly dying can no longer be farmed back into a rising score.
+    const cc = Math.min(m.cols - 1, Math.max(0, Math.floor((b.x - m.ox) / cs)));
+    const cr = Math.min(m.rows - 1, Math.max(0, Math.floor((b.y - m.oy) / cs)));
+    const ck = cc + ',' + cr;
+    if (!game.visited.has(ck)) {
+      game.visited.add(ck);
       addScore(1);
     }
 
@@ -480,7 +484,7 @@
   function startLevel(levelIndex) {
     game.level = levelIndex;
     game.maze = buildLevel(levelIndex);
-    game.distAcc = 0;
+    game.visited = new Set(['0,0']); // start cell is free, not scored
     game.fall = null;
     resetBall();
     levelEl.textContent = String(levelIndex + 1);

--- a/fun-and-games/ball-maze/index.html
+++ b/fun-and-games/ball-maze/index.html
@@ -197,7 +197,7 @@
     <div id="start-overlay" class="overlay">
     <h1>🕳️ Ball Maze</h1>
     <p>Tilt your phone to roll the ball from the top of the maze to the
-      green goal. Earn a point for every stretch of ground you cover, and a
+      green goal. Earn a point for every new stretch of ground you reach, and a
       big bonus for finishing each maze. From level&nbsp;2 on, holes sit right
       in your path — hug the wall to skirt around them, or the ball drops in
       and goes back to the start.</p>

--- a/fun-and-games/ball-maze/sw.js
+++ b/fun-and-games/ball-maze/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ball-maze-v5';
+const CACHE_NAME = 'ball-maze-v6';
 const PRECACHE_URLS = [
   './',
   'index.html',


### PR DESCRIPTION
## Summary

Fixes the reported scoring exploit: after draining to 0 on hole falls (the score floors at 0 rather than going negative), the score would "start counting up" again — distance points were awarded per cell-length rolled over *any* ground, so re-rolling already-covered corridors after each reset re-earned points, making repeated deaths farmable. Even jiggling against a wall accrued points.

Now each cell of a level scores exactly once, on first entry (the start cell is free). Backtracking and post-fall re-treads earn nothing, so the −25 penalty genuinely sets you back: after repeated falls the score drains to 0 and *stays* there until you reach ground you haven't covered before.

SW cache bumped v5 → v6.

## Testing

Headless Chromium via the `?debug` hook:
- Fresh ground earns points; three rounds of backtracking over the same corridors earn ~nothing.
- The reported repro: repeated hole falls with re-treading between reads 0, 0, 0 across cycles — never counts up, never goes negative.
- Fresh ground on a new level still scores (system not bricked).
- Full regression re-run: endless progression + bonuses (now +1 for the goal cell itself, as any new cell), save/continue, hole penalty/reset, rotation-preservation, containment, zero console errors.

## Preview

Branch preview deploys to Cloudflare Pages — find the `*.pages.dev` URL in the job summary of the latest [Branch Preview workflow run](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5)_