### PR TITLE
Add Bluesky advanced search URL builder page

### DIFF
--- a/bsky/advanced-search.html
+++ b/bsky/advanced-search.html
@@ -1,0 +1,1114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="ai-disclosure" content="ai-assisted">
+    <meta name="description" content="Build a Bluesky advanced search URL — every operator and filter the Bluesky app supports, assembled into a link. Nothing is searched here; the form just writes the URL.">
+    <title>Bluesky Advanced Search Builder</title>
+    <link rel="icon" href="/images/grouchsky.svg" type="image/svg+xml">
+    <link rel="stylesheet" href="/styles/style.css">
+    <style>
+        html { max-width: 82ch; }
+
+        fieldset {
+            border: 1px solid var(--rule);
+            border-radius: var(--radius);
+            padding: 1em 1.2em 1.2em;
+            margin: 0 0 1.5em;
+            background: var(--surface);
+        }
+
+        legend {
+            font-family: var(--font-display);
+            font-variation-settings: "SOFT" 0, "WONK" 1;
+            font-weight: 700;
+            font-size: 1.05rem;
+            color: var(--grouch);
+            padding: 0 0.4em;
+        }
+
+        .field { margin-bottom: 1em; }
+        .field:last-child { margin-bottom: 0; }
+
+        .field > label,
+        .field > .label {
+            display: block;
+            font-size: 0.85em;
+            font-weight: 500;
+            color: var(--muted);
+            margin-bottom: 0.3em;
+        }
+
+        input[type="text"],
+        input[type="search"],
+        input[type="date"],
+        select {
+            width: 100%;
+            padding: 0.5em 0.6em;
+            font-family: var(--font-body);
+            font-size: 0.95em;
+            color: var(--fg);
+            background: var(--bg);
+            border: 1px solid var(--rule);
+            border-radius: var(--radius);
+        }
+
+        input:focus, select:focus, button:focus-visible {
+            outline: 2px solid var(--grouch);
+            outline-offset: 1px;
+        }
+
+        .hint {
+            font-size: 0.78em;
+            color: var(--muted);
+            margin-top: 0.25em;
+        }
+
+        .hint code { font-size: 0.95em; }
+
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(15ch, 1fr));
+            gap: 1em;
+        }
+
+        /* ── Repeatable filter rows ── */
+        .filter-row {
+            display: grid;
+            grid-template-columns: 8.5em 11em 1fr auto;
+            gap: 0.5em;
+            align-items: center;
+            margin-bottom: 0.5em;
+        }
+
+        .filter-row select { width: 100%; }
+
+        .row-remove {
+            background: none;
+            border: 1px solid var(--rule);
+            border-radius: var(--radius);
+            color: var(--muted);
+            cursor: pointer;
+            font-size: 1em;
+            line-height: 1;
+            padding: 0.45em 0.6em;
+        }
+
+        .row-remove:hover { color: var(--tongue); border-color: var(--tongue); }
+
+        @media (max-width: 34em) {
+            .filter-row {
+                grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+                grid-template-areas:
+                    "mode  field field"
+                    "value value remove";
+                margin-bottom: 0.9em;
+            }
+            .filter-row .f-mode   { grid-area: mode; }
+            .filter-row .f-field  { grid-area: field; }
+            .filter-row .f-value  { grid-area: value; }
+            .filter-row .f-remove { grid-area: remove; }
+        }
+
+        /* ── Buttons ── */
+        button {
+            font-family: var(--font-body);
+            font-size: 0.9em;
+            cursor: pointer;
+        }
+
+        .btn {
+            padding: 0.55em 1.1em;
+            border: 1px solid var(--rule);
+            border-radius: var(--radius);
+            background: var(--surface);
+            color: var(--fg);
+        }
+
+        .btn:hover { border-color: var(--grouch); color: var(--grouch); }
+
+        .btn-primary {
+            background: var(--grouch);
+            border-color: var(--grouch);
+            color: #fff;
+            font-weight: 500;
+        }
+
+        .btn-primary:hover { background: var(--grouch-deep); border-color: var(--grouch-deep); color: #fff; }
+
+        .btn-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.5em;
+            align-items: center;
+        }
+
+        /* ── Output panel ── */
+        #output {
+            background: var(--surface);
+            border: 2px solid var(--grouch);
+            border-radius: var(--radius);
+            padding: 0.9em 1em;
+            margin: 0 0 1em;
+        }
+
+        #url-out {
+            display: block;
+            font-family: var(--font-mono);
+            font-size: 0.8em;
+            line-height: 1.45;
+            background: var(--code-bg);
+            border: 1px solid var(--rule);
+            border-radius: var(--radius);
+            padding: 0.6em 0.7em;
+            margin-bottom: 0.7em;
+            max-height: 7.5em;
+            overflow-y: auto;
+            overflow-wrap: anywhere;
+            word-break: break-all;
+        }
+
+        #url-out.empty { color: var(--muted); font-style: italic; word-break: normal; }
+
+        .style-toggle {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.4em 1.2em;
+            font-size: 0.82em;
+            color: var(--muted);
+            margin-bottom: 0.6em;
+        }
+
+        .style-toggle label { cursor: pointer; }
+        .style-toggle input { margin-right: 0.35em; }
+
+        #warnings {
+            font-size: 0.8em;
+            color: var(--tongue);
+            margin-top: 0.6em;
+        }
+
+        #warnings ul { margin: 0; padding-left: 1.2em; }
+        #warnings:empty { display: none; }
+
+        .status {
+            font-size: 0.8em;
+            color: var(--grouch);
+            margin-left: 0.3em;
+        }
+
+        details {
+            border-top: 1px solid var(--rule);
+            padding-top: 1em;
+            margin-top: 1.5em;
+        }
+
+        summary {
+            cursor: pointer;
+            font-family: var(--font-display);
+            font-weight: 700;
+            color: var(--grouch);
+        }
+
+        .no-auth {
+            font-size: 0.85em;
+            color: var(--muted);
+            border-left: 3px solid var(--grouch);
+            padding-left: 0.9em;
+            margin: 1.2em 0 2em;
+        }
+
+        table td code { white-space: nowrap; }
+    </style>
+</head>
+<body>
+<a href="/bsky/" class="back-link">BSky tools</a>
+
+<h1>Bluesky Advanced Search</h1>
+
+<p>Every filter Bluesky's search supports, in one form. Fill in what you want,
+get the <code>bsky.app/search</code> URL.</p>
+
+<p class="no-auth"><strong>This page searches nothing.</strong> It is a pure URL
+builder — no login, no API calls, no data leaves your browser. It assembles a
+link and hands it to you; Bluesky does the searching when you follow it.</p>
+
+<form id="form" autocomplete="off">
+
+    <fieldset>
+        <legend>Words</legend>
+
+        <div class="field">
+            <label for="f-query">All of these words</label>
+            <input type="text" id="f-query" placeholder="atproto firehose">
+            <div class="hint">Free text. Operators you type here (<code>from:</code>,
+                <code>domain:</code>, <code>#tag</code>&hellip;) are recognised and folded
+                into the fields below when you use <em>Load an existing search</em>.</div>
+        </div>
+
+        <div class="field">
+            <label for="f-exact">This exact phrase</label>
+            <input type="text" id="f-exact" placeholder="machine learning">
+            <div class="hint">Wrapped in quotes for you.</div>
+        </div>
+
+        <div class="field">
+            <label for="f-none">None of these words</label>
+            <input type="text" id="f-none" placeholder="crypto nft">
+            <div class="hint">Space-separated. Each becomes a <code>-word</code> exclusion.</div>
+        </div>
+    </fieldset>
+
+    <fieldset>
+        <legend>Accounts, links &amp; tags</legend>
+
+        <div id="filter-rows"></div>
+
+        <div class="btn-row" style="margin-top:0.7em">
+            <button type="button" class="btn" id="add-filter">+ Add filter</button>
+        </div>
+
+        <div class="hint" style="margin-top:0.7em">
+            Each row takes one or more space-separated values, matched with OR.
+            Add more rows to narrow further. Leading <code>@</code> and <code>#</code>
+            are stripped automatically. <strong>Exclude</strong> rows need the current
+            Bluesky app — they are dropped in classic operator mode.
+        </div>
+    </fieldset>
+
+    <fieldset>
+        <legend>Post attributes</legend>
+
+        <div class="grid">
+            <div class="field">
+                <label for="f-from">Author</label>
+                <select id="f-from">
+                    <option value="anyone">Anyone</option>
+                    <option value="following">People I follow</option>
+                    <option value="me">Me</option>
+                </select>
+                <div class="hint">Needs you signed in to Bluesky.</div>
+            </div>
+
+            <div class="field">
+                <label for="f-replies">Replies</label>
+                <select id="f-replies">
+                    <option value="all">Include replies</option>
+                    <option value="none">Exclude replies</option>
+                    <option value="only">Replies only</option>
+                </select>
+            </div>
+
+            <div class="field">
+                <label for="f-media">Media</label>
+                <select id="f-media">
+                    <option value="all">Any post</option>
+                    <option value="media">Has media</option>
+                    <option value="video">Has video</option>
+                </select>
+            </div>
+
+            <div class="field">
+                <label for="f-lang">Language</label>
+                <select id="f-lang">
+                    <option value="">Any language</option>
+          <option value="ab">Abkhazian</option>
+          <option value="aa">Afar</option>
+          <option value="af">Afrikaans</option>
+          <option value="ak">Akan</option>
+          <option value="sq">Albanian</option>
+          <option value="am">Amharic</option>
+          <option value="ar">Arabic</option>
+          <option value="an">Aragonese</option>
+          <option value="hy">Armenian</option>
+          <option value="as">Assamese</option>
+          <option value="av">Avaric</option>
+          <option value="ae">Avestan</option>
+          <option value="ay">Aymara</option>
+          <option value="az">Azerbaijani</option>
+          <option value="bm">Bambara</option>
+          <option value="bn">Bangla</option>
+          <option value="ba">Bashkir</option>
+          <option value="eu">Basque</option>
+          <option value="be">Belarusian</option>
+          <option value="bh">Bhojpuri</option>
+          <option value="bi">Bislama</option>
+          <option value="bs">Bosnian</option>
+          <option value="br">Breton</option>
+          <option value="bg">Bulgarian</option>
+          <option value="my">Burmese</option>
+          <option value="ca">Catalan</option>
+          <option value="ch">Chamorro</option>
+          <option value="ce">Chechen</option>
+          <option value="zh">Chinese</option>
+          <option value="cu">Church Slavic</option>
+          <option value="cv">Chuvash</option>
+          <option value="kw">Cornish</option>
+          <option value="co">Corsican</option>
+          <option value="cr">Cree</option>
+          <option value="hr">Croatian</option>
+          <option value="cs">Czech</option>
+          <option value="da">Danish</option>
+          <option value="dv">Divehi</option>
+          <option value="nl">Dutch</option>
+          <option value="dz">Dzongkha</option>
+          <option value="en">English</option>
+          <option value="eo">Esperanto</option>
+          <option value="et">Estonian</option>
+          <option value="ee">Ewe</option>
+          <option value="fo">Faroese</option>
+          <option value="fj">Fijian</option>
+          <option value="tl">Filipino</option>
+          <option value="fi">Finnish</option>
+          <option value="fr">French</option>
+          <option value="ff">Fulah</option>
+          <option value="gl">Galician</option>
+          <option value="lg">Ganda</option>
+          <option value="ka">Georgian</option>
+          <option value="de">German</option>
+          <option value="el">Greek</option>
+          <option value="gn">Guarani</option>
+          <option value="gu">Gujarati</option>
+          <option value="ht">Haitian Creole</option>
+          <option value="ha">Hausa</option>
+          <option value="he">Hebrew</option>
+          <option value="hz">Herero</option>
+          <option value="hi">Hindi</option>
+          <option value="ho">Hiri Motu</option>
+          <option value="hu">Hungarian</option>
+          <option value="is">Icelandic</option>
+          <option value="io">Ido</option>
+          <option value="ig">Igbo</option>
+          <option value="id">Indonesian</option>
+          <option value="ia">Interlingua</option>
+          <option value="ie">Interlingue</option>
+          <option value="iu">Inuktitut</option>
+          <option value="ik">Inupiaq</option>
+          <option value="ga">Irish</option>
+          <option value="it">Italian</option>
+          <option value="ja">Japanese</option>
+          <option value="jv">Javanese</option>
+          <option value="kl">Kalaallisut</option>
+          <option value="kn">Kannada</option>
+          <option value="kr">Kanuri</option>
+          <option value="ks">Kashmiri</option>
+          <option value="kk">Kazakh</option>
+          <option value="km">Khmer</option>
+          <option value="ki">Kikuyu; Gikuyu</option>
+          <option value="rw">Kinyarwanda</option>
+          <option value="kv">Komi</option>
+          <option value="kg">Kongo</option>
+          <option value="ko">Korean</option>
+          <option value="kj">Kuanyama; Kwanyama</option>
+          <option value="ku">Kurdish</option>
+          <option value="ky">Kyrgyz</option>
+          <option value="lo">Lao</option>
+          <option value="la">Latin</option>
+          <option value="lv">Latvian</option>
+          <option value="li">Limburgish</option>
+          <option value="ln">Lingala</option>
+          <option value="lt">Lithuanian</option>
+          <option value="lu">Luba-Katanga</option>
+          <option value="lb">Luxembourgish</option>
+          <option value="mk">Macedonian</option>
+          <option value="mg">Malagasy</option>
+          <option value="ms">Malay</option>
+          <option value="ml">Malayalam</option>
+          <option value="mt">Maltese</option>
+          <option value="gv">Manx</option>
+          <option value="mr">Marathi</option>
+          <option value="mh">Marshallese</option>
+          <option value="mn">Mongolian</option>
+          <option value="mi">Māori</option>
+          <option value="na">Nauru</option>
+          <option value="nv">Navajo</option>
+          <option value="ng">Ndonga</option>
+          <option value="ne">Nepali</option>
+          <option value="nd">North Ndebele</option>
+          <option value="se">Northern Sami</option>
+          <option value="no">Norwegian</option>
+          <option value="nb">Norwegian Bokmål</option>
+          <option value="nn">Norwegian Nynorsk</option>
+          <option value="ny">Nyanja</option>
+          <option value="oc">Occitan</option>
+          <option value="or">Odia</option>
+          <option value="oj">Ojibwa</option>
+          <option value="om">Oromo</option>
+          <option value="os">Ossetic</option>
+          <option value="pi">Pali</option>
+          <option value="ps">Pashto</option>
+          <option value="fa">Persian</option>
+          <option value="pl">Polish</option>
+          <option value="pt">Portuguese</option>
+          <option value="pa">Punjabi</option>
+          <option value="qu">Quechua</option>
+          <option value="ro">Romanian</option>
+          <option value="rm">Romansh</option>
+          <option value="rn">Rundi</option>
+          <option value="ru">Russian</option>
+          <option value="sm">Samoan</option>
+          <option value="sg">Sango</option>
+          <option value="sa">Sanskrit</option>
+          <option value="sc">Sardinian</option>
+          <option value="gd">Scottish Gaelic</option>
+          <option value="sr">Serbian</option>
+          <option value="sn">Shona</option>
+          <option value="ii">Sichuan Yi; Nuosu</option>
+          <option value="sd">Sindhi</option>
+          <option value="si">Sinhala</option>
+          <option value="sk">Slovak</option>
+          <option value="sl">Slovenian</option>
+          <option value="so">Somali</option>
+          <option value="nr">South Ndebele</option>
+          <option value="st">Southern Sotho</option>
+          <option value="es">Spanish</option>
+          <option value="su">Sundanese</option>
+          <option value="sw">Swahili</option>
+          <option value="ss">Swati</option>
+          <option value="sv">Swedish</option>
+          <option value="ty">Tahitian</option>
+          <option value="tg">Tajik</option>
+          <option value="ta">Tamil</option>
+          <option value="tt">Tatar</option>
+          <option value="te">Telugu</option>
+          <option value="th">Thai</option>
+          <option value="bo">Tibetan</option>
+          <option value="ti">Tigrinya</option>
+          <option value="to">Tongan</option>
+          <option value="ts">Tsonga</option>
+          <option value="tn">Tswana</option>
+          <option value="tr">Turkish</option>
+          <option value="tk">Turkmen</option>
+          <option value="uk">Ukrainian</option>
+          <option value="ur">Urdu</option>
+          <option value="ug">Uyghur</option>
+          <option value="uz">Uzbek</option>
+          <option value="ve">Venda</option>
+          <option value="vi">Vietnamese</option>
+          <option value="vo">Volapük</option>
+          <option value="wa">Walloon</option>
+          <option value="cy">Welsh</option>
+          <option value="fy">Western Frisian</option>
+          <option value="wo">Wolof</option>
+          <option value="xh">Xhosa</option>
+          <option value="yi">Yiddish</option>
+          <option value="yo">Yoruba</option>
+          <option value="za">Zhuang; Chuang</option>
+          <option value="zu">Zulu</option>
+                </select>
+            </div>
+
+            <div class="field">
+                <label for="f-since">Since</label>
+                <input type="date" id="f-since">
+            </div>
+
+            <div class="field">
+                <label for="f-until">Until</label>
+                <input type="date" id="f-until">
+            </div>
+        </div>
+
+        <div class="hint" style="margin-top:0.8em">
+            Dates filter on Bluesky's index timestamp, which can differ slightly
+            from a post's <code>createdAt</code>. <code>Since</code> is inclusive,
+            <code>Until</code> is not.
+        </div>
+    </fieldset>
+
+</form>
+
+<div id="output">
+    <div class="style-toggle" role="radiogroup" aria-label="URL style">
+        <label><input type="radio" name="urlstyle" value="params" checked> Structured params <span title="Current Bluesky app: filters ride as their own query params.">(current app)</span></label>
+        <label><input type="radio" name="urlstyle" value="operators"> Query operators <span title="Everything packed into q= using search operators. Fewer filters, but paste-able into the Bluesky search box.">(classic)</span></label>
+    </div>
+
+    <code id="url-out" class="empty">Fill in a field to build a search URL.</code>
+
+    <div class="btn-row">
+        <button type="button" class="btn btn-primary" id="go">Search on Bluesky</button>
+        <button type="button" class="btn" id="copy-url">Copy URL</button>
+        <button type="button" class="btn" id="copy-q">Copy query text</button>
+        <button type="button" class="btn" id="reset">Reset</button>
+        <span class="status" id="status" role="status" aria-live="polite"></span>
+    </div>
+
+    <div id="warnings"></div>
+</div>
+
+<details>
+    <summary>Load an existing search</summary>
+    <div class="field" style="margin-top:0.8em">
+        <label for="f-import">Paste a <code>bsky.app/search</code> URL or a raw query string</label>
+        <input type="text" id="f-import" placeholder="https://bsky.app/search?q=%22atproto%22&amp;author=austegard.com">
+        <div class="hint">Structured params and query operators are both understood; the
+            form fills in from whichever it finds.</div>
+    </div>
+    <div class="btn-row">
+        <button type="button" class="btn" id="import-go">Load into form</button>
+    </div>
+</details>
+
+<details>
+    <summary>Operator &amp; parameter reference</summary>
+
+    <p>Bluesky's search takes free text in <code>q</code> plus structured filter
+    params alongside it. The classic operators still work inside <code>q</code>
+    and are merged with the params, so a URL can carry either or both.</p>
+
+    <h3>Inside <code>q</code></h3>
+    <table>
+        <tr><th>Syntax</th><th>Effect</th></tr>
+        <tr><td><code>"exact phrase"</code></td><td>Phrase match</td></tr>
+        <tr><td><code>-word</code></td><td>Exclude a word</td></tr>
+        <tr><td><code>(a OR b)</code></td><td>Alternation group</td></tr>
+        <tr><td><code>#tag</code></td><td>Hashtag</td></tr>
+        <tr><td><code>from:handle</code>, <code>from:me</code></td><td>Author</td></tr>
+        <tr><td><code>mentions:handle</code>, <code>to:handle</code></td><td>Mentions an account</td></tr>
+        <tr><td><code>domain:example.com</code></td><td>Links to a domain</td></tr>
+        <tr><td><code>url:https://&hellip;</code></td><td>Links to a URL</td></tr>
+        <tr><td><code>lang:en</code></td><td>Post language (ISO 639-1)</td></tr>
+        <tr><td><code>since:2026-01-01</code> / <code>until:</code></td><td>Date range</td></tr>
+    </table>
+
+    <h3>Sibling params on <code>/search</code></h3>
+    <table>
+        <tr><th>Param</th><th>Value</th></tr>
+        <tr><td><code>author</code>, <code>mentions</code>, <code>domain</code>, <code>url</code>, <code>tag</code></td><td>Space-separated list, OR-matched</td></tr>
+        <tr><td><code>excludeAuthor</code>, <code>excludeMentions</code>, <code>excludeDomain</code>, <code>excludeUrl</code>, <code>excludeTag</code></td><td>Same, negated</td></tr>
+        <tr><td><code>lang</code></td><td>ISO 639-1 code</td></tr>
+        <tr><td><code>since</code>, <code>until</code></td><td><code>YYYY-MM-DD</code></td></tr>
+        <tr><td><code>replies</code></td><td><code>none</code> or <code>only</code></td></tr>
+        <tr><td><code>media</code>, <code>video</code>, <code>following</code></td><td><code>true</code></td></tr>
+        <tr><td><code>from</code></td><td><code>me</code></td></tr>
+    </table>
+
+    <p class="hint">The exclude, replies, media, video and following filters have no
+    operator equivalent — they exist only as params. Older Bluesky clients that
+    only read <code>q</code> will ignore them.</p>
+</details>
+
+<footer>
+    <p>Companion to the <a href="https://github.com/oaustegard/bookmarklets/blob/main/bsky_advanced_search_README.md">BlueSky Advanced Search bookmarklet</a>,
+    which does the same thing as an overlay on bsky.app.
+    <a href="advanced-search_README.md">README</a> &middot;
+    <a href="/bsky/">More BSky tools</a></p>
+</footer>
+
+<script>
+(function () {
+    'use strict';
+
+    /* ── Field definitions ───────────────────────────────────────────────
+       Mirrors the Bluesky app's advanced-search serialization: each field
+       maps to an include param and an exclude sibling, plus the classic
+       operator it corresponds to (null = hashtag, written as #value).     */
+    var FIELDS = [
+        {key: 'authors',  label: 'From account',  include: 'author',   exclude: 'excludeAuthor',   marker: '@', op: 'from'},
+        {key: 'mentions', label: 'Mentions',      include: 'mentions', exclude: 'excludeMentions', marker: '@', op: 'mentions'},
+        {key: 'domains',  label: 'Links domain',  include: 'domain',   exclude: 'excludeDomain',   marker: '',  op: 'domain'},
+        {key: 'urls',     label: 'Links URL',     include: 'url',      exclude: 'excludeUrl',      marker: '',  op: 'url'},
+        {key: 'tags',     label: 'Hashtag',       include: 'tag',      exclude: 'excludeTag',      marker: '#', op: null}
+    ];
+
+    var FIELD_BY_KEY = {};
+    FIELDS.forEach(function (f) { FIELD_BY_KEY[f.key] = f; });
+
+    var FILTER_PARAM_KEYS = ['author', 'mentions', 'domain', 'url', 'tag',
+        'excludeAuthor', 'excludeMentions', 'excludeDomain', 'excludeUrl', 'excludeTag',
+        'lang', 'since', 'until', 'replies', 'media', 'video', 'following', 'from'];
+
+    var PLACEHOLDERS = {
+        authors: 'austegard.com', mentions: 'bsky.team', domains: 'npr.org',
+        urls: 'https://example.com/article', tags: 'atproto'
+    };
+
+    var DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+    var WS = /\s+/;
+
+    var $ = function (id) { return document.getElementById(id); };
+    var rowsEl = $('filter-rows');
+    var nextRowId = 0;
+
+    /* ── Query tokenizer ─────────────────────────────────────────────────
+       Keeps "quoted phrases" and (parenthesised OR groups) intact so they
+       survive a round-trip through the form untouched.                    */
+    function tokenize(raw) {
+        var tokens = [], i = 0, n = raw.length;
+        while (i < n) {
+            if (/\s/.test(raw[i])) { i++; continue; }
+            var start = i;
+            if (raw[i] === '(') {
+                var depth = 0;
+                while (i < n) {
+                    if (raw[i] === '(') depth++;
+                    else if (raw[i] === ')') { depth--; if (depth === 0) { i++; break; } }
+                    i++;
+                }
+                tokens.push(raw.slice(start, i));
+                continue;
+            }
+            var buf = '';
+            while (i < n && !/\s/.test(raw[i]) && raw[i] !== '(') {
+                if (raw[i] === '"') {
+                    buf += raw[i++];
+                    while (i < n && raw[i] !== '"') buf += raw[i++];
+                    if (i < n) buf += raw[i++];
+                } else {
+                    buf += raw[i++];
+                }
+            }
+            if (buf) tokens.push(buf);
+        }
+        return tokens;
+    }
+
+    function isSimpleWord(w) { return w.length > 0 && w.indexOf('"') === -1; }
+
+    function splitValues(raw, marker) {
+        return String(raw || '').trim().split(WS).filter(Boolean).map(function (v) {
+            return marker && v.charAt(0) === marker ? v.slice(1) : v;
+        }).filter(Boolean);
+    }
+
+    /* ── Filter rows ─────────────────────────────────────────────────── */
+    function addRow(field, mode, value) {
+        var id = 'row-' + (nextRowId++);
+        var row = document.createElement('div');
+        row.className = 'filter-row';
+        row.dataset.rowId = id;
+
+        var modeSel = document.createElement('select');
+        modeSel.className = 'f-mode';
+        modeSel.setAttribute('aria-label', 'Include or exclude');
+        [['include', 'Include'], ['exclude', 'Exclude']].forEach(function (o) {
+            modeSel.add(new Option(o[1], o[0]));
+        });
+        modeSel.value = mode || 'include';
+
+        var fieldSel = document.createElement('select');
+        fieldSel.className = 'f-field';
+        fieldSel.setAttribute('aria-label', 'Filter field');
+        FIELDS.forEach(function (f) { fieldSel.add(new Option(f.label, f.key)); });
+        fieldSel.value = field || 'authors';
+
+        var input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'f-value';
+        input.setAttribute('aria-label', 'Filter values');
+        input.value = value || '';
+        input.placeholder = PLACEHOLDERS[fieldSel.value] || '';
+        fieldSel.addEventListener('change', function () {
+            input.placeholder = PLACEHOLDERS[fieldSel.value] || '';
+        });
+
+        var remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'row-remove f-remove';
+        remove.title = 'Remove this filter';
+        remove.setAttribute('aria-label', 'Remove this filter');
+        remove.textContent = '×';
+        remove.addEventListener('click', function () { row.remove(); render(); });
+
+        row.appendChild(modeSel);
+        row.appendChild(fieldSel);
+        row.appendChild(input);
+        row.appendChild(remove);
+        rowsEl.appendChild(row);
+        return row;
+    }
+
+    function readRows() {
+        return Array.prototype.map.call(rowsEl.children, function (row) {
+            var sels = row.getElementsByTagName('select');
+            return {
+                mode: sels[0].value,
+                field: sels[1].value,
+                value: row.getElementsByTagName('input')[0].value
+            };
+        });
+    }
+
+    function ensureBlankRow() {
+        if (!rowsEl.children.length) addRow('authors', 'include', '');
+    }
+
+    /* ── Read the form ───────────────────────────────────────────────── */
+    function readState() {
+        return {
+            query: $('f-query').value,
+            exactPhrase: $('f-exact').value,
+            negatedWords: $('f-none').value,
+            lang: $('f-lang').value,
+            replies: $('f-replies').value,
+            media: $('f-media').value,
+            from: $('f-from').value,
+            since: $('f-since').value,
+            until: $('f-until').value,
+            rows: readRows()
+        };
+    }
+
+    /* ── Serialize: state -> {q, filters} ────────────────────────────────
+       Same shape the Bluesky app produces when it shares a search link.   */
+    function serialize(state) {
+        var parts = [];
+
+        if (state.query.trim()) parts.push(state.query.trim());
+
+        var exact = state.exactPhrase.trim();
+        if (exact) parts.push(exact.indexOf('"') !== -1 ? exact : '"' + exact + '"');
+
+        state.negatedWords.trim().split(WS).forEach(function (word) {
+            if (!word) return;
+            var bare = word.replace(/^-+/, '');
+            parts.push(isSimpleWord(bare) ? '-' + bare : word);
+        });
+
+        var filters = {};
+        var byKey = {};
+
+        state.rows.forEach(function (row) {
+            var field = FIELD_BY_KEY[row.field];
+            if (!field) return;
+            var values = splitValues(row.value, field.marker);
+            if (!values.length) return;
+            var key = row.mode === 'exclude' ? field.exclude : field.include;
+            var set = byKey[key] || (byKey[key] = []);
+            values.forEach(function (v) { if (set.indexOf(v) === -1) set.push(v); });
+        });
+
+        Object.keys(byKey).forEach(function (key) { filters[key] = byKey[key].join(' '); });
+
+        if (state.lang) filters.lang = state.lang;
+        if (DATE_RE.test(state.since)) filters.since = state.since;
+        if (DATE_RE.test(state.until)) filters.until = state.until;
+        if (state.replies === 'none' || state.replies === 'only') filters.replies = state.replies;
+        if (state.media === 'media') filters.media = 'true';
+        else if (state.media === 'video') filters.video = 'true';
+
+        /* A `from:me` typed straight into the query box is promoted to the
+           structured filter, exactly as the app's dialog does on submit. */
+        var kept = tokenize(parts.join(' ')).filter(function (t) { return t !== 'from:me'; });
+        var fromMe = kept.length !== tokenize(parts.join(' ')).length;
+
+        if (state.from === 'following') filters.following = 'true';
+        else if (state.from === 'me' || fromMe) filters.from = 'me';
+
+        return {q: kept.join(' '), filters: filters};
+    }
+
+    /* ── Classic operator form ───────────────────────────────────────────
+       Packs everything expressible into a single q= string. Returns the
+       query text plus a list of filters that could not survive.           */
+    function toOperatorQuery(q, filters) {
+        var parts = q ? [q] : [];
+        var dropped = [];
+
+        FIELDS.forEach(function (f) {
+            var raw = filters[f.include];
+            if (raw) {
+                var values = raw.split(WS).filter(Boolean);
+                if (values.length > 1 && f.op) {
+                    dropped.push('multiple ' + f.label.toLowerCase() +
+                        ' values — older clients honour only the first');
+                }
+                values.forEach(function (v) {
+                    parts.push(f.op ? f.op + ':' + v : '#' + v);
+                });
+            }
+            if (filters[f.exclude]) dropped.push('exclude ' + f.label.toLowerCase());
+        });
+
+        if (filters.lang) parts.push('lang:' + filters.lang);
+        if (filters.since) parts.push('since:' + filters.since);
+        if (filters.until) parts.push('until:' + filters.until);
+        if (filters.from === 'me') parts.push('from:me');
+
+        if (filters.replies === 'none') dropped.push('exclude replies');
+        if (filters.replies === 'only') dropped.push('replies only');
+        if (filters.media === 'true') dropped.push('has media');
+        if (filters.video === 'true') dropped.push('has video');
+        if (filters.following === 'true') dropped.push('from people I follow');
+
+        return {q: parts.join(' '), dropped: dropped};
+    }
+
+    /* ── Build the URL ───────────────────────────────────────────────── */
+    function currentStyle() {
+        var checked = document.querySelector('input[name="urlstyle"]:checked');
+        return checked ? checked.value : 'params';
+    }
+
+    function build() {
+        var out = serialize(readState());
+        var style = currentStyle();
+        var url = new URL('https://bsky.app/search');
+        var dropped = [];
+        var queryText;
+
+        if (style === 'operators') {
+            var flat = toOperatorQuery(out.q, out.filters);
+            queryText = flat.q;
+            dropped = flat.dropped;
+            if (queryText) url.searchParams.set('q', queryText);
+        } else {
+            queryText = out.q;
+            if (out.q) url.searchParams.set('q', out.q);
+            FILTER_PARAM_KEYS.forEach(function (key) {
+                if (out.filters[key]) url.searchParams.set(key, out.filters[key]);
+            });
+        }
+
+        var empty = !url.search;
+        return {
+            url: url.toString(),
+            queryText: queryText,
+            empty: empty,
+            dropped: dropped
+        };
+    }
+
+    /* ── Permalink back to this form ─────────────────────────────────── */
+    function updatePermalink(result) {
+        var here = new URL(window.location.href);
+        here.search = result.empty ? '' : new URL(result.url).search;
+        window.history.replaceState(null, '', here.toString());
+    }
+
+    var latest = {url: '', queryText: '', empty: true, dropped: []};
+
+    function render() {
+        latest = build();
+        var outEl = $('url-out');
+
+        if (latest.empty) {
+            outEl.textContent = 'Fill in a field to build a search URL.';
+            outEl.classList.add('empty');
+        } else {
+            outEl.textContent = latest.url;
+            outEl.classList.remove('empty');
+        }
+
+        var warn = $('warnings');
+        if (latest.dropped.length) {
+            warn.innerHTML = '<strong>Not representable as operators:</strong><ul>' +
+                latest.dropped.map(function (d) {
+                    return '<li>' + d.replace(/[<>&]/g, '') + '</li>';
+                }).join('') + '</ul>';
+        } else {
+            warn.innerHTML = '';
+        }
+
+        updatePermalink(latest);
+    }
+
+    /* ── Hydrate the form from params ────────────────────────────────── */
+    function extractOperators(raw) {
+        /* Lifts the operators the app recognises out of free text, leaving
+           everything else (phrases, OR groups, negations) in place. */
+        var lifted = {tags: []}, remaining = [];
+
+        tokenize(raw).forEach(function (token) {
+            if (token.charAt(0) === '#' && token.length > 1 && token.indexOf(':') === -1) {
+                lifted.tags.push(token.slice(1));
+                return;
+            }
+            var idx = token.indexOf(':');
+            if (idx === -1) { remaining.push(token); return; }
+
+            var op = token.slice(0, idx), value = token.slice(idx + 1);
+            if (!value) { remaining.push(token); return; }
+            var handle = value.charAt(0) === '@' ? value.slice(1) : value;
+
+            switch (op) {
+                case 'from':
+                    if (value === 'me') remaining.push(token);
+                    else if (!lifted.author) lifted.author = handle;
+                    break;
+                case 'to':
+                case 'mentions':
+                    if (value === 'me') remaining.push(token);
+                    else if (!lifted.mentions) lifted.mentions = handle;
+                    break;
+                case 'domain': if (!lifted.domain) lifted.domain = value; break;
+                case 'url': if (!lifted.url) lifted.url = value; break;
+                case 'lang': if (!lifted.lang) lifted.lang = value; break;
+                case 'since':
+                    if (DATE_RE.test(value) && !lifted.since) lifted.since = value;
+                    else remaining.push(token);
+                    break;
+                case 'until':
+                    if (DATE_RE.test(value) && !lifted.until) lifted.until = value;
+                    else remaining.push(token);
+                    break;
+                default: remaining.push(token);
+            }
+        });
+
+        lifted.rest = remaining.join(' ');
+        return lifted;
+    }
+
+    function parseFreeText(raw) {
+        var queryParts = [], negated = [], exact = '', fromMe = false;
+
+        tokenize(raw).forEach(function (token) {
+            if (token === 'from:me') { fromMe = true; return; }
+            if (token.charAt(0) === '"' && token.slice(-1) === '"' && token.length > 1) {
+                var inner = token.slice(1, -1);
+                if (inner.indexOf('"') === -1) { exact = inner; return; }
+            }
+            if (token.charAt(0) === '-' && token.length > 1 && token.indexOf(':') === -1) {
+                var word = token.slice(1);
+                if (isSimpleWord(word)) { negated.push(word); return; }
+            }
+            queryParts.push(token);
+        });
+
+        return {
+            query: queryParts.join(' '),
+            exactPhrase: exact,
+            negatedWords: negated.join(' '),
+            fromMe: fromMe
+        };
+    }
+
+    function mergeValues(a, b) {
+        var seen = [];
+        (String(a || '') + ' ' + String(b || '')).split(WS).forEach(function (p) {
+            if (p && seen.indexOf(p) === -1) seen.push(p);
+        });
+        return seen.join(' ');
+    }
+
+    function hydrate(params) {
+        var lifted = extractOperators(params.get('q') || '');
+        var free = parseFreeText(lifted.rest);
+
+        $('f-query').value = free.query;
+        $('f-exact').value = free.exactPhrase;
+        $('f-none').value = free.negatedWords;
+
+        rowsEl.innerHTML = '';
+        var liftedByKey = {
+            authors: lifted.author, mentions: lifted.mentions, domains: lifted.domain,
+            urls: lifted.url, tags: lifted.tags.join(' ')
+        };
+
+        FIELDS.forEach(function (f) {
+            var include = mergeValues(params.get(f.include), liftedByKey[f.key]);
+            if (include) addRow(f.key, 'include', include);
+            var exclude = params.get(f.exclude);
+            if (exclude) addRow(f.key, 'exclude', exclude);
+        });
+        ensureBlankRow();
+
+        $('f-lang').value = params.get('lang') || lifted.lang || '';
+        var since = params.get('since') || lifted.since || '';
+        var until = params.get('until') || lifted.until || '';
+        $('f-since').value = DATE_RE.test(since) ? since : '';
+        $('f-until').value = DATE_RE.test(until) ? until : '';
+
+        var replies = params.get('replies');
+        $('f-replies').value = (replies === 'none' || replies === 'only') ? replies : 'all';
+
+        $('f-media').value = params.get('media') === 'true' ? 'media'
+            : params.get('video') === 'true' ? 'video' : 'all';
+
+        $('f-from').value = (free.fromMe || params.get('from') === 'me') ? 'me'
+            : params.get('following') === 'true' ? 'following' : 'anyone';
+
+        render();
+    }
+
+    /* ── Actions ─────────────────────────────────────────────────────── */
+    function flash(message) {
+        var el = $('status');
+        el.textContent = message;
+        window.setTimeout(function () { el.textContent = ''; }, 2000);
+    }
+
+    function copy(text, label) {
+        if (!text) { flash('Nothing to copy'); return; }
+        var done = function () { flash(label + ' copied'); };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done, function () { flash('Copy failed'); });
+        } else {
+            var ta = document.createElement('textarea');
+            ta.value = text;
+            document.body.appendChild(ta);
+            ta.select();
+            try { document.execCommand('copy'); done(); } catch (e) { flash('Copy failed'); }
+            ta.remove();
+        }
+    }
+
+    $('add-filter').addEventListener('click', function () {
+        var row = addRow('authors', 'include', '');
+        row.getElementsByTagName('input')[0].focus();
+        render();
+    });
+
+    $('go').addEventListener('click', function () {
+        if (latest.empty) { flash('Nothing to search yet'); return; }
+        window.open(latest.url, '_blank', 'noopener');
+    });
+
+    $('copy-url').addEventListener('click', function () {
+        copy(latest.empty ? '' : latest.url, 'URL');
+    });
+
+    $('copy-q').addEventListener('click', function () {
+        copy(latest.queryText, 'Query');
+    });
+
+    $('reset').addEventListener('click', function () {
+        $('form').reset();
+        rowsEl.innerHTML = '';
+        ensureBlankRow();
+        render();
+        flash('Cleared');
+    });
+
+    $('import-go').addEventListener('click', function () {
+        var raw = $('f-import').value.trim();
+        if (!raw) return;
+        var params;
+        try {
+            params = new URL(raw, 'https://bsky.app').searchParams;
+        } catch (e) {
+            params = new URLSearchParams();
+        }
+        /* A bare query string with no recognised params is treated as q. */
+        var recognised = params.get('q') !== null || FILTER_PARAM_KEYS.some(function (k) {
+            return params.get(k) !== null;
+        });
+        if (!recognised) {
+            params = new URLSearchParams();
+            params.set('q', raw);
+        }
+        hydrate(params);
+        flash('Loaded');
+    });
+
+    $('form').addEventListener('input', render);
+    $('form').addEventListener('change', render);
+    Array.prototype.forEach.call(document.getElementsByName('urlstyle'), function (radio) {
+        radio.addEventListener('change', render);
+    });
+
+    /* Submitting the form (Enter in a text field) runs the search. */
+    $('form').addEventListener('submit', function (event) {
+        event.preventDefault();
+        $('go').click();
+    });
+
+    /* Boot: the page's own query string doubles as a permalink. */
+    hydrate(new URLSearchParams(window.location.search));
+})();
+</script>
+</body>
+</html>

--- a/bsky/advanced-search_README.md
+++ b/bsky/advanced-search_README.md
@@ -1,0 +1,129 @@
+# Bluesky Advanced Search
+
+[advanced-search.html](https://austegard.com/bsky/advanced-search.html) — a form
+that builds a `bsky.app/search` URL.
+
+The standalone counterpart to the
+[BlueSky Advanced Search bookmarklet](https://github.com/oaustegard/bookmarklets/blob/main/bsky_advanced_search_README.md),
+which does the same job as an overlay injected into bsky.app. This page needs no
+bookmarklet, no extension, and no bookmarks bar — it is just a page.
+
+## It searches nothing
+
+The page is a pure URL builder. No login, no OAuth, no app password, no API
+calls, no analytics. Everything happens in the browser: you fill in fields, it
+assembles a link, you follow the link, and Bluesky does the searching. Nothing
+you type leaves the page until you click through.
+
+## What it covers
+
+Bluesky's search takes free text in `q` plus a set of structured filter params
+alongside it. The form writes both.
+
+### Words → `q`
+
+| Field | Produces |
+|---|---|
+| All of these words | free text, verbatim |
+| This exact phrase | `"phrase"` |
+| None of these words | `-word` per term |
+
+Quoted phrases and `(a OR b)` groups typed into the first field pass through
+untouched — the tokenizer keeps them intact rather than splitting on their
+spaces.
+
+### Accounts, links & tags → sibling params
+
+Repeatable rows. Each row picks a field, an include/exclude mode, and one or
+more space-separated values (OR-matched within a row). Rows of the same field
+and mode merge and dedupe.
+
+| Row field | Include param | Exclude param |
+|---|---|---|
+| From account | `author` | `excludeAuthor` |
+| Mentions | `mentions` | `excludeMentions` |
+| Links domain | `domain` | `excludeDomain` |
+| Links URL | `url` | `excludeUrl` |
+| Hashtag | `tag` | `excludeTag` |
+
+A leading `@` on handles and `#` on tags is stripped — the params want the bare
+value, and passing the marker through makes the appview 400.
+
+### Post attributes
+
+| Control | Produces |
+|---|---|
+| Author: People I follow | `following=true` |
+| Author: Me | `from=me` |
+| Replies: Exclude / Only | `replies=none` / `replies=only` |
+| Media: Has media | `media=true` |
+| Media: Has video | `video=true` |
+| Language | `lang=<ISO 639-1>` |
+| Since / Until | `since=` / `until=` (`YYYY-MM-DD`) |
+
+`following` and `from=me` only mean anything when you are signed in to Bluesky
+in the browser you open the link in.
+
+Dates filter on Bluesky's *index* timestamp, which can drift from a post's
+`createdAt`. `since` is inclusive; `until` is not.
+
+## Two URL styles
+
+**Structured params (default)** — what the Bluesky app itself produces when you
+share a search from its advanced-search dialog:
+
+```
+https://bsky.app/search?q=%22atproto%22+-spam&author=austegard.com&excludeDomain=example.com&tag=bsky&lang=en&replies=none
+```
+
+**Query operators (classic)** — everything packed into a single `q=`, using the
+operator syntax that predates the params:
+
+```
+https://bsky.app/search?q=%22atproto%22+-spam+from%3Aaustegard.com+%23bsky+lang%3Aen
+```
+
+The classic form is paste-able straight into Bluesky's own search box, and works
+in older clients that only read `q`. It cannot express the exclude filters, the
+replies filter, media, video, or following — the page lists exactly what it had
+to drop when you switch modes. Multi-value fields also degrade: an older client
+honours only the first `from:`/`domain:`/`url:` it sees.
+
+The two are not mutually exclusive in Bluesky itself: operators found in `q` are
+merged with the sibling params rather than overriding them. The toggle just
+picks which of the two the page writes.
+
+## Round-tripping
+
+**Load an existing search** takes a `bsky.app/search` URL — or a bare query
+string — and fills the form from it. Structured params and query operators are
+both understood, so a link shared from the Bluesky app and one typed by hand
+both load.
+
+The page also mirrors the search it built into its own address bar, so any
+configured form is bookmarkable and shareable. Reloading such a link restores
+every field.
+
+## Operator reference
+
+Inside `q`:
+
+| Syntax | Effect |
+|---|---|
+| `"exact phrase"` | phrase match |
+| `-word` | exclude a word |
+| `(a OR b)` | alternation group |
+| `#tag` | hashtag |
+| `from:handle`, `from:me` | author |
+| `mentions:handle`, `to:handle` | mentions an account |
+| `domain:example.com` | links to a domain |
+| `url:https://…` | links to a URL |
+| `lang:en` | post language |
+| `since:2026-01-01`, `until:…` | date range |
+
+The exclude/replies/media/video/following filters exist only as params — there
+is no operator spelling for them.
+
+## Author
+
+Concept and edits by [Oskar Austegard](https://austegard.com). Code by Claude.

--- a/tests/bsky-advanced-search.spec.js
+++ b/tests/bsky-advanced-search.spec.js
@@ -22,6 +22,22 @@ async function setRow(page, index, { mode, field, value }) {
 }
 
 test.describe('Bluesky advanced search builder', () => {
+  /*
+   * The page is entirely local, but the shared stylesheet @imports Google
+   * Fonts — a render-blocking third-party request that lands in the load
+   * event. Sandboxed CI has no egress to it and stalls ~12s per navigation.
+   * Cutting off every non-local request keeps these tests hermetic and fast;
+   * nothing under test depends on the network.
+   */
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/*', route => {
+      const host = new URL(route.request().url()).hostname;
+      return (host === 'localhost' || host === '127.0.0.1')
+        ? route.continue()
+        : route.abort();
+    });
+  });
+
   test('starts empty and offers no URL', async ({ page }) => {
     await page.goto(PAGE);
     await expect(page.locator('#url-out')).toHaveClass(/empty/);

--- a/tests/bsky-advanced-search.spec.js
+++ b/tests/bsky-advanced-search.spec.js
@@ -1,0 +1,213 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const PAGE = '/bsky/advanced-search.html';
+
+/** Reads the built URL out of the sticky output panel. */
+async function builtUrl(page) {
+  return (await page.locator('#url-out').textContent()) || '';
+}
+
+/** Parses the built URL into a {pathname, params} shape for assertions. */
+async function builtParams(page) {
+  const url = new URL(await builtUrl(page));
+  return Object.fromEntries(url.searchParams.entries());
+}
+
+async function setRow(page, index, { mode, field, value }) {
+  const row = page.locator('.filter-row').nth(index);
+  if (mode) await row.locator('select').nth(0).selectOption(mode);
+  if (field) await row.locator('select').nth(1).selectOption(field);
+  if (value !== undefined) await row.locator('input').fill(value);
+}
+
+test.describe('Bluesky advanced search builder', () => {
+  test('starts empty and offers no URL', async ({ page }) => {
+    await page.goto(PAGE);
+    await expect(page.locator('#url-out')).toHaveClass(/empty/);
+    await expect(page.locator('.filter-row')).toHaveCount(1);
+  });
+
+  test('builds free-text q with phrase and negation', async ({ page }) => {
+    await page.goto(PAGE);
+    await page.fill('#f-query', 'atproto firehose');
+    await page.fill('#f-exact', 'machine learning');
+    await page.fill('#f-none', 'crypto nft');
+
+    const params = await builtParams(page);
+    expect(params.q).toBe('atproto firehose "machine learning" -crypto -nft');
+  });
+
+  test('emits structured sibling params for filter rows', async ({ page }) => {
+    await page.goto(PAGE);
+    await page.fill('#f-query', 'claude');
+    await setRow(page, 0, { field: 'authors', value: '@austegard.com' });
+    await page.click('#add-filter');
+    await setRow(page, 1, { mode: 'exclude', field: 'domains', value: 'example.com' });
+    await page.click('#add-filter');
+    await setRow(page, 2, { field: 'tags', value: '#atproto #bsky' });
+
+    const params = await builtParams(page);
+    expect(params.q).toBe('claude');
+    expect(params.author).toBe('austegard.com');   // leading @ stripped
+    expect(params.excludeDomain).toBe('example.com');
+    expect(params.tag).toBe('atproto bsky');       // leading # stripped, space-joined
+  });
+
+  test('merges duplicate rows of the same field and mode', async ({ page }) => {
+    await page.goto(PAGE);
+    await setRow(page, 0, { field: 'authors', value: 'alice.test alice.test' });
+    await page.click('#add-filter');
+    await setRow(page, 1, { field: 'authors', value: 'bob.test' });
+
+    const params = await builtParams(page);
+    expect(params.author).toBe('alice.test bob.test');
+  });
+
+  test('emits attribute params for replies, media, language and dates', async ({ page }) => {
+    await page.goto(PAGE);
+    await page.fill('#f-query', 'cats');
+    await page.selectOption('#f-replies', 'none');
+    await page.selectOption('#f-media', 'video');
+    await page.selectOption('#f-lang', 'no');
+    await page.fill('#f-since', '2026-01-01');
+    await page.fill('#f-until', '2026-02-01');
+
+    const params = await builtParams(page);
+    expect(params).toMatchObject({
+      q: 'cats',
+      replies: 'none',
+      video: 'true',
+      lang: 'no',
+      since: '2026-01-01',
+      until: '2026-02-01',
+    });
+    expect(params.media).toBeUndefined();
+  });
+
+  test('maps the author dropdown to from=me and following=true', async ({ page }) => {
+    await page.goto(PAGE);
+    await page.fill('#f-query', 'cats');
+
+    await page.selectOption('#f-from', 'me');
+    expect(await builtParams(page)).toMatchObject({ from: 'me' });
+
+    await page.selectOption('#f-from', 'following');
+    const params = await builtParams(page);
+    expect(params.following).toBe('true');
+    expect(params.from).toBeUndefined();
+  });
+
+  test('promotes a typed from:me out of the query text', async ({ page }) => {
+    await page.goto(PAGE);
+    await page.fill('#f-query', 'cats from:me');
+
+    const params = await builtParams(page);
+    expect(params.q).toBe('cats');
+    expect(params.from).toBe('me');
+  });
+
+  test('classic mode packs filters into q and warns about the rest', async ({ page }) => {
+    await page.goto(PAGE);
+    await page.fill('#f-query', 'cats');
+    await setRow(page, 0, { field: 'authors', value: 'austegard.com' });
+    await page.click('#add-filter');
+    await setRow(page, 1, { mode: 'exclude', field: 'tags', value: 'spam' });
+    await page.selectOption('#f-lang', 'en');
+    await page.selectOption('#f-media', 'media');
+
+    await page.check('input[name="urlstyle"][value="operators"]');
+
+    const params = await builtParams(page);
+    expect(Object.keys(params)).toEqual(['q']);
+    expect(params.q).toBe('cats from:austegard.com lang:en');
+
+    const warnings = await page.locator('#warnings').textContent();
+    expect(warnings).toContain('exclude hashtag');
+    expect(warnings).toContain('has media');
+  });
+
+  test('round-trips a shared bsky.app URL back into the form', async ({ page }) => {
+    await page.goto(PAGE);
+    await page.locator('details', { hasText: 'Load an existing search' }).first()
+      .locator('summary').click();
+    await page.fill('#f-import',
+      'https://bsky.app/search?q=%22hello+world%22+-spam&author=austegard.com&excludeDomain=example.com&tag=atproto&lang=en&since=2026-03-01&replies=only&video=true');
+    await page.click('#import-go');
+
+    await expect(page.locator('#f-exact')).toHaveValue('hello world');
+    await expect(page.locator('#f-none')).toHaveValue('spam');
+    await expect(page.locator('#f-lang')).toHaveValue('en');
+    await expect(page.locator('#f-since')).toHaveValue('2026-03-01');
+    await expect(page.locator('#f-replies')).toHaveValue('only');
+    await expect(page.locator('#f-media')).toHaveValue('video');
+
+    const params = await builtParams(page);
+    expect(params).toMatchObject({
+      author: 'austegard.com',
+      excludeDomain: 'example.com',
+      tag: 'atproto',
+      replies: 'only',
+      video: 'true',
+    });
+  });
+
+  test('lifts classic operators out of an imported raw query', async ({ page }) => {
+    await page.goto(PAGE);
+    await page.locator('details', { hasText: 'Load an existing search' }).first()
+      .locator('summary').click();
+    await page.fill('#f-import', 'cats from:@alice.test domain:npr.org #caturday lang:ja since:2026-05-05');
+    await page.click('#import-go');
+
+    await expect(page.locator('#f-query')).toHaveValue('cats');
+    await expect(page.locator('#f-lang')).toHaveValue('ja');
+    await expect(page.locator('#f-since')).toHaveValue('2026-05-05');
+
+    const params = await builtParams(page);
+    expect(params).toMatchObject({
+      author: 'alice.test',
+      domain: 'npr.org',
+      tag: 'caturday',
+      lang: 'ja',
+      since: '2026-05-05',
+    });
+  });
+
+  test('keeps quoted phrases and OR groups verbatim in q', async ({ page }) => {
+    await page.goto(PAGE);
+    await page.fill('#f-query', '(cats OR dogs) "not an operator: really"');
+
+    const params = await builtParams(page);
+    expect(params.q).toBe('(cats OR dogs) "not an operator: really"');
+  });
+
+  test('mirrors the built search into the page URL as a permalink', async ({ page }) => {
+    await page.goto(PAGE);
+    await page.fill('#f-query', 'cats');
+    await page.selectOption('#f-lang', 'en');
+
+    await expect(page).toHaveURL(/[?&]q=cats/);
+    await expect(page).toHaveURL(/[?&]lang=en/);
+
+    // Reloading that permalink restores the form.
+    await page.reload();
+    await expect(page.locator('#f-query')).toHaveValue('cats');
+    await expect(page.locator('#f-lang')).toHaveValue('en');
+  });
+
+  test('never issues a network request to Bluesky', async ({ page }) => {
+    const external = [];
+    page.on('request', req => {
+      const host = new URL(req.url()).host;
+      if (host && !host.startsWith('localhost')) external.push(req.url());
+    });
+
+    await page.goto(PAGE);
+    await page.fill('#f-query', 'cats');
+    await setRow(page, 0, { field: 'authors', value: 'austegard.com' });
+    await page.waitForTimeout(250);
+
+    const bluesky = external.filter(u => /bsky|bluesky/i.test(u));
+    expect(bluesky).toEqual([]);
+  });
+});


### PR DESCRIPTION
Standalone `/bsky/advanced-search.html` — the bookmarklet's form as a page.

Fill it in, it writes a `bsky.app/search` URL. No auth, no API calls, nothing searched on the page; it assembles the link and hands it over.

**Preview:** [Branch Preview workflow runs](https://github.com/oaustegard/oaustegard.github.io/actions/workflows/branch-preview.yml) → open the latest run's job summary for the `*.pages.dev` URL.

## What's new vs. the bookmarklet

The bookmarklet packs everything into `q=` using search operators. Bluesky has since moved advanced filters out of the query string into structured sibling params on `/search`, and added filters that have no operator spelling at all. Beyond the bookmarklet's terms / hashtag / from / mentions / url / lang / date, the page adds:

- exact phrase and `-negated` words as their own fields
- repeatable **include/exclude** rows over author, mentions, domain, url and tag — each multi-valued, OR-matched within a row, merged and deduped across rows
- replies: exclude / only
- has media, has video
- author scope: anyone / people I follow / me

Serialization mirrors the Bluesky app's own advanced-search dialog: `@` and `#` markers stripped off values, a typed `from:me` promoted to `from=me`, quoted phrases and `(a OR b)` groups passed through the tokenizer intact.

## Two URL styles

- **Structured params** (default) — byte-for-byte what the app produces from its own "share search" action.
- **Query operators** (classic) — everything packed into one `q=`, paste-able into Bluesky's search box and readable by older clients. It can't express exclude / replies / media / video / following, so the page lists exactly which filters it had to drop when you switch.

## Round-tripping

"Load an existing search" accepts a shared `bsky.app/search` URL *or* a bare operator query and refills the form from either. The page also mirrors its built search into its own address bar, so a configured form is bookmarkable and reloads intact.

## Files

- `bsky/advanced-search.html` — the page, self-contained, uses `/styles/style.css` tokens (light + dark)
- `bsky/advanced-search_README.md` — companion doc per the repo's tool convention
- `tests/bsky-advanced-search.spec.js` — 13 Playwright cases: q construction, param emission, marker stripping, row merging, `from:me` promotion, classic-mode degradation + warnings, URL and raw-query import, permalink round-trip, and an assertion that the page issues no request to Bluesky

`bsky/index.html` needs no edit — its `github-toc` lists non-index HTML in the directory automatically.

All 13 tests pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PAezAnpMTQG4Y1u7fLwDrq)_