### PR TITLE
fd/signaling: report ICE gathering outcome, guard restarts against a re-pair

### DIFF
--- a/scripts/fd/signaling.js
+++ b/scripts/fd/signaling.js
@@ -40,15 +40,22 @@ function defaultPageUrl() {
   return location.origin + location.pathname.replace(/\.html$/, '') + '?b=' + Date.now().toString(36);
 }
 
-/* ---------- non-trickle ICE: resolve when gathering completes ---------- */
-function gatherComplete(pc, timeoutMs) {
-  if (pc.iceGatheringState === 'complete') return Promise.resolve();
+/* ---------- non-trickle ICE: resolve when gathering completes ----------
+   Resolves TRUE when gathering genuinely reached 'complete', FALSE when the
+   timeout fired first. The two used to be indistinguishable, which meant an
+   SDP could be shipped carrying no usable candidates and the only symptom
+   was a connection that never came up — surfacing much later, and looking
+   like the peer went away rather than like gathering never produced
+   anything. Callers log the difference; none of them abort on it, since
+   proceeding with a partial candidate set is still the right move. */
+export function gatherComplete(pc, timeoutMs) {
+  if (pc.iceGatheringState === 'complete') return Promise.resolve(true);
   return new Promise((resolve) => {
     const timer = setTimeout(() => {
-      cleanup(); resolve();
+      cleanup(); resolve(false);
     }, timeoutMs);
     function onChange() {
-      if (pc.iceGatheringState === 'complete') { cleanup(); resolve(); }
+      if (pc.iceGatheringState === 'complete') { cleanup(); resolve(true); }
     }
     function cleanup() {
       clearTimeout(timer);
@@ -56,6 +63,26 @@ function gatherComplete(pc, timeoutMs) {
     }
     pc.addEventListener('icegatheringstatechange', onChange);
   });
+}
+
+/** How many candidates a local description ended up carrying. */
+export function countCandidates(sdp) {
+  return (String(sdp || '').match(/^a=candidate:/gm) || []).length;
+}
+
+/**
+ * Gather, then say plainly what came of it. `label` names the exchange in
+ * the log so a truncated gather is attributable to the offer, the reply, or
+ * a restart. Zero candidates after a timeout is the case worth seeing: the
+ * code that follows cannot connect.
+ */
+async function gatherAndReport(pc, timeoutMs, label) {
+  const complete = await gatherComplete(pc, timeoutMs);
+  const n = countCandidates(pc.localDescription && pc.localDescription.sdp);
+  if (complete) console.log('[ice] ' + label + ': gathering complete,', n, 'candidates');
+  else if (n === 0) console.warn('[ice] ' + label + ': gathering timed out with NO candidates - this code cannot connect');
+  else console.log('[ice] ' + label + ': gathering timed out after', timeoutMs + 'ms, proceeding with', n, 'candidates');
+  return complete;
 }
 
 /**
@@ -185,7 +212,7 @@ export class Signaling {
     this.pc = this._newPC();
     this._bindChannel(this.pc.createDataChannel(this.channelLabel, { ordered: true }));
     await this.pc.setLocalDescription(await this.pc.createOffer());
-    await gatherComplete(this.pc, this.gatherTimeout);
+    await gatherAndReport(this.pc, this.gatherTimeout, 'invite');
     const code = await encodeBlob({ t: 'o', sdp: this.pc.localDescription.sdp });
     const link = this.pageUrl() + '#o=' + code;
     console.log('[invite] link length:', link.length, 'chars');
@@ -226,7 +253,7 @@ export class Signaling {
     this.pc.ondatachannel = (ev) => this._bindChannel(ev.channel);
     await this.pc.setRemoteDescription({ type: 'offer', sdp: msg.sdp });
     await this.pc.setLocalDescription(await this.pc.createAnswer());
-    await gatherComplete(this.pc, this.gatherTimeout);
+    await gatherAndReport(this.pc, this.gatherTimeout, 'reply');
     const reply = await encodeBlob({ t: 'a', sdp: this.pc.localDescription.sdp });
     const replyLink = this.pageUrl() + '#a=' + reply;
     console.log('[reply] link length:', replyLink.length, 'chars');
@@ -264,6 +291,21 @@ export class Signaling {
     this.dc = null; this.pc = null; this.wasConnected = false;
   }
 
+  /**
+   * Has the peer connection been replaced since `pc` was captured?
+   *
+   * The restart paths below await SDP work and ICE gathering — seconds, on a
+   * flapping network — and `resetPeer()` can land in the middle of that,
+   * because declaring the connection dead is exactly what prompts the app to
+   * re-pair. Without this check the code after the await runs against a
+   * connection that is closed or already superseded: `this.dc.send()` on a
+   * null channel throws, the catch reports it as another death, and a
+   * deliberate re-pair looks like a second failure.
+   */
+  _stale(pc) {
+    return this.pc !== pc;
+  }
+
   /** Reconnect by showing a fresh invite (reuses createInvite). Returns {code, link}. */
   async reconnectAsInviter() {
     this.reconnPending = false;
@@ -283,6 +325,7 @@ export class Signaling {
      first it nudges the inviter instead. */
   async tryIceRestart() {
     if (!this.dc || this.dc.readyState !== 'open') { this._connectionDead(); return; }
+    const pc = this.pc;
     this._cancelDeadTimer();
     this.deadTimer = setTimeout(() => this._connectionDead(), RESTART_DEADLINE);
     try {
@@ -293,33 +336,40 @@ export class Signaling {
       }
       console.log('[reconn] attempting ICE restart over the data channel');
       this._emit('statechange', { kind: 'reconnecting' });
-      this.pc.restartIce();
-      await this.pc.setLocalDescription(await this.pc.createOffer({ iceRestart: true }));
-      await gatherComplete(this.pc, this.gatherTimeout);
-      this.dc.send(JSON.stringify({ type: 'ICE_RESTART_OFFER', sdp: this.pc.localDescription.sdp }));
+      pc.restartIce();
+      await pc.setLocalDescription(await pc.createOffer({ iceRestart: true }));
+      if (this._stale(pc)) { console.log('[reconn] restart abandoned: peer was reset'); return; }
+      await gatherAndReport(pc, this.gatherTimeout, 'restart offer');
+      if (this._stale(pc)) { console.log('[reconn] restart abandoned: peer was reset'); return; }
+      this.dc.send(JSON.stringify({ type: 'ICE_RESTART_OFFER', sdp: pc.localDescription.sdp }));
     } catch (e) {
+      if (this._stale(pc)) { console.log('[reconn] restart abandoned: peer was reset'); return; }
       console.log('[reconn] ICE restart failed:', e.message);
       this._connectionDead();
     }
   }
 
   async _handleIceRestartMsg(msg) {
+    const pc = this.pc;
     try {
       if (msg.type === 'ICE_NUDGE' && this.isInviter) { this.tryIceRestart(); return; }
       if (msg.type === 'ICE_RESTART_OFFER' && !this.isInviter) {
         this._cancelDeadTimer();
         this.deadTimer = setTimeout(() => this._connectionDead(), RESTART_DEADLINE);
-        await this.pc.setRemoteDescription({ type: 'offer', sdp: String(msg.sdp || '') });
-        await this.pc.setLocalDescription(await this.pc.createAnswer());
-        await gatherComplete(this.pc, this.gatherTimeout);
-        this.dc.send(JSON.stringify({ type: 'ICE_RESTART_ANSWER', sdp: this.pc.localDescription.sdp }));
+        await pc.setRemoteDescription({ type: 'offer', sdp: String(msg.sdp || '') });
+        await pc.setLocalDescription(await pc.createAnswer());
+        if (this._stale(pc)) { console.log('[reconn] restart answer abandoned: peer was reset'); return; }
+        await gatherAndReport(pc, this.gatherTimeout, 'restart answer');
+        if (this._stale(pc)) { console.log('[reconn] restart answer abandoned: peer was reset'); return; }
+        this.dc.send(JSON.stringify({ type: 'ICE_RESTART_ANSWER', sdp: pc.localDescription.sdp }));
         return;
       }
       if (msg.type === 'ICE_RESTART_ANSWER' && this.isInviter) {
-        await this.pc.setRemoteDescription({ type: 'answer', sdp: String(msg.sdp || '') });
+        await pc.setRemoteDescription({ type: 'answer', sdp: String(msg.sdp || '') });
         return;
       }
     } catch (e) {
+      if (this._stale(pc)) { console.log('[reconn] restart negotiation abandoned: peer was reset'); return; }
       console.log('[reconn] restart negotiation failed:', e.message);
       this._connectionDead();
     }

--- a/scripts/fd/tests/signaling.test.mjs
+++ b/scripts/fd/tests/signaling.test.mjs
@@ -1,0 +1,146 @@
+// Contract tests for scripts/fd/signaling.js — the ICE-gathering outcome
+// signal and the restart-vs-reset race. No real RTCPeerConnection: these
+// cover the module's own bookkeeping around the browser API, not WebRTC
+// itself, which still needs the two-browser smoke test.
+// Run: node --test scripts/fd/tests/signaling.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Signaling, gatherComplete, countCandidates } from '../signaling.js';
+
+const SDP_2 = 'v=0\r\na=candidate:1 1 udp 2 10.0.0.1 1 typ host\r\na=candidate:2 1 udp 1 1.2.3.4 2 typ srflx\r\n';
+
+/** Minimal RTCPeerConnection stand-in. `gather` controls how ICE resolves. */
+function fakePC({ gather = 'complete', sdp = SDP_2 } = {}) {
+  const listeners = {};
+  const pc = {
+    iceGatheringState: gather === 'immediate' ? 'complete' : 'gathering',
+    localDescription: { sdp },
+    closed: false,
+    addEventListener: (e, cb) => { (listeners[e] || (listeners[e] = [])).push(cb); },
+    removeEventListener: (e, cb) => {
+      if (listeners[e]) listeners[e] = listeners[e].filter(x => x !== cb);
+    },
+    restartIce: () => {},
+    createOffer: async () => ({ type: 'offer', sdp }),
+    createAnswer: async () => ({ type: 'answer', sdp }),
+    setLocalDescription: async () => {},
+    setRemoteDescription: async () => {},
+    close: () => { pc.closed = true; }
+  };
+  /** Drive gathering to completion, as the browser would. */
+  pc.finishGathering = () => {
+    pc.iceGatheringState = 'complete';
+    for (const cb of (listeners.icegatheringstatechange || [])) cb();
+  };
+  return pc;
+}
+
+function fakeDC() {
+  const dc = { readyState: 'open', sent: [], send: (m) => dc.sent.push(m), close: () => {} };
+  return dc;
+}
+
+/** A Signaling wired to fakes, with the gather timeout short enough to await. */
+function harness({ isInviter = true, gather = 'complete' } = {}) {
+  const s = new Signaling({ iceServers: [], gatherTimeout: 20, pageUrl: () => 'https://x/fd' });
+  const pc = fakePC({ gather });
+  s.pc = pc;
+  s.dc = fakeDC();
+  s.isInviter = isInviter;
+  s.wasConnected = true;
+  const events = [];
+  s.on('statechange', (d) => events.push(d.kind));
+  return { s, pc, events };
+}
+
+const tick = () => new Promise(r => setTimeout(r, 0));
+
+/* ---------- gathering outcome ---------- */
+
+test('countCandidates counts candidate lines and tolerates junk', () => {
+  assert.equal(countCandidates(SDP_2), 2);
+  assert.equal(countCandidates('v=0\r\n'), 0);
+  assert.equal(countCandidates(null), 0);
+  assert.equal(countCandidates(undefined), 0);
+});
+
+test('gatherComplete reports true only when gathering actually completed', async () => {
+  // Already complete before we ask.
+  assert.equal(await gatherComplete(fakePC({ gather: 'immediate' }), 50), true);
+
+  // Completes while we wait.
+  const pc = fakePC();
+  const p = gatherComplete(pc, 500);
+  pc.finishGathering();
+  assert.equal(await p, true);
+
+  // Never completes: the timeout wins, and that is now distinguishable.
+  assert.equal(await gatherComplete(fakePC(), 20), false);
+});
+
+/* ---------- restart happy path ---------- */
+
+test('inviter restart ships an ICE_RESTART_OFFER over the channel', async () => {
+  const { s, events } = harness();
+  await s.tryIceRestart();
+  const sent = s.dc.sent.map(JSON.parse);
+  assert.deepEqual(sent.map(m => m.type), ['ICE_RESTART_OFFER']);
+  assert.ok(events.includes('reconnecting'));
+  s._cancelDeadTimer();
+});
+
+test('answerer nudges rather than offering, avoiding glare', async () => {
+  const { s } = harness({ isInviter: false });
+  await s.tryIceRestart();
+  assert.deepEqual(s.dc.sent.map(m => JSON.parse(m).type), ['ICE_NUDGE']);
+  s._cancelDeadTimer();
+});
+
+/* ---------- the race ----------
+   resetPeer() alone is nearly harmless: the post-await send throws on a null
+   channel and _connectionDead() early-returns because wasConnected is false.
+   The case that bites is a re-pair — resetPeer() followed by a NEW connection,
+   which is exactly what reconnectAsInviter() does. Code reading `this.pc`
+   after the await then picks up the FRESH pairing and posts its SDP onto the
+   fresh channel as a restart offer. */
+
+/** Simulate the app taking the re-pair path: reset, then a new pc + open dc. */
+function repair(s) {
+  s.resetPeer();
+  s.pc = fakePC({ sdp: 'v=0\r\na=candidate:99 1 udp 1 9.9.9.9 9 typ host\r\n' });
+  s.dc = fakeDC();
+  return s.dc;
+}
+
+test('a restart abandoned by a re-pair does not post onto the fresh connection', async () => {
+  const { s, events } = harness({ gather: 'never' });
+
+  const restart = s.tryIceRestart();
+  await tick();
+  const freshDc = repair(s);   // the user took the fresh-invite path mid-gather
+  await restart;
+
+  assert.deepEqual(freshDc.sent, [], 'the new pairing is left alone');
+  assert.ok(!events.includes('dead'), 'a deliberate re-pair is not reported as a failure');
+});
+
+test('a restart ANSWER abandoned by a re-pair does not post onto the fresh connection', async () => {
+  const { s, events } = harness({ isInviter: false, gather: 'never' });
+
+  const handled = s._handleIceRestartMsg({ type: 'ICE_RESTART_OFFER', sdp: SDP_2 });
+  await tick();
+  const freshDc = repair(s);
+  await handled;
+
+  assert.deepEqual(freshDc.sent, []);
+  assert.ok(!events.includes('dead'));
+});
+
+test('a genuine restart failure still declares the connection dead', async () => {
+  const { s, events } = harness();
+  s.pc.createOffer = async () => { throw new Error('InvalidStateError'); };
+
+  await s.tryIceRestart();
+  assert.ok(events.includes('dead'), 'the reset guard does not swallow real failures');
+});


### PR DESCRIPTION
The two findings from #328 that actually transfer to `/fd`. The cursor, per-peer backoff and idle cadence do not — `/fd` reads nothing remote — but both of these are the same underlying shape: async work that outlives the state it was started against.

### `gatherComplete` could not report a truncated gather

It resolved with no value on both paths — real completion and the 5s timeout. So a restart on a flapping network could ship an SDP carrying zero candidates, and the only symptom was a connection that never came up, surfacing 12 seconds later as `RESTART_DEADLINE` expiring. That reads like the peer went away rather than like gathering never produced anything.

It now resolves `true`/`false`, and `gatherAndReport()` logs the candidate count at each of the four exchange points (invite, reply, restart offer, restart answer), warning explicitly when a timeout produced none. No caller aborts on a partial gather — proceeding with what you have is still right — this is purely about the failure being visible where it happens.

### A restart surviving into a re-pair posted onto the fresh connection

`tryIceRestart()` and `_handleIceRestartMsg()` await `setLocalDescription` and gathering — seconds — then read `this.pc` and `this.dc`. `resetPeer()` lands in between, because declaring the connection dead is precisely what prompts the app to re-pair.

`resetPeer()` on its own is close to harmless: the send throws on a null channel and `_connectionDead()` early-returns since `wasConnected` is false. The case that bites is `reconnectAsInviter()`, which resets **and then builds a new connection**. By the time the stale restart resumes, `this.pc` is the fresh pairing, so it posts the new invite's SDP onto the new channel as an `ICE_RESTART_OFFER`.

Both now capture `pc` on entry and check `_stale(pc)` after each await, including in the `catch`, so a deliberate re-pair is not logged as a restart failure. A genuine failure still declares the connection dead — covered by a test.

### Verification

`node --test scripts/fd/tests/*.test.mjs` — 28 passing, 7 of them new. The existing 21 are unchanged.

The two race tests were rewritten after the first version passed with the guard disabled: they had asserted on `resetPeer()` alone, where the symptom is only a misleading log line. Modelling the re-pair is what makes them discriminate. Confirmed by disabling `_stale()` and watching exactly those two fail.

**Not covered:** the real WebRTC path — no `RTCPeerConnection` here, only stubs. A two-browser reconnect test on `/fd` (background one side on iOS until the connection dies, then take the fresh-invite path) is still the check that matters before merge.

`gatherComplete` and `countCandidates` are now exported for the tests; nothing outside this module imported them.