### PR TITLE
Ball Maze: wait out iOS's staggered rotation signals (kills the sideways flash)

### DIFF
--- a/fun-and-games/ball-maze/game.js
+++ b/fun-and-games/ball-maze/game.js
@@ -648,11 +648,28 @@
     return ((a % 360) + 360) % 360;
   }
 
+  // Counter-rotation only makes sense on portrait-natural devices (phones).
+  // On landscape-natural screens (desktops, some tablets) angle 90/270
+  // means the device was turned to PORTRAIT — forcing our portrait layout
+  // sideways there would be exactly wrong. type and angle come from the
+  // same update, so this stays consistent even mid-rotation.
+  function naturalPortrait() {
+    const o = screen.orientation;
+    if (!o || !o.type) return window.innerHeight >= window.innerWidth;
+    const landscapeType = o.type.indexOf('landscape') === 0;
+    const quarterTurn = o.angle === 90 || o.angle === 270;
+    return landscapeType === quarterTurn;
+  }
+
   function applyOrientationFix(forceAngle) {
     uiAngle = forceAngle != null ? forceAngle : orientationAngle();
+    if (forceAngle == null && !naturalPortrait()) uiAngle = 0;
     const s = appEl.style;
     if (uiAngle === 90 || uiAngle === 270) {
-      const w = window.innerHeight, h = window.innerWidth; // device-portrait box
+      // innerWidth/innerHeight can be stale mid-rotation on iOS; min/max
+      // yields the right portrait-shaped box either way
+      const w = Math.min(window.innerWidth, window.innerHeight);
+      const h = Math.max(window.innerWidth, window.innerHeight);
       s.width = w + 'px';
       s.height = h + 'px';
       s.transformOrigin = 'top left';
@@ -711,10 +728,26 @@
   // an opacity mask just added a visible black flash after it. Plain
   // same-orientation resizes (desktop drags, toolbar show/hide) keep the
   // debounce.
+  let agreeRetries = 0;
   function handleViewportChange(orientationEvent) {
-    const flipped = orientationAngle() !== uiAngle;
     clearTimeout(resizeCanvas._t);
-    if (flipped || orientationEvent) {
+    const angle = orientationAngle();
+    const angleLandscape = angle === 90 || angle === 270;
+    const viewportLandscape = window.innerWidth > window.innerHeight;
+    // On iOS the resize and the orientation-angle update arrive at
+    // different moments during a rotation. Painting while they disagree
+    // briefly shows an UN-countered landscape layout (seen on-device as a
+    // sideways board for ~100ms). Hold off until the signals agree, then
+    // apply layout + transform in one shot. Only portrait-natural devices
+    // rotate like this; desktops skip straight through.
+    if (naturalPortrait() && angleLandscape !== viewportLandscape &&
+        agreeRetries < 30) {
+      agreeRetries++;
+      resizeCanvas._t = setTimeout(() => handleViewportChange(true), 50);
+      return;
+    }
+    agreeRetries = 0;
+    if (angle !== uiAngle || orientationEvent) {
       resizeCanvas();
     } else {
       resizeCanvas._t = setTimeout(resizeCanvas, 150);

--- a/fun-and-games/ball-maze/sw.js
+++ b/fun-and-games/ball-maze/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ball-maze-v8';
+const CACHE_NAME = 'ball-maze-v9';
 const PRECACHE_URLS = [
   './',
   'index.html',


### PR DESCRIPTION
## Summary

Contact-sheet analysis of the second on-device recording (120 fps) pinned down the remaining artifact: after iOS's rotation animation (~1.77–1.97 s), the board painted **sideways and small for ~100 ms** (2.00–2.07 s) before snapping to the counter-rotated layout (2.10 s). Cause: on iOS the `resize` event arrives *before* `screen.orientation.angle` updates, so the handler classified it as a plain resize, re-laid-out for landscape without the transform, and only corrected when the angle event landed ~100 ms later.

Fixes:
- **Signal-agreement gate.** When the orientation angle and the viewport shape disagree on a portrait-natural device, the handler paints nothing — it polls every 50 ms (capped at 1.5 s) until the signals agree, then applies re-layout + counter-rotation in one shot. The old portrait frame simply stays up beneath the OS animation, so the flip is one transition with no intermediate state.
- **Portrait-natural gating.** Counter-rotation (and the wait logic) now only engages on portrait-natural devices. On landscape-natural screens (desktops, some tablets), angle 90/270 means the device was turned *to* portrait — counter-rotating there would be exactly wrong, and desktop window resizes skip straight through as before.
- **Stale-dimension hardening.** The device-portrait app box is computed as min/max of the inner dimensions, so stale values can't produce a landscape-shaped box.

SW cache bumped v8 → v9.

## Testing

Headless Chromium, including a new stale-signal simulation (viewport swapped to landscape while the angle still reads 0 with `portrait-primary` type, then angle+type catch up together as on iOS): during the disagreement window nothing repaints (no transform, unchanged maze layout); once the signals agree the counter-rotated portrait layout applies in one shot. Prior rotation guarantees (same maze/ball/score, clean rotate-back, 270° mirror), flow, scoring, and state suites all green with zero console errors.

## Preview

Branch preview deploys to Cloudflare Pages — find the `*.pages.dev` URL in the job summary of the latest [Branch Preview workflow run](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5)_