### PR TITLE
atproto-rtc 1.3.0: cursor-based polling, per-peer backoff, abortable teardown

### DIFF
--- a/bsky/atproto-rtc.js
+++ b/bsky/atproto-rtc.js
@@ -27,8 +27,22 @@
  * ATProto. Application payloads belong on the resulting RTCDataChannel;
  * this library does not interpret or transport them.
  *
+ * POLL RESILIENCE (1.3.0):
+ *  - Peer reads are CURSOR-BASED. `com.atproto.repo.listRecords` with
+ *    `reverse=true&cursor=<last rkey>` returns only records written after
+ *    that rkey, ascending, so the steady-state poll transfers an empty
+ *    array instead of re-reading 50 records every interval.
+ *  - A peer's cursor only advances past records that were processed
+ *    successfully, so a transient failure mid-handshake is re-read rather
+ *    than skipped.
+ *  - Failed reads back off per-peer (exponential, jittered) and are
+ *    classified: a 4xx means that peer's repo is unreadable and polling
+ *    stops for it, anything else is transient and retried.
+ *  - The loop idles to `idlePollMs` when every trusted peer is connected,
+ *    and wakes back to `pollMs` when anything needs signaling.
+ *
  * @license MIT
- * @version 1.2.0
+ * @version 1.3.0
  *
  * @example
  *   import { AtprotoRTC } from '/bsky/atproto-rtc.js';
@@ -45,6 +59,79 @@
  *
  *   const requests = await rtc.discoverPeers(); // who has signaled me
  */
+
+/* ---------- poll resilience primitives (pure, exported for tests) ---------- */
+
+/**
+ * A failed unauthenticated read of a peer's repo. Carries the HTTP status
+ * so the poll loop can tell "this peer's repo does not exist" from "that
+ * PDS is having a bad minute". `status` is undefined for network-level
+ * failures, which are always transient as far as we can tell.
+ */
+export class PeerReadError extends Error {
+  constructor(message, status) {
+    super(message);
+    this.name = 'PeerReadError';
+    this.status = status;
+  }
+}
+
+/**
+ * Exponential backoff with ±25% jitter, capped at `maxMs`.
+ *
+ * The jitter is not decoration: peers commonly share a PDS (bsky.social
+ * hosts most of the network), so an un-jittered backoff has every peer
+ * retrying the same host on the same tick.
+ *
+ * @param {number} attempt consecutive failures so far, 0 for the first retry
+ */
+export function backoffMs(attempt, baseMs, maxMs) {
+  const raw = Math.min(maxMs, baseMs * Math.pow(2, attempt));
+  return Math.round(raw * (0.75 + Math.random() * 0.5));
+}
+
+/**
+ * Should a failed peer read be retried?
+ *
+ * A 4xx is the PDS saying the request will never work: an unknown repo
+ * answers 400 InvalidRequest ("Could not find repo"), and a malformed
+ * request is our own bug — neither improves by asking again. Note that a
+ * peer who simply has no signal records is NOT an error: that reads 200
+ * with an empty array. 429 is the exception, a 4xx that explicitly means
+ * "later". Everything else — 5xx, and network failures with no status at
+ * all — is transient.
+ */
+export function isRetryableReadError(err) {
+  const status = err && err.status;
+  if (status === undefined || status === null) return true;   /* network / CORS / offline */
+  if (status === 429) return true;
+  return status < 400 || status >= 500;
+}
+
+/**
+ * TIDs are 13 chars of sortable base32. A cursor that is not one would be
+ * accepted by the PDS and answered with an empty page *silently* (verified
+ * against bsky.social), which would strand a peer with no error to notice,
+ * so anything that fails this check is discarded rather than sent.
+ */
+export function isValidTid(rkey) {
+  return typeof rkey === 'string' && /^[234567abcdefghijklmnopqrstuvwxyz]{13}$/.test(rkey);
+}
+
+/**
+ * Query params for one peer read.
+ *
+ * With a cursor: ascending from just after it, so only records we have
+ * never seen come back — usually none. Without one (first read of a peer,
+ * or a resync): a small descending page, i.e. the most recent records
+ * only, since an unbounded backfill of someone's history is never useful
+ * for signaling and every record older than the TTL is ignored anyway.
+ */
+export function peerReadParams(collection, did, cursor, pageLimit) {
+  const p = { repo: did, collection, limit: String(pageLimit) };
+  if (isValidTid(cursor)) { p.reverse = 'true'; p.cursor = cursor; }
+  return p;
+}
 
 /* ---------- minimal event emitter ---------- */
 class Emitter {
@@ -95,7 +182,14 @@ export class AtprotoRTC extends Emitter {
    * @param {Object} [opts]
    * @param {string} [opts.collection='com.austegard.rtc.signal']
    * @param {Array}  [opts.iceServers] default: [{urls:'stun:stun.l.google.com:19302'}]
-   * @param {number} [opts.pollMs=2000]
+   * @param {number} [opts.pollMs=2000] interval while anything needs signaling
+   * @param {number} [opts.idlePollMs=15000] interval once every trusted peer
+   *                 is connected; any new work wakes the loop back to pollMs
+   * @param {number} [opts.maxBackoffMs=60000] ceiling for a failing peer's
+   *                 per-peer exponential backoff
+   * @param {number} [opts.resyncEvery=15] cursor-free re-read of a pending
+   *                 peer every N polls, so a cursor that somehow stops
+   *                 matching can't silence that peer indefinitely
    * @param {number} [opts.signalTtlS=300]
    * @param {boolean}[opts.persistSession=true] store token pair (never the
    *                 password) in localStorage 'bsky_session' for resumeSession()
@@ -107,6 +201,9 @@ export class AtprotoRTC extends Emitter {
       ? opts.iceServers
       : [{ urls: 'stun:stun.l.google.com:19302' }];
     this.pollMs      = opts.pollMs      || 2000;
+    this.idlePollMs  = opts.idlePollMs  || 15000;
+    this.maxBackoffMs = opts.maxBackoffMs || 60000;
+    this.resyncEvery = opts.resyncEvery || 15;
     this.persistSession = opts.persistSession !== false;
     this.signalTtlS  = opts.signalTtlS  || 300;
     this.discoverMs  = opts.discoverMs  || 6000;
@@ -126,6 +223,10 @@ export class AtprotoRTC extends Emitter {
     this._pollTimer = null;
     this._discoverTimer = null;
     this._running = false;
+    /* Aborted by stop(). Every read the loops issue carries this signal, so
+       stopping cancels in-flight requests instead of letting a late response
+       land in state that has already been torn down. */
+    this._abort = null;
 
     console.debug('[atproto-rtc] iceServers:', JSON.stringify(this.iceServers));
   }
@@ -307,13 +408,33 @@ export class AtprotoRTC extends Emitter {
     return j.records || [];
   }
 
-  /** Unauthenticated read of a peer's repo, straight from their PDS. */
-  async _listPeerRecords(peer) {
-    const url = peer.pds + '/xrpc/com.atproto.repo.listRecords?' +
-      new URLSearchParams({ repo: peer.did, collection: this.collection, limit: '50' });
-    const r = await fetch(url);
-    if (!r.ok) throw new Error('listRecords on ' + peer.handle + ' -> ' + r.status);
-    return (await r.json()).records || [];
+  /**
+   * Unauthenticated read of a peer's repo, straight from their PDS.
+   *
+   * `cursor` is the rkey of the last record we processed for this peer.
+   * Given one, the PDS returns only records written after it, ascending —
+   * an empty array in the steady state. Given none, it returns the most
+   * recent `pageLimit` records, newest first, which is the cold-start and
+   * resync path.
+   *
+   * @returns {Promise<Array>} records, always in oldest-first order so
+   *          offer/answer are processed in the order they were written
+   */
+  async _listPeerRecords(peer, cursor, pageLimit = 50) {
+    const params = peerReadParams(this.collection, peer.did, cursor, pageLimit);
+    const url = peer.pds + '/xrpc/com.atproto.repo.listRecords?' + new URLSearchParams(params);
+    let r;
+    try {
+      r = await fetch(url, { signal: this._abort ? this._abort.signal : undefined });
+    } catch (e) {
+      if (e && e.name === 'AbortError') throw e;               /* teardown, not a peer fault */
+      throw new PeerReadError('listRecords on ' + peer.handle + ' -> ' + e.message);
+    }
+    if (!r.ok) throw new PeerReadError('listRecords on ' + peer.handle + ' -> ' + r.status, r.status);
+    const records = (await r.json()).records || [];
+    /* A cursored read already arrives ascending; a cold page arrives
+       descending. Normalise so callers never have to care which they got. */
+    return params.reverse ? records : records.reverse();
   }
 
   async _sweepOwnSignals() {
@@ -346,7 +467,13 @@ export class AtprotoRTC extends Emitter {
       did, handle, pds, trusted: !!trusted,
       pc: null, dc: null, conn: null,
       offerRkey: null, answerRkey: null, knockRkey: null,
-      sending: false
+      sending: false,
+      /* poll resilience */
+      cursor: null,        /* rkey of the last record processed for this peer */
+      polls: 0,            /* successful reads, drives the periodic resync */
+      failures: 0,         /* consecutive failed reads, drives the backoff */
+      nextPollAt: 0,       /* epoch ms; the loop skips this peer until then */
+      unreadable: false    /* a 4xx said this repo will never read; stop asking */
     };
     this.peers.set(did, p);
     this.emit('statechange', did, p);
@@ -523,24 +650,46 @@ export class AtprotoRTC extends Emitter {
   async _pollPeer(did) {
     const p = this.peers.get(did);
     if (!p) return;
-    const recs = await this._listPeerRecords(p);
-    /* oldest-first so offer/answer arrive in order */
-    recs.sort((a, b) => String((a.value || {}).createdAt || '').localeCompare(String((b.value || {}).createdAt || '')));
+
+    /* Periodically re-read without the cursor. A cursor the PDS does not
+       recognise is answered 200 with an empty page rather than an error
+       (verified against bsky.social), so a cursor that ever goes wrong
+       would silence this peer with nothing to notice. The resync is one
+       small page every `resyncEvery` polls and only while unconnected. */
+    const resync = p.polls > 0 && p.polls % this.resyncEvery === 0;
+    const cursor = resync ? null : p.cursor;
+    /* A cursored read is bounded by how much a peer wrote since the last
+       poll, so it can afford a full page. A cursor-free one — cold start or
+       resync — is reading into history, where only the newest records can
+       still be inside the TTL, so it stays small. */
+    const useCursor = isValidTid(cursor);
+    const recs = await this._listPeerRecords(p, cursor, useCursor ? 50 : 20);
+    p.polls++;
+
     for (const rec of recs) {
-      if (this._seenUris.has(rec.uri)) continue;
+      const rkey = rec.uri.split('/').pop();
       const v = rec.value || {};
-      if (v.to !== this.me.did) continue;
-      const age = Date.now() - Date.parse(String(v.createdAt || ''));
-      if (isNaN(age) || age > this.signalTtlS * 1000) { this._seenUris.set(rec.uri, Date.now()); continue; }
-      this._seenUris.set(rec.uri, Date.now());
-      try {
-        if (v.msgType === 'offer')  await this._handleOffer(did, String(v.payload || ''));
-        if (v.msgType === 'answer') await this._handleAnswer(did, String(v.payload || ''));
-      } catch (e) {
-        /* transient failure (e.g. answer write) — unmark so the record is retried */
-        this._seenUris.delete(rec.uri);
-        throw e;
+      const already = this._seenUris.has(rec.uri);
+      if (!already && v.to === this.me.did) {
+        const age = Date.now() - Date.parse(String(v.createdAt || ''));
+        const fresh = !isNaN(age) && age <= this.signalTtlS * 1000;
+        this._seenUris.set(rec.uri, Date.now());
+        if (fresh) {
+          try {
+            if (v.msgType === 'offer')  await this._handleOffer(did, String(v.payload || ''));
+            if (v.msgType === 'answer') await this._handleAnswer(did, String(v.payload || ''));
+          } catch (e) {
+            /* Transient failure (e.g. the answer write). Unmark the record
+               AND leave the cursor where it was, so the next read returns
+               this record again instead of skipping past a live handshake. */
+            this._seenUris.delete(rec.uri);
+            throw e;
+          }
+        }
       }
+      /* Only reached once the record above is fully handled, which is what
+         makes the cursor a record of progress rather than of arrival. */
+      if (isValidTid(rkey)) p.cursor = rkey;
     }
   }
 
@@ -549,12 +698,18 @@ export class AtprotoRTC extends Emitter {
     const cutoff = Date.now() - this.signalTtlS * 1000;
     for (const [uri, ts] of this._seenUris) if (ts < cutoff) this._seenUris.delete(uri);
     if (this._discoverChecked.size > 5000) this._discoverChecked.clear();  /* re-verification is cheap and gated */
+    const now = Date.now();
+    let pending = 0;   /* peers still needing signaling; decides the next interval */
     for (const did of this.peers.keys()) {
+      const p = this.peers.get(did);
+      if (!p.trusted) continue;   /* consent gate: no polling, offering, or knocking until accepted */
+      const connected = p.dc && p.dc.readyState === 'open';
+      if (!connected && !p.unreadable) pending++;
+      if (p.unreadable) continue;
+      if (now < p.nextPollAt) continue;   /* backing off from an earlier failure */
       try {
-        const p = this.peers.get(did);
-        if (!p.trusted) continue;   /* consent gate: no polling, offering, or knocking until accepted */
-        const connected = p.dc && p.dc.readyState === 'open';
         if (!connected) await this._pollPeer(did);
+        p.failures = 0;
         /* glare avoidance: lexicographically smaller DID initiates.
            The larger DID instead writes a one-time 'knock' so the peer
            can discover us via the backlink index without typing anything. */
@@ -565,11 +720,45 @@ export class AtprotoRTC extends Emitter {
           console.debug('[atproto-rtc][knock] sent to', p.handle);
         }
       } catch (e) {
+        if (e && e.name === 'AbortError') return;   /* stop() won the race */
         /* isolate: one peer's bad records or network hiccup must not halt polling of others */
-        console.debug('[atproto-rtc][poll]', did, 'error:', e.message);
+        if (!isRetryableReadError(e)) {
+          /* The PDS says this repo will not read — an unknown or deactivated
+             account, most likely. Retrying is pure noise, so stop and let the
+             application surface it. accept()/connect() clears the flag. */
+          p.unreadable = true;
+          console.debug('[atproto-rtc][poll]', p.handle, 'unreadable:', e.message);
+          this.emit('peererror', did, e);
+          this.emit('statechange', did, p);
+        } else {
+          const wait = backoffMs(p.failures++, this.pollMs, this.maxBackoffMs);
+          p.nextPollAt = Date.now() + wait;
+          console.debug('[atproto-rtc][poll]', p.handle, 'error:', e.message, '- retry in', wait + 'ms');
+        }
       }
     }
-    if (this._running) this._pollTimer = setTimeout(() => this._poll(), this.pollMs);
+    /* Nothing left to signal: idle the loop rather than re-reading repos
+       that only change when a peer wants something. _wake() reverses this
+       the moment a peer is added, accepted, or a connection drops. */
+    const next = pending ? this.pollMs : this.idlePollMs;
+    if (this._running) this._pollTimer = setTimeout(() => this._poll(), next);
+  }
+
+  /**
+   * Bring the poll loop back to full speed and clear accumulated backoff.
+   *
+   * Called whenever the reason for a wait may no longer hold: a new or
+   * newly-trusted peer, a dropped connection, or a tab coming back to the
+   * foreground (where the failures are the suspension's fault, not the
+   * peer's, and holding them against the peer would delay reconnection
+   * exactly when the user is watching).
+   */
+  _wake() {
+    for (const p of this.peers.values()) { p.failures = 0; p.nextPollAt = 0; }
+    if (!this._running) return;
+    if (this._pollTimer) clearTimeout(this._pollTimer);
+    this._pollTimer = null;
+    this._poll();
   }
 
   /* ================= peer discovery via Constellation backlink index ================
@@ -591,7 +780,7 @@ export class AtprotoRTC extends Emitter {
     try {
       const q = 'https://constellation.microcosm.blue/xrpc/blue.microcosm.links.getBacklinks?' +
         new URLSearchParams({ subject: this.me.did, source: this.collection + ':to', limit: '50' });
-      const r = await fetch(q);
+      const r = await fetch(q, { signal: this._abort ? this._abort.signal : undefined });
       if (!r.ok) throw new Error('getBacklinks -> ' + r.status);
       const j = await r.json();
       for (const rec of (j.records || [])) {
@@ -601,13 +790,13 @@ export class AtprotoRTC extends Emitter {
         this._discoverChecked.add(key);
         try {
           const pds = await AtprotoRTC.resolvePds(did);
-          const live = (await this._listPeerRecords({ did, pds, handle: did })).some(x => {
+          const live = (await this._listPeerRecords({ did, pds, handle: did }, null, 20)).some(x => {
             const v = x.value || {};
             const age = Date.now() - Date.parse(String(v.createdAt || ''));
             return v.to === this.me.did && !isNaN(age) && age <= this.signalTtlS * 1000;
           });
           if (!live) continue;             /* stale index entry — ignore */
-          const dr = await fetch(pds + '/xrpc/com.atproto.repo.describeRepo?repo=' + encodeURIComponent(did));
+          const dr = await fetch(pds + '/xrpc/com.atproto.repo.describeRepo?repo=' + encodeURIComponent(did), { signal: this._abort ? this._abort.signal : undefined });
           const handle = dr.ok ? (await dr.json()).handle : did;
           console.debug('[atproto-rtc][discover] live signal from', handle);
 
@@ -622,7 +811,7 @@ export class AtprotoRTC extends Emitter {
         } catch (e) { console.debug('[atproto-rtc][discover]', did, '->', e.message); }
       }
     } catch (e) {
-      console.debug('[atproto-rtc][discover] error:', e.message);
+      if (!(e && e.name === 'AbortError')) console.debug('[atproto-rtc][discover] error:', e.message);
     }
     return found;
   }
@@ -635,6 +824,7 @@ export class AtprotoRTC extends Emitter {
   start() {
     if (this._running) return;
     this._running = true;
+    this._abort = typeof AbortController !== 'undefined' ? new AbortController() : null;
     this._poll();
     const loop = async () => {
       if (!this._running) return;
@@ -646,10 +836,7 @@ export class AtprotoRTC extends Emitter {
        the remaining poll interval — re-signal the moment we're visible again. */
     if (typeof document !== 'undefined' && !this._visHandler) {
       this._visHandler = () => {
-        if (document.visibilityState === 'visible' && this._running) {
-          if (this._pollTimer) clearTimeout(this._pollTimer);
-          this._poll();
-        }
+        if (document.visibilityState === 'visible' && this._running) this._wake();
       };
       document.addEventListener('visibilitychange', this._visHandler);
     }
@@ -664,6 +851,9 @@ export class AtprotoRTC extends Emitter {
     if (this._discoverTimer) clearTimeout(this._discoverTimer);
     this._pollTimer = null;
     this._discoverTimer = null;
+    /* Cancel reads already in flight. Without this a response can land
+       after stop() and mutate peer state that is meant to be dormant. */
+    if (this._abort) { try { this._abort.abort(); } catch (e) {} this._abort = null; }
     if (this._visHandler && typeof document !== 'undefined') {
       document.removeEventListener('visibilitychange', this._visHandler);
       this._visHandler = null;
@@ -690,7 +880,9 @@ export class AtprotoRTC extends Emitter {
       conn.channel = p.dc;
       p.conn = conn;
     }
+    p.unreadable = false;
     console.debug('[atproto-rtc] connecting to', handle);
+    this._wake();                      /* don't sit out an idle interval */
     return p.conn;
   }
 
@@ -703,7 +895,9 @@ export class AtprotoRTC extends Emitter {
     const p = this.peers.get(did);
     if (!p) return;
     p.trusted = true;
+    p.unreadable = false;              /* user asked again; give the repo another chance */
     this.emit('statechange', did, p);
+    this._wake();
   }
 
   /**
@@ -730,6 +924,7 @@ export class AtprotoRTC extends Emitter {
     if (p.conn) p.conn.close();
     if (p.pc) { try { p.pc.close(); } catch (e) {} }
     p.pc = null; p.dc = null; p.conn = null;
+    this._wake();                      /* signaling is needed again */
   }
 
   /**

--- a/bsky/tests/atproto-rtc.test.mjs
+++ b/bsky/tests/atproto-rtc.test.mjs
@@ -1,0 +1,200 @@
+// Contract tests for the poll-resilience layer of bsky/atproto-rtc.js.
+// Covers the pure helpers plus _pollPeer's cursor discipline and _poll's
+// backoff/classification, all against a stubbed fetch. WebRTC itself is not
+// exercised here — it needs a real RTCPeerConnection and belongs in a browser
+// smoke test.
+// Run: node --test bsky/tests/atproto-rtc.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  AtprotoRTC, PeerReadError, backoffMs, isRetryableReadError, isValidTid, peerReadParams
+} from '../atproto-rtc.js';
+
+const COLL = 'com.austegard.rtc.signal';
+const ME = 'did:plc:aaaaaaaaaaaaaaaaaaaaaaaa';
+const PEER = 'did:plc:zzzzzzzzzzzzzzzzzzzzzzzz';   // > ME, so we knock rather than offer
+
+/* rkeys must be real TIDs: 13 chars of sortable base32, and the alphabet has
+   no 0/1/8/9 — so build them from the alphabet itself rather than from digits,
+   with tid(n) sorting ascending in n. */
+const B32 = '234567abcdefghijklmnopqrstuvwxyz';
+const tid = (n) => '3ms222222222' + B32[n];
+
+function record(rkey, { to = ME, msgType = 'offer', ageS = 0, payload = 'sdp' } = {}) {
+  return {
+    uri: `at://${PEER}/${COLL}/${rkey}`,
+    value: { $type: COLL, to, msgType, payload, createdAt: new Date(Date.now() - ageS * 1000).toISOString() }
+  };
+}
+
+/** An AtprotoRTC wired to a fake PDS, with WebRTC and signal writes stubbed out. */
+function harness({ pages = [], failWith = null } = {}) {
+  const rtc = new AtprotoRTC({ collection: COLL, iceServers: [], persistSession: false });
+  rtc.me = { did: ME, handle: 'me.test', pds: 'https://pds.test', accessJwt: 'x', password: null };
+  const calls = [];
+  rtc.handled = [];
+
+  globalThis.fetch = async (url) => {
+    const u = new URL(url);
+    calls.push(Object.fromEntries(u.searchParams));
+    if (failWith) return { ok: false, status: failWith, json: async () => ({}) };
+    const page = pages.shift() || [];
+    return { ok: true, status: 200, json: async () => ({ records: page }) };
+  };
+
+  rtc._handleOffer = async (did, sdp) => { rtc.handled.push(sdp); };
+  rtc._handleAnswer = async (did, sdp) => { rtc.handled.push(sdp); };
+  rtc._offerTo = async () => {};
+  rtc._sendSignal = async () => ({ uri: `at://${ME}/${COLL}/${tid(999)}` });
+
+  const peer = rtc._upsertPeer(PEER, 'peer.test', 'https://peer.test', true);
+  return { rtc, peer, calls };
+}
+
+/* ---------- pure helpers ---------- */
+
+test('isValidTid accepts real rkeys and rejects anything else', () => {
+  assert.ok(isValidTid('3msawaukmak2y'));
+  assert.ok(!isValidTid('zzzznotatid'));      // wrong length and alphabet
+  assert.ok(!isValidTid('3msawaukmak2Y'));    // TIDs are lowercase
+  assert.ok(!isValidTid('3msawaukmak21'));    // 0, 1, 8, 9 are not in the alphabet
+  assert.ok(!isValidTid(null));
+  assert.ok(!isValidTid(undefined));
+});
+
+test('peerReadParams only sends a cursor when it is a usable TID', () => {
+  // A bad cursor reads 200-with-empty-page on a real PDS, which would strand
+  // the peer silently, so it must never reach the wire.
+  const cold = peerReadParams(COLL, PEER, null, 20);
+  assert.equal(cold.cursor, undefined);
+  assert.equal(cold.reverse, undefined);
+  assert.equal(cold.limit, '20');
+
+  assert.equal(peerReadParams(COLL, PEER, 'garbage', 50).cursor, undefined);
+
+  const warm = peerReadParams(COLL, PEER, '3msawaukmak2y', 50);
+  assert.equal(warm.cursor, '3msawaukmak2y');
+  assert.equal(warm.reverse, 'true');
+});
+
+test('backoffMs grows exponentially, jitters, and honours the cap', () => {
+  const at = (n) => Array.from({ length: 50 }, () => backoffMs(n, 2000, 60000));
+  for (const ms of at(0)) assert.ok(ms >= 1500 && ms <= 2500, `attempt 0: ${ms}`);
+  for (const ms of at(3)) assert.ok(ms >= 12000 && ms <= 20000, `attempt 3: ${ms}`);
+  for (const ms of at(20)) assert.ok(ms <= 75000, `capped: ${ms}`);
+  assert.ok(new Set(at(3)).size > 1, 'jitter produces distinct values');
+});
+
+test('isRetryableReadError treats 4xx as fatal, everything else as transient', () => {
+  assert.ok(!isRetryableReadError(new PeerReadError('unknown repo', 400)));
+  assert.ok(!isRetryableReadError(new PeerReadError('gone', 404)));
+  assert.ok(isRetryableReadError(new PeerReadError('slow down', 429)));
+  assert.ok(isRetryableReadError(new PeerReadError('bad gateway', 502)));
+  assert.ok(isRetryableReadError(new PeerReadError('offline')));   // no status = network
+});
+
+/* ---------- cursor discipline ---------- */
+
+test('cold start reads a descending page, then every later read is cursored', async () => {
+  const { rtc, peer, calls } = harness({
+    pages: [[record(tid(2)), record(tid(1))], []]   // PDS returns newest-first
+  });
+
+  await rtc._pollPeer(PEER);
+  assert.equal(calls[0].cursor, undefined, 'first read has no cursor');
+  assert.equal(calls[0].limit, '20');
+  assert.deepEqual(rtc.handled, ['sdp', 'sdp']);
+  assert.equal(peer.cursor, tid(2), 'cursor lands on the newest record, not the last returned');
+
+  await rtc._pollPeer(PEER);
+  assert.equal(calls[1].cursor, tid(2));
+  assert.equal(calls[1].reverse, 'true');
+});
+
+test('a failed handler leaves the cursor behind the record so it is re-read', async () => {
+  const { rtc, peer } = harness({ pages: [[record(tid(1)), record(tid(2))]] });
+  peer.cursor = tid(0);
+  rtc._handleOffer = async (did, sdp) => {
+    rtc.handled.push(sdp);
+    if (rtc.handled.length === 2) throw new Error('answer write failed');
+  };
+
+  await assert.rejects(() => rtc._pollPeer(PEER));
+  assert.equal(peer.cursor, tid(1), 'advanced past the record that succeeded, not the one that did not');
+  assert.ok(!rtc._seenUris.has(`at://${PEER}/${COLL}/${tid(2)}`), 'failed record is unmarked for retry');
+});
+
+test('records not addressed to us, and expired ones, still advance the cursor', async () => {
+  const { rtc, peer } = harness({
+    pages: [[record(tid(1), { to: 'did:plc:someone-else' }), record(tid(2), { ageS: 9999 })]]
+  });
+  peer.cursor = tid(0);
+
+  await rtc._pollPeer(PEER);
+  assert.deepEqual(rtc.handled, [], 'neither record is acted on');
+  assert.equal(peer.cursor, tid(2), 'but both are consumed, so they are never re-read');
+});
+
+test('every resyncEvery-th poll drops the cursor to re-read from scratch', async () => {
+  const { rtc, peer, calls } = harness({ pages: Array.from({ length: 6 }, () => []) });
+  rtc.resyncEvery = 3;
+  peer.cursor = tid(5);
+
+  for (let i = 0; i < 6; i++) await rtc._pollPeer(PEER);
+  const cursored = calls.map(c => c.cursor !== undefined);
+  // polls 0,1,2 cursored; poll 3 (polls % 3 === 0) resyncs; 4,5 cursored again
+  assert.deepEqual(cursored, [true, true, true, false, true, true]);
+});
+
+/* ---------- failure handling in the loop ---------- */
+
+test('a transient failure backs the peer off instead of hammering', async () => {
+  const { rtc, peer } = harness({ failWith: 503 });
+  rtc._running = false;   // no rescheduling
+
+  await rtc._poll();
+  assert.equal(peer.unreadable, false);
+  assert.equal(peer.failures, 1);
+  assert.ok(peer.nextPollAt > Date.now(), 'peer is parked in backoff');
+
+  const parkedAt = peer.nextPollAt;
+  await rtc._poll();
+  assert.equal(peer.failures, 1, 'skipped while backing off, so no second failure counted');
+  assert.equal(peer.nextPollAt, parkedAt);
+});
+
+test('a 4xx marks the peer unreadable and stops polling it', async () => {
+  const { rtc, peer } = harness({ failWith: 400 });
+  rtc._running = false;
+  const errors = [];
+  rtc.on('peererror', (did, e) => errors.push(did));
+
+  await rtc._poll();
+  assert.equal(peer.unreadable, true);
+  assert.equal(errors.length, 1);
+
+  await rtc._poll();
+  assert.equal(errors.length, 1, 'no further attempts, no repeat error');
+});
+
+test('_wake clears backoff so a foregrounded tab retries immediately', async () => {
+  const { rtc, peer } = harness({ failWith: 503 });
+  rtc._running = false;
+
+  await rtc._poll();
+  assert.ok(peer.nextPollAt > Date.now());
+
+  rtc._wake();
+  assert.equal(peer.nextPollAt, 0);
+  assert.equal(peer.failures, 0);
+});
+
+test('accept() un-blacklists a peer that had read as unreadable', () => {
+  const { rtc, peer } = harness();
+  peer.unreadable = true;
+  peer.trusted = false;
+  rtc.accept(PEER);
+  assert.equal(peer.trusted, true);
+  assert.equal(peer.unreadable, false);
+});


### PR DESCRIPTION
Applies the resumption/reconnect discipline from the `@atproto/ws-client` Jetstream demo to the existing `listRecords` poll. No Jetstream, no new dependency — the module stays vanilla and serverless.

### Cursor-based peer reads

`com.atproto.repo.listRecords` supports `reverse=true&cursor=<rkey>`, which returns only records written after that rkey, ascending. Verified against bsky.social: the steady-state poll now transfers `{"records":[]}` instead of re-reading a 50-record page every 2s.

The cursor advances **only past records that were fully processed**. A handler that throws mid-handshake (a failed answer write, say) leaves the cursor behind that record so the next read returns it again — the same retry semantics `_seenUris` already gave, now on the fetch side too.

### The silent-cursor hazard

A cursor the PDS does not recognise is answered **200 with an empty page**, not an error (measured). Left alone that would strand a peer permanently with nothing to log. Two guards:

- `isValidTid()` — a cursor that is not 13 chars of TID base32 is never sent.
- Cursor-free resync every `resyncEvery` polls (default 15) while a peer is unconnected: one 20-record descending page, ~once per 30s per pending peer.

### Per-peer backoff and failure classification

`_poll` previously caught every error, logged it, and retried at a fixed 2s forever. Now:

- Transient (5xx, 429, network) → exponential backoff with ±25% jitter, capped at `maxBackoffMs`. Jitter matters because most peers share bsky.social; un-jittered, they all retry the same host on the same tick.
- 4xx → that repo will never read (an unknown repo answers `400 InvalidRequest`), so the peer is marked `unreadable`, a `peererror` event fires, and polling stops for it. `accept()`/`connect()` clears the flag.

A peer with no signal records is *not* an error — that reads 200 with an empty array — so this doesn't fire on a quiet peer.

### Abortable teardown

`stop()` aborts in-flight reads through an `AbortController` rather than letting a late response land in state that has already been torn down.

### Adaptive cadence

The loop idles to `idlePollMs` (15s) once every trusted peer is connected, and `_wake()` returns it to `pollMs` on connect, accept, disconnect, or the tab coming back to the foreground — where it also clears backoff, since those failures are the suspension's fault, not the peer's.

### Verification

`node --test bsky/tests/atproto-rtc.test.mjs` — 12 tests, all passing. `node --test scripts/fd/tests/*.test.mjs` still 21/21.

The suite caught two real bugs while being written: the cold-start read was using the cursored page size (50) rather than the cursor-free one (20), and a test helper collapsing distinct rkeys exposed that the TID alphabet excludes 0/1/8/9.

**Not covered by tests:** the WebRTC path itself, which needs a real `RTCPeerConnection` — the two-browser handshake still wants a manual smoke test on `/bsky/filedrop.html` before merge.

Public API is additive only: new constructor options (`idlePollMs`, `maxBackoffMs`, `resyncEvery`) and a new `peererror` event. `pad.html` and `filedrop.html` construct with options only and need no changes.