### PR TITLE
Ball Maze: per-level timer with par-based time bonus and penalty

### DIFF
--- a/fun-and-games/ball-maze/README.md
+++ b/fun-and-games/ball-maze/README.md
@@ -22,6 +22,13 @@ green goal.
   path plus 18 decoys).
 - **Level bonus** — completing level *N* awards 100 × *N* points, so the
   stakes keep rising.
+- **Race the clock** — every level has a "par" time that scales with the
+  solution length (0.85 s per solution cell, min 8 s). The HUD timer runs
+  green while you're ahead of par and turns amber once you fall behind.
+  Finish under par for a big bonus (15 points per second saved); finish
+  over par for a small penalty (4 points per second). The penalty is capped
+  at the level's base bonus, so a slow level just means less reward, never a
+  net loss.
 - **Holes** — from level 2 on, holes appear in the board. Roll over one and
   the ball drops in: −25 points and back to the start. Like the physical
   toy, most holes sit **on** the solution path, offset to one side of the

--- a/fun-and-games/ball-maze/game.js
+++ b/fun-and-games/ball-maze/game.js
@@ -24,8 +24,17 @@
     return { cols, rows, holes, pathHoles };
   }
   const LEVEL_BONUS = 100;   // × level number on completion
-  const GAME_VERSION = 'v11'; // keep in sync with sw.js CACHE_NAME
+  const GAME_VERSION = 'v12'; // keep in sync with sw.js CACHE_NAME
   const HOLE_PENALTY = 25;
+
+  // time scoring: each level gets a "par" time based on its solution length.
+  // Finishing under par pays a big bonus (per second saved); finishing over
+  // par costs a small per-second penalty. Par is generous enough that a
+  // clean run beats it, so the bonus is the common case.
+  const PAR_SEC_PER_CELL = 0.85;  // par time = solution-path cells × this
+  const PAR_MIN_SEC = 8;          // floor so tiny early mazes aren't trivial
+  const TIME_BONUS_PER_SEC = 15;  // points per second finished under par
+  const TIME_PENALTY_PER_SEC = 4; // points per second finished over par
   const BEST_KEY = 'ball-maze-best';
   const PROGRESS_KEY = 'ball-maze-progress';
 
@@ -54,6 +63,7 @@
   const boardWrap = document.getElementById('board-wrap');
   const levelEl = document.getElementById('level-value');
   const scoreEl = document.getElementById('score-value');
+  const timeEl = document.getElementById('time-value');
   const bestEl = document.getElementById('best-value');
   const toastEl = document.getElementById('toast');
   const startOverlay = document.getElementById('start-overlay');
@@ -72,6 +82,8 @@
     score: 0,
     best: Number(localStorage.getItem(BEST_KEY)) || 0,
     visited: new Set(),      // cells credited with a distance point this level
+    elapsed: 0,              // seconds spent playing the current level
+    par: 0,                  // par time for the current level, seconds
     maze: null,
     ball: { x: 0, y: 0, vx: 0, vy: 0, r: 0 },
     fall: null,              // { hole, t } during fall animation
@@ -454,6 +466,18 @@
     saveProgress();
   }
 
+  // ---------------------------------------------------------------- timer
+  function formatTime(sec) {
+    const s = Math.max(0, Math.floor(sec));
+    return Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
+  }
+
+  function renderTime() {
+    timeEl.textContent = formatTime(game.elapsed);
+    // amber once the ball is behind par, green while ahead of pace
+    timeEl.classList.toggle('over', game.par > 0 && game.elapsed > game.par);
+  }
+
   // ---------------------------------------------------------------- progress
   // The run (level + score) survives closing the app: saved on every score
   // change and level transition, restored via the Continue button. A resume
@@ -498,6 +522,10 @@
     game.maze = buildLevel(levelIndex);
     game.visited = new Set(['0,0']); // start cell is free, not scored
     game.fall = null;
+    // par scales with the solution length, so bigger mazes get more time
+    game.par = Math.max(PAR_MIN_SEC, game.maze.path.length * PAR_SEC_PER_CELL);
+    game.elapsed = 0;
+    renderTime();
     resetBall();
     levelEl.textContent = String(levelIndex + 1);
     game.state = 'playing';
@@ -514,18 +542,35 @@
 
   function completeLevel() {
     const level = game.level + 1;
-    const bonus = LEVEL_BONUS * level;
-    addScore(bonus);
+    const base = LEVEL_BONUS * level;
+
+    // time result: bonus for beating par, penalty for missing it. The
+    // penalty can't sink the base bonus below zero, so a level never costs
+    // points overall — slow just means less reward.
+    const delta = game.par - game.elapsed;      // + = under par
+    let timePoints;
+    if (delta >= 0) {
+      timePoints = Math.round(delta * TIME_BONUS_PER_SEC);
+    } else {
+      timePoints = -Math.min(base, Math.round(-delta * TIME_PENALTY_PER_SEC));
+    }
+    const gained = base + timePoints;
+    addScore(gained);
     saveProgress(game.level + 1); // quitting at the overlay resumes at next level
     if (navigator.vibrate) navigator.vibrate([30, 40, 30]);
     game.state = 'between';
+
+    const beat = delta >= 0;
+    const timeLine = beat
+      ? 'Beat par by ' + formatTime(delta) + ' — time bonus +' + timePoints + '.'
+      : 'Over par by ' + formatTime(-delta) + ' — time penalty ' + timePoints + '.';
     const milestone = level % 5 === 0;
     showMessage(
       (milestone ? '🏆 ' : '') + 'Level ' + level + ' complete!',
-      '+' + bonus,
-      milestone
-        ? level + ' levels down, ' + game.score + ' points. The mazes keep coming — how far can you get?'
-        : 'Next: a fresh maze, a little meaner.',
+      '+' + gained,
+      timeLine + (milestone
+        ? ' ' + level + ' levels down — how far can you get?'
+        : ''),
       'Level ' + (level + 1),
       () => startLevel(game.level + 1));
   }
@@ -553,6 +598,8 @@
     lastTime = now;
 
     if (game.state === 'playing') {
+      game.elapsed += dt;      // wall-clock while playing (pauses on overlays)
+      renderTime();
       acc += dt;
       while (acc >= STEP) {
         acc -= STEP;

--- a/fun-and-games/ball-maze/index.html
+++ b/fun-and-games/ball-maze/index.html
@@ -74,6 +74,9 @@
     }
     #hud .value { font-size: 1.25rem; font-weight: 600; }
     #hud #score-value { color: #ffd77a; }
+    /* timer is green while under par, amber once the ball is behind pace */
+    #hud #time-value { color: #7ad4a0; }
+    #hud #time-value.over { color: #ff9d8a; }
 
     #board-wrap {
       flex: 1;
@@ -182,6 +185,10 @@
       <div class="stat">
         <div class="label">Score</div>
         <div class="value" id="score-value">0</div>
+      </div>
+      <div class="stat">
+        <div class="label">Time</div>
+        <div class="value" id="time-value">0:00</div>
       </div>
       <div class="stat">
         <div class="label">Best</div>

--- a/fun-and-games/ball-maze/sw.js
+++ b/fun-and-games/ball-maze/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'ball-maze-v11';
+const CACHE_NAME = 'ball-maze-v12';
 const PRECACHE_URLS = [
   './',
   'index.html',


### PR DESCRIPTION
## Summary

Adds a race-the-clock dimension to scoring:

- **Par time per level** — scales with the level's solution length: `0.85 s × solution-path cells`, floored at 8 s so tiny early mazes aren't trivially beatable. Bigger, twistier mazes get proportionally more time.
- **HUD timer** — a new **Time** stat between Score and Best counts up while playing. It runs **green while you're ahead of par** and turns **amber the moment you fall behind**, so par is communicated without a separate target readout.
- **Completion scoring** — on reaching the goal:
  - **Under par → big bonus:** 15 points per second saved.
  - **Over par → small penalty:** 4 points per second, **capped at the level's base bonus** so a slow level just means less reward, never a net loss.
  - The completion overlay states the result, e.g. *"Beat par by 0:12 — time bonus +190."* and the headline figure includes it (`+290` = base 100 + time 190).
- The timer accrues **only while playing**, so it pauses cleanly on overlays and during hole-fall animations, and it survives resize/rotation because par lives on the preserved maze data.

SW cache + `GAME_VERSION` bumped to v12.

## Testing

Headless Chromium (new `test_timer.js`, run 3× for flake-safety): par derives from path length; the HUD ticks and flips to amber past par; an under-par finish pays a positive bonus consistent with the overlay and score; an absurdly-slow finish is capped to a net-zero level gain (never negative); the timer is frozen while the completion overlay is up. Full regression — flow (base bonuses with the timer neutralized), scoring, state, holes, rotation, version-tap, smoke — all green, zero console errors. Screenshot-verified the green HUD timer and the "Beat par" overlay.

## Preview

Branch preview deploys to Cloudflare Pages — find the `*.pages.dev` URL in the job summary of the latest [Branch Preview workflow run](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XChyNAw4SsyTbVBzQh4nG5)_