### PR TITLE
Ball Maze: handle stuck orientation APIs in installed home-screen apps

### DIFF
--- a/fun-and-games/ball-maze/README.md
+++ b/fun-and-games/ball-maze/README.md
@@ -62,7 +62,12 @@ uses stale-while-revalidate, so the game is installable and playable offline.
   counter-rotation is applied synchronously on the orientation-change
   events (no debounce) so it lands inside the OS's own rotation animation
   and reads as one motion — no masking; frame analysis showed the OS
-  animation ends cleanly on the corrected layout on its own. Native
+  animation ends cleanly on the corrected layout on its own. Installed
+  (home-screen) apps can leave `screen.orientation` stuck after rotating,
+  so the angle is taken from whichever source reports one —
+  `window.orientation` still updates in standalone mode — with a
+  last-resort quarter-turn inferred from the tilt sensor's gravity vector
+  when every API is stuck. Native
   `screen.orientation.lock('portrait')` is still attempted at
   game start for platforms that support it (installed Android PWAs).
 - A resize or orientation flip re-lays-out the **same** maze at the new

--- a/fun-and-games/ball-maze/game.js
+++ b/fun-and-games/ball-maze/game.js
@@ -641,10 +641,27 @@
   const appEl = document.getElementById('app');
   let uiAngle = 0; // viewport rotation the fix is currently countering
 
+  // In installed (home-screen) web apps iOS can leave screen.orientation
+  // stuck at its launch value after a rotation, so prefer whichever source
+  // reports a rotation; the deprecated window.orientation still updates
+  // reliably in standalone mode. inferredAngle is a last-resort quarter-turn
+  // deduced from gravity when BOTH report 0 yet the viewport is landscape —
+  // it clears itself as soon as a real source speaks or portrait returns.
+  let inferredAngle = null;
   function orientationAngle() {
-    const a = (screen.orientation && screen.orientation.angle != null)
-      ? screen.orientation.angle
-      : (window.orientation || 0);
+    const so = (screen.orientation && screen.orientation.angle != null)
+      ? screen.orientation.angle : null;
+    const wo = (typeof window.orientation === 'number') ? window.orientation : null;
+    let a = so || wo || 0;
+    if (a === 0) {
+      if (inferredAngle != null && window.innerWidth > window.innerHeight) {
+        a = inferredAngle;
+      } else {
+        inferredAngle = null;
+      }
+    } else {
+      inferredAngle = null;
+    }
     return ((a % 360) + 360) % 360;
   }
 
@@ -740,11 +757,18 @@
     // sideways board for ~100ms). Hold off until the signals agree, then
     // apply layout + transform in one shot. Only portrait-natural devices
     // rotate like this; desktops skip straight through.
-    if (naturalPortrait() && angleLandscape !== viewportLandscape &&
-        agreeRetries < 30) {
-      agreeRetries++;
-      resizeCanvas._t = setTimeout(() => handleViewportChange(true), 50);
-      return;
+    if (naturalPortrait() && angleLandscape !== viewportLandscape) {
+      if (agreeRetries < 12) {
+        agreeRetries++;
+        resizeCanvas._t = setTimeout(() => handleViewportChange(true), 50);
+        return;
+      }
+      if (viewportLandscape) {
+        // No angle source ever spoke (stuck standalone API): deduce the
+        // quarter-turn from gravity — at angle 90 screen-down is -gamma,
+        // so a negative device-x tilt means the device turned to 90.
+        inferredAngle = game.raw.x < 0 ? 90 : 270;
+      }
     }
     agreeRetries = 0;
     if (angle !== uiAngle || orientationEvent) {

--- a/fun-and-games/ball-maze/sw.js
+++ b/fun-and-games/ball-maze/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ball-maze-v9';
+const CACHE_NAME = 'ball-maze-v10';
 const PRECACHE_URLS = [
   './',
   'index.html',


### PR DESCRIPTION
## Summary

Contact-sheet analysis of the third on-device recording — this one from the **installed home-screen app** — showed the board tiny and zoomed-out for ~1.5 s after rotating, which is exactly the length of #319's agreement-poll cap. Diagnosis: in standalone mode iOS can leave `screen.orientation.angle` **stuck at its launch value** after a rotation. The angle and viewport shape therefore never agreed; the gate (correctly) held the old portrait layout, iOS displayed that un-repainted layout scaled down into the landscape viewport (the "tiny board" / zoom effect), and the poll expired just as the user rotated back.

Fixes:
- **Use whichever angle source actually reports a rotation.** The deprecated `window.orientation` still updates reliably in iOS standalone mode; it's now consulted when `screen.orientation.angle` reads 0.
- **Gravity inference as last resort.** If every API is stuck at 0 while the viewport is landscape on a portrait-natural device, infer the quarter-turn from the tilt sensor after a shortened 600 ms cap: at angle 90, screen-down is −gamma, so the sign of the device-x tilt distinguishes landscape-left from landscape-right. The inference clears itself as soon as a real source reports an angle or portrait returns.

SW cache bumped v9 → v10.

## Testing

Headless Chromium, three standalone scenarios simulated: (a) `screen.orientation` stuck + live `window.orientation` → counter-rotation applies immediately from the fallback source; (b) both sources stuck at 0 → gravity inference (negative device-x tilt) counter-rotates to a portrait board after the 600 ms cap; (c) rotating back to portrait clears the inference and transform. Prior stale-signal and rotation guarantees, plus flow/scoring/state suites, all green with zero console errors.

## Preview

Branch preview deploys to Cloudflare Pages — find the `*.pages.dev` URL in the job summary of the latest [Branch Preview workflow run](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5)_