### PR TITLE
Ball Maze: tap the goal disc for a version + orientation debug readout

### DIFF
--- a/fun-and-games/ball-maze/README.md
+++ b/fun-and-games/ball-maze/README.md
@@ -29,6 +29,11 @@ green goal.
   rest are decoys in dead ends. The geometry guarantees the open side is
   always passable, so every maze stays winnable.
 - **Best score** — persisted in `localStorage`.
+- **Version check** — tap the green goal disc to toggle a debug readout in
+  the score slot: game version, the orientation angle currently being
+  countered, and the viewport dimensions (e.g. `v11 a90 844x390`). Tap
+  again to restore the score. Handy for verifying which build an
+  installed copy is actually running.
 - **Continue where you left off** — the run (current level + score) is saved
   to `localStorage` on every score change and level transition. Reopening
   the app offers "Continue · Level N" alongside "Start over"; resuming

--- a/fun-and-games/ball-maze/game.js
+++ b/fun-and-games/ball-maze/game.js
@@ -24,6 +24,7 @@
     return { cols, rows, holes, pathHoles };
   }
   const LEVEL_BONUS = 100;   // × level number on completion
+  const GAME_VERSION = 'v11'; // keep in sync with sw.js CACHE_NAME
   const HOLE_PENALTY = 25;
   const BEST_KEY = 'ball-maze-best';
   const PROGRESS_KEY = 'ball-maze-progress';
@@ -431,9 +432,20 @@
   }
 
   // ---------------------------------------------------------------- scoring
+  // Tapping the goal disc toggles a debug readout in the score slot:
+  // version, the orientation angle being countered, and viewport dims —
+  // enough to verify on-device which build is running and what it sees.
+  let showDebug = false;
+  function renderScore() {
+    scoreEl.textContent = showDebug
+      ? GAME_VERSION + ' a' + uiAngle + ' ' +
+        window.innerWidth + 'x' + window.innerHeight
+      : String(game.score);
+  }
+
   function addScore(points) {
     game.score = Math.max(0, game.score + points);
-    scoreEl.textContent = game.score;
+    renderScore();
     if (game.score > game.best) {
       game.best = game.score;
       bestEl.textContent = game.best;
@@ -623,7 +635,31 @@
     game.raw.x = Math.max(-1, Math.min(1, dx / 90));
     game.raw.y = Math.max(-1, Math.min(1, dy / 90));
   });
-  const endDrag = () => {
+  // map viewport coords back to board-local coords through the
+  // counter-rotation, for hit-testing taps on the board
+  function clientToBoard(cx, cy) {
+    const r = boardWrap.getBoundingClientRect();
+    switch (uiAngle) {
+      case 90: return { x: r.bottom - cy, y: cx - r.left };
+      case 270: return { x: cy - r.top, y: r.right - cx };
+      case 180: return { x: r.right - cx, y: r.bottom - cy };
+      default: return { x: cx - r.left, y: cy - r.top };
+    }
+  }
+
+  const endDrag = (e) => {
+    // a release without movement is a tap; tapping the goal disc toggles
+    // the version/debug readout in the score slot
+    if (dragOrigin && e && game.maze &&
+        Math.hypot(e.clientX - dragOrigin.x, e.clientY - dragOrigin.y) < 12) {
+      const p = clientToBoard(e.clientX, e.clientY);
+      const g = game.maze.goal;
+      const hitR = Math.max(game.maze.cs * 0.6, 24);
+      if (Math.hypot(p.x - g.x, p.y - g.y) < hitR) {
+        showDebug = !showDebug;
+        renderScore();
+      }
+    }
     dragOrigin = null;
     game.raw.x = 0;
     game.raw.y = 0;
@@ -735,6 +771,7 @@
       b.vy *= k;
       b.r = m.cs * BALL_R;
     }
+    renderScore(); // keep the debug readout's angle/dims current
   }
   // A flip must be countered SYNCHRONOUSLY: any delay here splits the
   // rotation into two visible steps (OS animation, then our flip-back).
@@ -809,7 +846,7 @@
     keepAwake();
     tryNativeLock();
     game.score = score;
-    scoreEl.textContent = score;
+    renderScore();
     startLevel(level);
     if (!tiltOk) toast('No tilt sensor — use keys or drag');
   }

--- a/fun-and-games/ball-maze/sw.js
+++ b/fun-and-games/ball-maze/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ball-maze-v10';
+const CACHE_NAME = 'ball-maze-v11';
 const PRECACHE_URLS = [
   './',
   'index.html',


### PR DESCRIPTION
## Summary

Diagnosing the landscape-shrink on-device is ambiguous without knowing which build the installed app is actually running (service-worker update lag means "merged" ≠ "running"). Tapping the **green goal disc** now toggles a debug readout in the score slot:

```
v11 a90 844x390
```

— game version, the orientation angle currently being countered (`a0` = none), and live viewport dimensions. Tap again to restore the score. The readout updates live on rotation, so it doubles as a diagnostic for the shrink itself: if the board shrinks while it still reads `a0` with portrait-shaped dims, the viewport metrics are frozen (iOS scaling the page) rather than our counter-rotation misfiring — the two remaining hypotheses produce visibly different readouts.

Implementation: `GAME_VERSION` constant kept in sync with the SW cache name (v11); the tap is hit-tested through the counter-rotation transform (`clientToBoard`) so it works in any orientation; a release with >12 px of movement is a drag, never a tap.

## Testing

Headless Chromium: goal tap shows `v11 a0 420x800`, second tap restores the numeric score, taps elsewhere and drags over the goal are ignored. Full regression (rotation incl. stuck-API scenarios, flow, scoring, state, smoke) green with zero console errors.

## Preview

Branch preview deploys to Cloudflare Pages — find the `*.pages.dev` URL in the job summary of the latest [Branch Preview workflow run](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5)_