### PR TITLE
Ball Maze: drop the opacity mask — it was the remaining jarring step

### DIFF
--- a/fun-and-games/ball-maze/README.md
+++ b/fun-and-games/ball-maze/README.md
@@ -61,8 +61,9 @@ uses stale-while-revalidate, so the game is installable and playable offline.
   device coordinates; pointer-drag deltas are un-rotated to match. The
   counter-rotation is applied synchronously on the orientation-change
   events (no debounce) so it lands inside the OS's own rotation animation
-  and reads as one motion, with a ~180 ms opacity dip masking the layout
-  swap. Native `screen.orientation.lock('portrait')` is still attempted at
+  and reads as one motion — no masking; frame analysis showed the OS
+  animation ends cleanly on the corrected layout on its own. Native
+  `screen.orientation.lock('portrait')` is still attempted at
   game start for platforms that support it (installed Android PWAs).
 - A resize or orientation flip re-lays-out the **same** maze at the new
   size and carries the ball across proportionally — mid-level progress

--- a/fun-and-games/ball-maze/game.js
+++ b/fun-and-games/ball-maze/game.js
@@ -704,27 +704,17 @@
   }
   // A flip must be countered SYNCHRONOUSLY: any delay here splits the
   // rotation into two visible steps (OS animation, then our flip-back).
-  // Applying the fix while the OS is still animating lets iOS reveal the
-  // already-counter-rotated layout at the end of its own animation, so the
-  // whole thing reads as one motion. A brief opacity dip masks the layout
-  // swap. Plain same-orientation resizes (desktop window drags, toolbar
-  // show/hide) keep the debounce.
-  let fadeTimer = 0;
-  function maskFlip() {
-    appEl.style.transition = 'none';
-    appEl.style.opacity = '0';
-    clearTimeout(fadeTimer);
-    fadeTimer = setTimeout(() => {
-      appEl.style.transition = 'opacity 0.18s ease-out';
-      appEl.style.opacity = '1';
-    }, 60);
-  }
-
+  // Applied in the same event turn, iOS's own rotation animation ends by
+  // revealing the already-counter-rotated layout, so the whole thing reads
+  // as one motion. No masking on top — frame analysis of a real rotation
+  // showed the OS animation landing cleanly on the corrected layout, and
+  // an opacity mask just added a visible black flash after it. Plain
+  // same-orientation resizes (desktop drags, toolbar show/hide) keep the
+  // debounce.
   function handleViewportChange(orientationEvent) {
     const flipped = orientationAngle() !== uiAngle;
     clearTimeout(resizeCanvas._t);
     if (flipped || orientationEvent) {
-      if (flipped) maskFlip();
       resizeCanvas();
     } else {
       resizeCanvas._t = setTimeout(resizeCanvas, 150);

--- a/fun-and-games/ball-maze/sw.js
+++ b/fun-and-games/ball-maze/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ball-maze-v7';
+const CACHE_NAME = 'ball-maze-v8';
 const PRECACHE_URLS = [
   './',
   'index.html',


### PR DESCRIPTION
## Summary

Frame-by-frame analysis of an on-device screen recording (ffmpeg contact sheet, 10 fps) of a real rotation showed:

- **3.7–3.9 s**: iOS's rotation animation spins the page, and mid-animation the incoming layout is already the counter-rotated board — the synchronous fix from #317 works; the OS animation ends on the corrected layout by itself.
- **4.0 s**: a full black frame — the opacity mask firing right as the OS animation lands.
- **4.1–4.2 s**: the board fades back in.

So the remaining "second step" was the mask itself, not the counter-rotation. This PR removes the mask entirely: a flip is now just the OS rotation animation ending on the right layout, with no black flash or fade after it.

SW cache bumped v7 → v8.

## Testing

Headless Chromium: rotation suite still passes (synchronous counter-rotation within 80 ms, same maze/ball/score preserved, clean rotate-back, 270° mirror) and the app is never left dimmed. Flow and scoring regressions green, zero console errors.

## Preview

Branch preview deploys to Cloudflare Pages — find the `*.pages.dev` URL in the job summary of the latest [Branch Preview workflow run](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5)_