### PR TITLE
Ball Maze: counter-rotate synchronously so orientation flips read as one motion

### DIFF
--- a/fun-and-games/ball-maze/README.md
+++ b/fun-and-games/ball-maze/README.md
@@ -58,9 +58,12 @@ uses stale-while-revalidate, so the game is installable and playable offline.
   with a CSS transform — visually the game never leaves portrait, even with
   the iOS orientation lock off. Tilt input uses raw device beta/gamma
   (identity mapping), which stays correct because the UI is always in
-  device coordinates; pointer-drag deltas are un-rotated to match. Native
-  `screen.orientation.lock('portrait')` is still attempted at game start
-  for platforms that support it (installed Android PWAs).
+  device coordinates; pointer-drag deltas are un-rotated to match. The
+  counter-rotation is applied synchronously on the orientation-change
+  events (no debounce) so it lands inside the OS's own rotation animation
+  and reads as one motion, with a ~180 ms opacity dip masking the layout
+  swap. Native `screen.orientation.lock('portrait')` is still attempted at
+  game start for platforms that support it (installed Android PWAs).
 - A resize or orientation flip re-lays-out the **same** maze at the new
   size and carries the ball across proportionally — mid-level progress
   survives rotation.

--- a/fun-and-games/ball-maze/game.js
+++ b/fun-and-games/ball-maze/game.js
@@ -702,14 +702,42 @@
       b.r = m.cs * BALL_R;
     }
   }
-  window.addEventListener('resize', () => {
+  // A flip must be countered SYNCHRONOUSLY: any delay here splits the
+  // rotation into two visible steps (OS animation, then our flip-back).
+  // Applying the fix while the OS is still animating lets iOS reveal the
+  // already-counter-rotated layout at the end of its own animation, so the
+  // whole thing reads as one motion. A brief opacity dip masks the layout
+  // swap. Plain same-orientation resizes (desktop window drags, toolbar
+  // show/hide) keep the debounce.
+  let fadeTimer = 0;
+  function maskFlip() {
+    appEl.style.transition = 'none';
+    appEl.style.opacity = '0';
+    clearTimeout(fadeTimer);
+    fadeTimer = setTimeout(() => {
+      appEl.style.transition = 'opacity 0.18s ease-out';
+      appEl.style.opacity = '1';
+    }, 60);
+  }
+
+  function handleViewportChange(orientationEvent) {
+    const flipped = orientationAngle() !== uiAngle;
     clearTimeout(resizeCanvas._t);
-    resizeCanvas._t = setTimeout(resizeCanvas, 150);
-  });
-  window.addEventListener('orientationchange', () => {
-    clearTimeout(resizeCanvas._t);
-    resizeCanvas._t = setTimeout(resizeCanvas, 150);
-  });
+    if (flipped || orientationEvent) {
+      if (flipped) maskFlip();
+      resizeCanvas();
+    } else {
+      resizeCanvas._t = setTimeout(resizeCanvas, 150);
+    }
+  }
+  window.addEventListener('resize', () => handleViewportChange(false));
+  window.addEventListener('orientationchange', () => handleViewportChange(true));
+  if (screen.orientation && screen.orientation.addEventListener) {
+    screen.orientation.addEventListener('change', () => handleViewportChange(true));
+  }
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', () => handleViewportChange(false));
+  }
   resizeCanvas();
 
   // ---------------------------------------------------------------- wake lock

--- a/fun-and-games/ball-maze/sw.js
+++ b/fun-and-games/ball-maze/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ball-maze-v6';
+const CACHE_NAME = 'ball-maze-v7';
 const PRECACHE_URLS = [
   './',
   'index.html',


### PR DESCRIPTION
## Summary

The orientation fix worked but felt like a two-step operation: the OS rotated the viewport (with its own animation and zoom change), and only *then* did the board flip back. Cause: the counter-rotation sat behind the resize handler's 150 ms debounce, so it always landed after the OS animation finished.

Now a flip is countered **synchronously**: `orientationchange`, `screen.orientation`'s `change` event, `visualViewport` resizes, and any `resize` whose angle differs from the currently-countered one all apply the fix immediately, with no debounce. That places the counter-rotation inside the OS's own rotation animation, so iOS reveals the already-corrected layout as its animation completes — one motion instead of two. A ~180 ms opacity dip masks the layout swap underneath the OS transition. Plain same-orientation resizes (desktop window drags, toolbar show/hide) keep the debounce.

SW cache bumped v6 → v7.

## Testing

Headless Chromium, simulated rotation (viewport swap + `screen.orientation.angle` override): the counter-rotation transform is present within 80 ms of the flip (previously 150 ms+ by construction), the app fades back to full opacity, and the previous guarantees all hold — same maze object, ball position/score preserved, transform cleared on rotate-back, 270° mirror rotation. Scoring, flow, and state regression suites re-run green with zero console errors.

The real smoothness test is on-device: with the OS lock off, tilt into landscape — the rotation should now read as a single motion with a brief dim, not a rotate-then-flip-back.

## Preview

Branch preview deploys to Cloudflare Pages — find the `*.pages.dev` URL in the job summary of the latest [Branch Preview workflow run](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5)_